### PR TITLE
NIP-05: Add support for relays

### DIFF
--- a/crates/nostr/Cargo.toml
+++ b/crates/nostr/Cargo.toml
@@ -69,7 +69,7 @@ required-features = ["base", "nip04"]
 
 [[example]]
 name = "nip05"
-required-features = ["nip05", "blocking"]
+required-features = ["base", "nip05", "blocking"]
 
 [[example]]
 name = "nip06"

--- a/crates/nostr/examples/nip05.rs
+++ b/crates/nostr/examples/nip05.rs
@@ -20,5 +20,8 @@ fn main() -> Result<()> {
         println!("NIP-05 NOT verified");
     }
 
+    let profile = nip05::get_profile_blocking("_@fiatjaf.com", None)?;
+    println!("Profile example (including relays): {profile:#?}");
+
     Ok(())
 }

--- a/crates/nostr/src/nips/nip05.rs
+++ b/crates/nostr/src/nips/nip05.rs
@@ -5,16 +5,19 @@
 //!
 //! <https://github.com/nostr-protocol/nips/blob/master/05.md>
 
-use bitcoin_hashes::hex::ToHex;
 #[cfg(not(target_arch = "wasm32"))]
 use std::net::SocketAddr;
 use std::str::FromStr;
 
-use crate::Profile;
+#[cfg(feature = "base")]
+use bitcoin_hashes::hex::ToHex;
 #[cfg(not(target_arch = "wasm32"))]
 use reqwest::Proxy;
 use secp256k1::XOnlyPublicKey;
 use serde_json::Value;
+
+#[cfg(feature = "base")]
+use crate::Profile;
 
 /// `NIP05` error
 #[derive(Debug, thiserror::Error)]
@@ -133,6 +136,7 @@ pub async fn verify(public_key: XOnlyPublicKey, nip05: &str) -> Result<(), Error
 
 /// Get [Profile] from NIP05 (public key and list of advertised relays)
 #[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "base")]
 pub async fn get_profile(nip05: &str, proxy: Option<SocketAddr>) -> Result<Profile, Error> {
     use reqwest::Client;
 
@@ -154,7 +158,7 @@ pub async fn get_profile(nip05: &str, proxy: Option<SocketAddr>) -> Result<Profi
 
 /// Get [Profile] from NIP05 (public key and list of advertised relays)
 #[cfg(not(target_arch = "wasm32"))]
-#[cfg(feature = "blocking")]
+#[cfg(all(feature = "blocking", feature = "base"))]
 pub fn get_profile_blocking(nip05: &str, proxy: Option<SocketAddr>) -> Result<Profile, Error> {
     use reqwest::blocking::Client;
 
@@ -176,6 +180,7 @@ pub fn get_profile_blocking(nip05: &str, proxy: Option<SocketAddr>) -> Result<Pr
 
 /// Get [Profile] from NIP05 (public key and list of advertised relays)
 #[cfg(target_arch = "wasm32")]
+#[cfg(feature = "base")]
 pub async fn get_profile(nip05: &str) -> Result<Profile, Error> {
     use reqwest::Client;
 

--- a/crates/nostr/src/nips/nip05.rs
+++ b/crates/nostr/src/nips/nip05.rs
@@ -57,6 +57,7 @@ fn get_key_from_json(json: Value, name: &str) -> Option<XOnlyPublicKey> {
         .and_then(|pubkey| XOnlyPublicKey::from_str(pubkey).ok())
 }
 
+#[cfg(feature = "base")]
 fn get_relays_from_json(json: Value, pk: XOnlyPublicKey) -> Vec<String> {
     let relays_list: Option<Vec<String>> = json
         .get("relays")


### PR DESCRIPTION
### Description

NIP-05 has support for an optional list of relays where the respective pubkey will be listening and / or writing to.

This PR returns this list of relays, together with the pubkey, in a `Profile` struct.

### Notes to the reviewers

Returning the `Profile` is more compact than having two separate getters for the key and the relays.

### Changelog notice

NIP-05: Add support for relays

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](../CONTRIBUTING.md)
* [x] I ran `make precommit` before committing