### PR TITLE
Make relay url mandatory for kind 42 events

### DIFF
--- a/bindings/nostr-nodejs/src/event/builder.rs
+++ b/bindings/nostr-nodejs/src/event/builder.rs
@@ -162,13 +162,10 @@ impl JsEventBuilder {
     #[napi(factory)]
     pub fn new_channel_msg(
         channel_id: &JsChannelId,
-        relay_url: Option<String>,
+        relay_url: String,
         content: String,
     ) -> Result<Self> {
-        let relay_url: Option<Url> = match relay_url {
-            Some(relay_url) => Some(Url::parse(&relay_url).map_err(into_err)?),
-            None => None,
-        };
+        let relay_url: Url = Url::parse(&relay_url).map_err(into_err)?;
         Ok(Self {
             builder: EventBuilder::new_channel_msg(channel_id.into(), relay_url, content),
         })

--- a/bindings/nostr-sdk-nodejs/src/client/mod.rs
+++ b/bindings/nostr-sdk-nodejs/src/client/mod.rs
@@ -402,13 +402,10 @@ impl JsClient {
     pub async fn send_channel_msg(
         &self,
         channel_id: &JsChannelId,
-        relay_url: Option<String>,
+        relay_url: String,
         msg: String,
     ) -> Result<JsEventId> {
-        let relay_url: Option<Url> = match relay_url {
-            Some(relay_url) => Some(Url::parse(&relay_url).map_err(into_err)?),
-            None => None,
-        };
+        let relay_url: Url = Url::parse(&relay_url).map_err(into_err)?;
         self.inner
             .send_channel_msg(channel_id.into(), relay_url, msg)
             .await

--- a/crates/nostr-sdk/src/client/blocking.rs
+++ b/crates/nostr-sdk/src/client/blocking.rs
@@ -290,7 +290,7 @@ impl Client {
     pub fn send_channel_msg<S>(
         &self,
         channel_id: ChannelId,
-        relay_url: Option<Url>,
+        relay_url: Url,
         msg: S,
     ) -> Result<EventId, Error>
     where

--- a/crates/nostr-sdk/src/client/mod.rs
+++ b/crates/nostr-sdk/src/client/mod.rs
@@ -801,7 +801,7 @@ impl Client {
     pub async fn send_channel_msg<S>(
         &self,
         channel_id: ChannelId,
-        relay_url: Option<Url>,
+        relay_url: Url,
         msg: S,
     ) -> Result<EventId, Error>
     where

--- a/crates/nostr/src/event/builder.rs
+++ b/crates/nostr/src/event/builder.rs
@@ -279,7 +279,7 @@ impl EventBuilder {
     /// New channel message
     ///
     /// <https://github.com/nostr-protocol/nips/blob/master/28.md>
-    pub fn new_channel_msg<S>(channel_id: ChannelId, relay_url: Option<Url>, content: S) -> Self
+    pub fn new_channel_msg<S>(channel_id: ChannelId, relay_url: Url, content: S) -> Self
     where
         S: Into<String>,
     {
@@ -288,7 +288,7 @@ impl EventBuilder {
             content,
             &[Tag::Event(
                 channel_id.into(),
-                relay_url.map(|u| u.to_string()),
+                Some(relay_url.to_string()),
                 Some(Marker::Root),
             )],
         )


### PR DESCRIPTION
### Description
Removes the Option<> around the relay url parameter for kind 42 events. NIP-28 defines that kind 42 events SHOULD use NIP-10 marked "e tags". NIP-10 defines "relay-url" to be NOT optional.

### Notes to the reviewers
I have not tested this change in any external implementation but the project builds just fine and the existing tests are running successfully.

The commit wasn't signed as I haven't really set up a PGP key yet. If it's mandatory for contributing, I can get that set up over the next couple of days.

### Changelog notice

**Fixed**
- Made relay-url mandatory for kind 42 events

### Checklists

#### All Submissions:

* [ ] I've signed all my commits
* [x] I followed the [contribution guidelines](../CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing