### PR TITLE
nostr: nip11: make all fields optional and accept wss://

### DIFF
--- a/crates/nostr/examples/nip11.rs
+++ b/crates/nostr/examples/nip11.rs
@@ -6,7 +6,7 @@ use nostr::prelude::*;
 fn main() -> Result<()> {
     env_logger::init();
 
-    let relay_url = Url::parse("https://relay.damus.io")?;
+    let relay_url = Url::parse("wss://relay.damus.io")?;
 
     let info = RelayInformationDocument::get(relay_url, None)?;
 

--- a/crates/nostr/src/nips/nip11.rs
+++ b/crates/nostr/src/nips/nip11.rs
@@ -36,22 +36,20 @@ pub enum Error {
 /// Relay information document
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct RelayInformationDocument {
-    ///
-    pub id: String,
     /// Name
-    pub name: String,
+    pub name: Option<String>,
     /// Description
-    pub description: String,
+    pub description: Option<String>,
     /// Owner public key
-    pub pubkey: String,
+    pub pubkey: Option<String>,
     /// Owner contact
-    pub contact: String,
+    pub contact: Option<String>,
     /// Supported NIPs
-    pub supported_nips: Vec<u16>,
+    pub supported_nips: Option<Vec<u16>>,
     /// Software
-    pub software: String,
+    pub software: Option<String>,
     /// Software version
-    pub version: String,
+    pub version: Option<String>,
 }
 
 impl RelayInformationDocument {


### PR DESCRIPTION
Supersedes #20.

Three related changes in NIP11:

 - allow passing WS(S) scheme to relay information document retrieval
 - make all fields in the information document optional according to spec
 - remove unspecified field `id` from the document