### PR TITLE
 Add verify_delegation_signature()

### DIFF
--- a/crates/nostr/src/nips/nip26.rs
+++ b/crates/nostr/src/nips/nip26.rs
@@ -23,6 +23,10 @@ pub enum Error {
     Secp256k1(#[from] bitcoin::secp256k1::Error),
 }
 
+fn delegation_token(delegatee_pk: &XOnlyPublicKey, conditions: &str) -> String {
+    format!("nostr:delegation:{delegatee_pk}:{conditions}")
+}
+
 /// Sign delegation
 pub fn sign_delegation(
     keys: &Keys,
@@ -31,8 +35,109 @@ pub fn sign_delegation(
 ) -> Result<Signature, Error> {
     let secp = Secp256k1::new();
     let keypair: &KeyPair = &keys.key_pair()?;
-    let unhashed_token: String = format!("nostr:delegation:{delegatee_pk}:{conditions}");
+    let unhashed_token: String = delegation_token(&delegatee_pk, &conditions);
     let hashed_token = Sha256Hash::hash(unhashed_token.as_bytes());
     let message = Message::from_slice(&hashed_token)?;
     Ok(secp.sign_schnorr(&message, keypair))
+}
+
+/// Verify delegation signature
+pub fn verify_delegation_signature(
+    keys: &Keys,
+    signature: &Signature,
+    delegatee_pk: XOnlyPublicKey,
+    conditions: String,
+) -> Result<(), Error> {
+    let secp = Secp256k1::new();
+    let unhashed_token: String = delegation_token(&delegatee_pk, &conditions);
+    let hashed_token = Sha256Hash::hash(unhashed_token.as_bytes());
+    let message = Message::from_slice(&hashed_token)?;
+    secp.verify_schnorr(&signature, &message, &keys.public_key())?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::prelude::{FromBech32, SecretKey};
+    use std::str::FromStr;
+
+    #[test]
+    fn test_sign_delegation_verify_delegation_signature() {
+        let sk = SecretKey::from_bech32(
+            "nsec1ktekw0hr5evjs0n9nyyquz4sue568snypy2rwk5mpv6hl2hq3vtsk0kpae",
+        )
+        .unwrap();
+        let keys = Keys::new(sk);
+        let delegatee_pk = XOnlyPublicKey::from_bech32(
+            "npub1h652adkpv4lr8k66cadg8yg0wl5wcc29z4lyw66m3rrwskcl4v6qr82xez",
+        )
+        .unwrap();
+        let conditions = "kind=1&created_at>1674834236&created_at<1677426236".to_string();
+
+        let signature = sign_delegation(&keys, delegatee_pk, conditions.clone()).unwrap();
+
+        // signature is changing, validate by verify method
+        let verify_result =
+            verify_delegation_signature(&keys, &signature, delegatee_pk, conditions);
+        assert!(verify_result.is_ok());
+    }
+
+    #[test]
+    fn test_sign_delegation_verify_lowlevel() {
+        let sk = SecretKey::from_bech32(
+            "nsec1ktekw0hr5evjs0n9nyyquz4sue568snypy2rwk5mpv6hl2hq3vtsk0kpae",
+        )
+        .unwrap();
+        let keys = Keys::new(sk);
+        let delegatee_pk = XOnlyPublicKey::from_bech32(
+            "npub1h652adkpv4lr8k66cadg8yg0wl5wcc29z4lyw66m3rrwskcl4v6qr82xez",
+        )
+        .unwrap();
+        let conditions = "kind=1&created_at>1674834236&created_at<1677426236";
+
+        let signature = sign_delegation(&keys, delegatee_pk, conditions.to_string()).unwrap();
+
+        // signature is changing, validate by lowlevel verify
+        let unhashed_token: String = format!("nostr:delegation:{delegatee_pk}:{conditions}");
+        let hashed_token = Sha256Hash::hash(unhashed_token.as_bytes());
+        let message = Message::from_slice(&hashed_token).unwrap();
+        let secp = Secp256k1::new();
+        let verify_result = secp.verify_schnorr(&signature, &message, &keys.public_key());
+        assert!(verify_result.is_ok());
+    }
+
+    #[test]
+    fn test_verify_delegation_signature() {
+        let sk = SecretKey::from_bech32(
+            "nsec1ktekw0hr5evjs0n9nyyquz4sue568snypy2rwk5mpv6hl2hq3vtsk0kpae",
+        )
+        .unwrap();
+        let keys = Keys::new(sk);
+        // use one concrete signature
+        let signature = Signature::from_str("05deed1262a42c832ae0acb42a2259ca9d82193e15aa6f0817dc9ccce08e107976778c60131783c6a2b4d48acd15b1c5bd2b06107af4a2bc657404a6077223b6").unwrap();
+        let delegatee_pk = XOnlyPublicKey::from_bech32(
+            "npub1h652adkpv4lr8k66cadg8yg0wl5wcc29z4lyw66m3rrwskcl4v6qr82xez",
+        )
+        .unwrap();
+        let conditions = "k=1".to_string();
+
+        let verify_result =
+            verify_delegation_signature(&keys, &signature, delegatee_pk, conditions);
+        assert!(verify_result.is_ok());
+    }
+
+    #[test]
+    fn test_delegation_token() {
+        let delegatee_pk = XOnlyPublicKey::from_bech32(
+            "npub1h652adkpv4lr8k66cadg8yg0wl5wcc29z4lyw66m3rrwskcl4v6qr82xez",
+        )
+        .unwrap();
+        let conditions = "kind=1&created_at>1674834236&created_at<1677426236";
+        let unhashed_token: String = delegation_token(&delegatee_pk, &conditions);
+        assert_eq!(
+            unhashed_token,
+            "nostr:delegation:bea8aeb6c1657e33db5ac75a83910f77e8ec6145157e476b5b88c6e85b1fab34:kind=1&created_at>1674834236&created_at<1677426236"
+        );
+    }
 }

--- a/crates/nostr/src/nips/nip26.rs
+++ b/crates/nostr/src/nips/nip26.rs
@@ -64,13 +64,12 @@ mod test {
 
     #[test]
     fn test_sign_delegation_verify_delegation_signature() {
-        let sk = SecretKey::from_bech32(
-            "nsec1ktekw0hr5evjs0n9nyyquz4sue568snypy2rwk5mpv6hl2hq3vtsk0kpae",
-        )
-        .unwrap();
+        let sk =
+            SecretKey::from_str("ee35e8bb71131c02c1d7e73231daa48e9953d329a4b701f7133c8f46dd21139c")
+                .unwrap();
         let keys = Keys::new(sk);
         let delegatee_pk = XOnlyPublicKey::from_bech32(
-            "npub1h652adkpv4lr8k66cadg8yg0wl5wcc29z4lyw66m3rrwskcl4v6qr82xez",
+            "npub1gae33na4gfaeelrx48arwc2sc8wmccs3tt38emmjg9ltjktfzwtqtl4l6u",
         )
         .unwrap();
         let conditions = "kind=1&created_at>1674834236&created_at<1677426236".to_string();
@@ -85,13 +84,12 @@ mod test {
 
     #[test]
     fn test_sign_delegation_verify_lowlevel() {
-        let sk = SecretKey::from_bech32(
-            "nsec1ktekw0hr5evjs0n9nyyquz4sue568snypy2rwk5mpv6hl2hq3vtsk0kpae",
-        )
-        .unwrap();
+        let sk =
+            SecretKey::from_str("ee35e8bb71131c02c1d7e73231daa48e9953d329a4b701f7133c8f46dd21139c")
+                .unwrap();
         let keys = Keys::new(sk);
         let delegatee_pk = XOnlyPublicKey::from_bech32(
-            "npub1h652adkpv4lr8k66cadg8yg0wl5wcc29z4lyw66m3rrwskcl4v6qr82xez",
+            "npub1gae33na4gfaeelrx48arwc2sc8wmccs3tt38emmjg9ltjktfzwtqtl4l6u",
         )
         .unwrap();
         let conditions = "kind=1&created_at>1674834236&created_at<1677426236";
@@ -109,18 +107,17 @@ mod test {
 
     #[test]
     fn test_verify_delegation_signature() {
-        let sk = SecretKey::from_bech32(
-            "nsec1ktekw0hr5evjs0n9nyyquz4sue568snypy2rwk5mpv6hl2hq3vtsk0kpae",
-        )
-        .unwrap();
+        let sk =
+            SecretKey::from_str("ee35e8bb71131c02c1d7e73231daa48e9953d329a4b701f7133c8f46dd21139c")
+                .unwrap();
         let keys = Keys::new(sk);
         // use one concrete signature
-        let signature = Signature::from_str("05deed1262a42c832ae0acb42a2259ca9d82193e15aa6f0817dc9ccce08e107976778c60131783c6a2b4d48acd15b1c5bd2b06107af4a2bc657404a6077223b6").unwrap();
+        let signature = Signature::from_str("f9f00fcf8480686d9da6dfde1187d4ba19c54f6ace4c73361a14db429c4b96eb30b29283d6ea1f06ba9e18e06e408244c689039ddadbacffc56060f3da5b04b8").unwrap();
         let delegatee_pk = XOnlyPublicKey::from_bech32(
-            "npub1h652adkpv4lr8k66cadg8yg0wl5wcc29z4lyw66m3rrwskcl4v6qr82xez",
+            "npub1gae33na4gfaeelrx48arwc2sc8wmccs3tt38emmjg9ltjktfzwtqtl4l6u",
         )
         .unwrap();
-        let conditions = "k=1".to_string();
+        let conditions = "kind=1&created_at>1674834236&created_at<1677426236".to_string();
 
         let verify_result =
             verify_delegation_signature(&keys, &signature, delegatee_pk, conditions);
@@ -130,14 +127,14 @@ mod test {
     #[test]
     fn test_delegation_token() {
         let delegatee_pk = XOnlyPublicKey::from_bech32(
-            "npub1h652adkpv4lr8k66cadg8yg0wl5wcc29z4lyw66m3rrwskcl4v6qr82xez",
+            "npub1gae33na4gfaeelrx48arwc2sc8wmccs3tt38emmjg9ltjktfzwtqtl4l6u",
         )
         .unwrap();
         let conditions = "kind=1&created_at>1674834236&created_at<1677426236";
         let unhashed_token: String = delegation_token(&delegatee_pk, &conditions);
         assert_eq!(
             unhashed_token,
-            "nostr:delegation:bea8aeb6c1657e33db5ac75a83910f77e8ec6145157e476b5b88c6e85b1fab34:kind=1&created_at>1674834236&created_at<1677426236"
+            "nostr:delegation:477318cfb5427b9cfc66a9fa376150c1ddbc62115ae27cef72417eb959691396:kind=1&created_at>1674834236&created_at<1677426236"
         );
     }
 }

--- a/crates/nostr/src/nips/nip26.rs
+++ b/crates/nostr/src/nips/nip26.rs
@@ -52,7 +52,7 @@ pub fn verify_delegation_signature(
     let unhashed_token: String = delegation_token(&delegatee_pk, &conditions);
     let hashed_token = Sha256Hash::hash(unhashed_token.as_bytes());
     let message = Message::from_slice(&hashed_token)?;
-    secp.verify_schnorr(&signature, &message, &keys.public_key())?;
+    secp.verify_schnorr(signature, &message, &keys.public_key())?;
     Ok(())
 }
 


### PR DESCRIPTION
### Description

Add `verify_delegation_signature()`, to match `sign_delegation()`.
Useful for verifying a signature (by delegatee) and also for testing.
Also added tests.

### Checklists

#### All Submissions:

* [ ] I've signed all my commits
* [x] I followed the [contribution guidelines](../CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing