### PR TITLE
Disable default use of all features for nostr-sdk dependency

### DIFF
--- a/crates/nostr-sdk/Cargo.toml
+++ b/crates/nostr-sdk/Cargo.toml
@@ -27,7 +27,7 @@ nip26 = ["nostr/nip26"]
 [dependencies]
 futures-util = "0.3"
 log = "0.4"
-nostr = { version = "0.18", path = "../nostr", default-features = false }
+nostr = { version = "0.18", path = "../nostr", default-features = false, features = [ "base" ] }
 once_cell = "1"
 thiserror = "1.0"
 tokio = { version = "1", features = ["full"] }

--- a/crates/nostr-sdk/Cargo.toml
+++ b/crates/nostr-sdk/Cargo.toml
@@ -27,7 +27,7 @@ nip26 = ["nostr/nip26"]
 [dependencies]
 futures-util = "0.3"
 log = "0.4"
-nostr = { version = "0.18", path = "../nostr" }
+nostr = { version = "0.18", path = "../nostr", default-features = false }
 once_cell = "1"
 thiserror = "1.0"
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
### Description

Avoid using the full features of `nostr` when it's used as a dependency of `nostr-sdk`.

Right now, using `nostr-sdk` with a limited subset of features still pulls the `nostr` dependency with all its features. This causes for example a `Cargo.toml` which only wants to load feature `nip04` alongside other dependencies

```toml
[dependencies]
nostr-sdk = { version = "0.18", default-features = false, features = [ "nip04" ] }
unicode-normalization = "^0.1.17"
```

to fail because the `nostr-sdk` dependency `nostr` is loaded with all its features, including `nip06` which brings along `bip39`, which has a specific version of  `unicode-normalization`:

```
error: failed to select a version for `unicode-normalization`.
// ...
all possible versions conflict with previously selected packages.

  previously selected package `unicode-normalization v0.1.9`
    ... which satisfies dependency `unicode-normalization = "=0.1.9"` of package `bip39 v1.0.0`
    ... which satisfies dependency `bip39 = "^1.0"` of package `nostr v0.18.0`
    ... which satisfies dependency `nostr = "^0.18"` of package `nostr-sdk v0.18.0`
```

This PR makes sure the `nostr` dependency of `nostr-sdk` is not always loaded with all features.

Using `nostr-sdk` with specific features will still load the corresponding ones in `nostr`.

### Notes to the reviewers

This is relevant when `nostr-sdk` is used with with specific features like `default-features = false, features = [...]`.

This also doesn't affect the default case, when `nostr-sdk` loads `all-nips`.

### Changelog notice

Load only necessary `nostr` dependencies when using `nostr-sdk` feature flags

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](../CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing