### PR TITLE
nostr: nip11: make information fields optional and accept wss://

### DIFF
--- a/crates/nostr/examples/nip11.rs
+++ b/crates/nostr/examples/nip11.rs
@@ -8,7 +8,7 @@ use nostr::Result;
 fn main() -> Result<()> {
     env_logger::init();
 
-    let relay_url = Url::parse("https://relay.damus.io")?;
+    let relay_url = Url::parse("wss://relay.damus.io")?;
 
     let info: RelayInformationDocument = nip11::get_relay_information_document(relay_url, None)?;
 

--- a/crates/nostr/src/nips/nip11.rs
+++ b/crates/nostr/src/nips/nip11.rs
@@ -26,17 +26,19 @@ pub enum Error {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RelayInformationDocument {
-    pub id: String,
-    pub name: String,
-    pub description: String,
-    pub pubkey: String,
-    pub contact: String,
-    pub supported_nips: Vec<u16>,
-    pub software: String,
-    pub version: String,
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub pubkey: Option<String>,
+    pub contact: Option<String>,
+    pub supported_nips: Option<Vec<u16>>,
+    pub software: Option<String>,
+    pub version: Option<String>,
 }
 
-/// Get Relay Information Document
+/// Get Relay Information Document.
+///
+/// NIP-11 expects the `url` to be HTTP(S). When WSS is passed, it is converted
+/// to HTTPS.
 #[cfg(not(feature = "blocking"))]
 pub async fn get_relay_information_document(
     url: Url,
@@ -48,6 +50,17 @@ pub async fn get_relay_information_document(
         builder = builder.proxy(Proxy::all(proxy)?);
     }
     let client: Client = builder.build()?;
+    let url = {
+        if url.scheme() == "wss" {
+            let mut http_url = url;
+            http_url
+                .set_scheme("https")
+                .expect("'https' is a valid scheme.");
+            http_url
+        } else {
+            url
+        }
+    };
     let req = client.get(url).header("Accept", "application/nostr+json");
     match req.send().await {
         Ok(response) => match response.json().await {
@@ -59,6 +72,9 @@ pub async fn get_relay_information_document(
 }
 
 /// Get Relay Information Document
+///
+/// NIP-11 expects the `url` to be HTTP(S). When WSS is passed, it is converted
+/// to HTTPS.
 #[cfg(feature = "blocking")]
 pub fn get_relay_information_document(
     url: Url,
@@ -70,6 +86,17 @@ pub fn get_relay_information_document(
         builder = builder.proxy(Proxy::all(proxy)?);
     }
     let client: Client = builder.build()?;
+    let url = {
+        if url.scheme() == "wss" {
+            let mut http_url = url;
+            http_url
+                .set_scheme("https")
+                .expect("'https' is a valid scheme.");
+            http_url
+        } else {
+            url
+        }
+    };
     let req = client.get(url).header("Accept", "application/nostr+json");
     match req.send() {
         Ok(response) => match response.json() {


### PR DESCRIPTION
According to NIP-11, 'any field may be omitted', so all the fields in information struct should be optional. Additionally, no 'id' field is defined. Last, NIP-11 calls HTTP(S), however relays are normally stored as wss:// and therefore such addresses should be also accepted.