### PR TITLE
Add NIP-26 delegation tag support

### DIFF
--- a/bindings/nostr-nodejs/src/nips/nip26.rs
+++ b/bindings/nostr-nodejs/src/nips/nip26.rs
@@ -20,7 +20,9 @@ pub fn create_delegation_tag(
     delegatee_pubkey: &JsPublicKey,
     conditions: String,
 ) -> Result<String> {
-    let tag = nip26::create_delegation_tag(delegator_keys.deref(), delegatee_pubkey.into(), &conditions).map_err(into_err)?;
+    let tag =
+        nip26::create_delegation_tag(delegator_keys.deref(), delegatee_pubkey.into(), &conditions)
+            .map_err(into_err)?;
     Ok(tag.to_string())
 }
 

--- a/bindings/nostr-nodejs/src/nips/nip26.rs
+++ b/bindings/nostr-nodejs/src/nips/nip26.rs
@@ -4,6 +4,7 @@
 use std::ops::Deref;
 use std::str::FromStr;
 
+use napi::bindgen_prelude::BigInt;
 use napi::Result;
 use nostr::nips::nip26;
 use nostr::secp256k1::schnorr::Signature;
@@ -27,16 +28,18 @@ pub fn create_delegation_tag(
 }
 
 /// Validate a NIP-26 delegation tag, check signature and conditions.
+#[napi]
 pub fn validate_delegation_tag(
     delegation_tag: String,
     delegatee_pubkey: &JsPublicKey,
-    event_kind: u64,
-    created_at: u64,
+    event_kind: BigInt,
+    created_at: BigInt,
 ) -> Result<bool> {
     match nip26::DelegationTag::from_str(&delegation_tag) {
         Err(_) => Ok(false),
         Ok(tag) => {
-            let event_properties = nip26::EventProperties::new(event_kind, created_at);
+            let event_properties =
+                nip26::EventProperties::new(event_kind.get_u64().1, created_at.get_u64().1);
             match nip26::validate_delegation_tag(&tag, delegatee_pubkey.into(), &event_properties) {
                 Err(_) => Ok(false),
                 Ok(_) => Ok(true),

--- a/bindings/nostr-nodejs/src/nips/nip26.rs
+++ b/bindings/nostr-nodejs/src/nips/nip26.rs
@@ -11,6 +11,40 @@ use nostr::secp256k1::schnorr::Signature;
 use crate::error::into_err;
 use crate::{JsKeys, JsPublicKey};
 
+/// Create a NIP-26 delegation tag (including the signature).
+/// See also validate_delegation_tag().
+#[napi]
+pub fn create_delegation_tag(
+    delegator_keys: &JsKeys,
+    delegatee_pubkey: &JsPublicKey,
+    conditions: String,
+) -> Result<String> {
+    match nip26::create_delegation_tag(delegator_keys.deref(), delegatee_pubkey.into(), &conditions)
+    {
+        Ok(tag) => Ok(tag.to_string()),
+        Err(_) => Ok("".to_string()),
+    }
+}
+
+/// Validate a NIP-26 delegation tag, check signature and conditions.
+pub fn validate_delegation_tag(
+    delegation_tag: String,
+    delegatee_pubkey: &JsPublicKey,
+    event_kind: u64,
+    created_at: u64,
+) -> Result<bool> {
+    match nip26::DelegationTag::from_str(&delegation_tag) {
+        Err(_) => Ok(false),
+        Ok(tag) => {
+            let event_properties = nip26::EventProperties::new(event_kind, created_at);
+            match nip26::validate_delegation_tag(&tag, delegatee_pubkey.into(), &event_properties) {
+                Err(_) => Ok(false),
+                Ok(_) => Ok(true),
+            }
+        }
+    }
+}
+
 /// Sign delegation (NIP26)
 #[napi]
 pub fn sign_delegation(
@@ -29,15 +63,15 @@ pub fn sign_delegation(
 #[napi]
 pub fn verify_delegation_signature(
     delegator_public_key: &JsPublicKey,
-    delegatee_pk: &JsPublicKey,
+    delegatee_public_key: &JsPublicKey,
     conditions: String,
     signature: String,
 ) -> Result<bool> {
-    let signature = Signature::from_str(&signature).map_err(into_err)?;
+    let signature_struct = Signature::from_str(&signature).map_err(into_err)?;
     match nip26::verify_delegation_signature(
         delegator_public_key.deref(),
-        &signature,
-        delegatee_pk.into(),
+        &signature_struct,
+        delegatee_public_key.into(),
         conditions,
     ) {
         Ok(_) => Ok(true),

--- a/bindings/nostr-nodejs/src/nips/nip26.rs
+++ b/bindings/nostr-nodejs/src/nips/nip26.rs
@@ -28,14 +28,14 @@ pub fn sign_delegation(
 /// Verify delegation signature (NIP26)
 #[napi]
 pub fn verify_delegation_signature(
-    keys: &JsKeys,
+    delegator_public_key: &JsPublicKey,
     delegatee_pk: &JsPublicKey,
     conditions: String,
     signature: String,
 ) -> Result<bool> {
     let signature = Signature::from_str(&signature).map_err(into_err)?;
     match nip26::verify_delegation_signature(
-        keys.deref(),
+        delegator_public_key.deref(),
         &signature,
         delegatee_pk.into(),
         conditions,

--- a/bindings/nostr-nodejs/src/nips/nip26.rs
+++ b/bindings/nostr-nodejs/src/nips/nip26.rs
@@ -20,11 +20,8 @@ pub fn create_delegation_tag(
     delegatee_pubkey: &JsPublicKey,
     conditions: String,
 ) -> Result<String> {
-    match nip26::create_delegation_tag(delegator_keys.deref(), delegatee_pubkey.into(), &conditions)
-    {
-        Ok(tag) => Ok(tag.to_string()),
-        Err(_) => Ok("".to_string()),
-    }
+    let tag = nip26::create_delegation_tag(delegator_keys.deref(), delegatee_pubkey.into(), &conditions).map_err(into_err)?;
+    Ok(tag.to_string())
 }
 
 /// Validate a NIP-26 delegation tag, check signature and conditions.

--- a/crates/nostr/src/nips/nip26.rs
+++ b/crates/nostr/src/nips/nip26.rs
@@ -179,7 +179,7 @@ impl DelegationTag {
         }
 
         // validate conditions
-        self.conditions.evaluate(&event_properties)?;
+        self.conditions.evaluate(event_properties)?;
 
         Ok(())
     }
@@ -427,7 +427,12 @@ mod test {
 
         let tag = create_delegation_tag(&delegator_keys, delegatee_pubkey, &conditions).unwrap();
 
-        assert!(validate_delegation_tag(&tag, delegatee_pubkey, &EventProperties::new(1, 1677000000)).is_ok());
+        assert!(validate_delegation_tag(
+            &tag,
+            delegatee_pubkey,
+            &EventProperties::new(1, 1677000000)
+        )
+        .is_ok());
     }
 
     #[test]
@@ -440,7 +445,12 @@ mod test {
 
         let tag = DelegationTag::from_str(tag_str).unwrap();
 
-        assert!(validate_delegation_tag(&tag, delegatee_pubkey, &EventProperties::new(1, 1677000000)).is_ok());
+        assert!(validate_delegation_tag(
+            &tag,
+            delegatee_pubkey,
+            &EventProperties::new(1, 1677000000)
+        )
+        .is_ok());
 
         // additional test: verify a value from inside the tag
         assert_eq!(
@@ -601,7 +611,12 @@ mod test {
         let tag = create_delegation_tag(&delegator_keys, delegatee_pubkey, &conditions).unwrap();
 
         // positive
-        assert!(validate_delegation_tag(&tag, delegatee_pubkey, &EventProperties::new(1, 1677000000)).is_ok());
+        assert!(validate_delegation_tag(
+            &tag,
+            delegatee_pubkey,
+            &EventProperties::new(1, 1677000000)
+        )
+        .is_ok());
 
         // signature verification fails if wrong delegatee key is given
         let wrong_pubkey = XOnlyPublicKey::from_bech32(

--- a/crates/nostr/src/nips/nip26.rs
+++ b/crates/nostr/src/nips/nip26.rs
@@ -64,7 +64,7 @@ pub enum ValidationError {
     CreatedTooLate,
 }
 
-/// Create a delegation tag (including the signature).
+/// Create a NIP-26 delegation tag (including the signature).
 /// See also validate_delegation_tag().
 pub fn create_delegation_tag(
     delegator_keys: &Keys,
@@ -74,7 +74,7 @@ pub fn create_delegation_tag(
     DelegationTag::create(delegator_keys, delegatee_pubkey, conditions_string)
 }
 
-/// Validate a delegation tag, check signature and conditions.
+/// Validate a NIP-26 delegation tag, check signature and conditions.
 pub fn validate_delegation_tag(
     delegation_tag: &DelegationTag,
     delegatee_pubkey: XOnlyPublicKey,
@@ -105,15 +105,15 @@ pub fn sign_delegation(
 
 /// Verify delegation signature
 pub fn verify_delegation_signature(
-    delegator_pk: &XOnlyPublicKey,
+    delegator_public_key: &XOnlyPublicKey,
     signature: &Signature,
-    delegatee_pk: XOnlyPublicKey,
+    delegatee_public_key: XOnlyPublicKey,
     conditions: String,
 ) -> Result<(), Error> {
-    let unhashed_token: String = delegation_token(&delegatee_pk, &conditions);
+    let unhashed_token: String = delegation_token(&delegatee_public_key, &conditions);
     let hashed_token = Sha256Hash::hash(unhashed_token.as_bytes());
     let message = Message::from_slice(&hashed_token)?;
-    SECP256K1.verify_schnorr(signature, &message, delegator_pk)?;
+    SECP256K1.verify_schnorr(signature, &message, delegator_public_key)?;
     Ok(())
 }
 

--- a/crates/nostr/src/nips/nip26.rs
+++ b/crates/nostr/src/nips/nip26.rs
@@ -86,7 +86,8 @@ pub fn validate_delegation_tag(
 
 const DELEGATION_KEYWORD: &str = "delegation";
 
-fn delegation_token(delegatee_pk: &XOnlyPublicKey, conditions: &str) -> String {
+/// Compile the delegation token, of the form 'nostr:delegation:<pubkey of publisher (delegatee)>:<conditions query string>'
+pub fn delegation_token(delegatee_pk: &XOnlyPublicKey, conditions: &str) -> String {
     format!("nostr:{DELEGATION_KEYWORD}:{delegatee_pk}:{conditions}")
 }
 

--- a/crates/nostr/src/nips/nip26.rs
+++ b/crates/nostr/src/nips/nip26.rs
@@ -42,7 +42,7 @@ pub enum Error {
 }
 
 /// Tag validation errors
-#[derive(Debug, PartialEq, thiserror::Error)]
+#[derive(Debug, PartialEq, Eq, thiserror::Error)]
 pub enum ValidationError {
     /// Signature does not match
     #[error("Signature does not match")]

--- a/crates/nostr/src/nips/nip26.rs
+++ b/crates/nostr/src/nips/nip26.rs
@@ -11,8 +11,8 @@ use secp256k1::schnorr::Signature;
 use secp256k1::{KeyPair, Message, XOnlyPublicKey};
 use serde_json::{json, Value};
 
+use crate::event::Event;
 use crate::key::{self, Keys};
-//use crate::event::Kind;  // TODO use Kind instead of u64
 use crate::SECP256K1;
 
 use core::fmt;
@@ -370,6 +370,14 @@ impl EventProperties {
         EventProperties {
             kind: event_kind,
             created_time,
+        }
+    }
+
+    /// Create from an Event
+    pub fn from_event(event: &Event) -> Self {
+        EventProperties {
+            kind: event.kind.as_u64(),
+            created_time: event.created_at.as_u64(),
         }
     }
 }

--- a/crates/nostr/src/nips/nip26.rs
+++ b/crates/nostr/src/nips/nip26.rs
@@ -65,7 +65,7 @@ pub enum ValidationError {
 }
 
 /// Create a delegation tag (including the signature).
-/// See also verify_delegation_tag().
+/// See also validate_delegation_tag().
 pub fn create_delegation_tag(
     delegator_keys: &Keys,
     delegatee_pubkey: XOnlyPublicKey,
@@ -86,7 +86,7 @@ pub fn create_delegation_tag(
 
 /// Verify a delegation tag, check signature and conditions.
 /// TODO: for event properties it could take EventProperties, or even Event
-pub fn verify_delegation_tag(
+pub fn validate_delegation_tag(
     delegation_tag: &DelegationTag,
     delegatee_pubkey: XOnlyPublicKey,
     event_kind: u64,
@@ -104,7 +104,7 @@ pub fn verify_delegation_tag(
         ));
     }
 
-    // verify conditions
+    // validate conditions
     let props = EventProperties::new(event_kind, created_time);
     delegation_tag.conditions.evaluate(&props)?;
 
@@ -397,7 +397,7 @@ mod test {
     }
 
     #[test]
-    fn test_verify_delegation_tag() {
+    fn test_validate_delegation_tag() {
         let delegator_secret_key = SecretKey::from_bech32(
             "nsec1ktekw0hr5evjs0n9nyyquz4sue568snypy2rwk5mpv6hl2hq3vtsk0kpae",
         )
@@ -411,7 +411,7 @@ mod test {
 
         let tag = create_delegation_tag(&delegator_keys, delegatee_pubkey, &conditions).unwrap();
 
-        assert!(verify_delegation_tag(&tag, delegatee_pubkey, 1, 1677000000).is_ok());
+        assert!(validate_delegation_tag(&tag, delegatee_pubkey, 1, 1677000000).is_ok());
     }
 
     #[test]
@@ -424,7 +424,7 @@ mod test {
 
         let tag = DelegationTag::from_str(tag_str).unwrap();
 
-        assert!(verify_delegation_tag(&tag, delegatee_pubkey, 1, 1677000000).is_ok());
+        assert!(validate_delegation_tag(&tag, delegatee_pubkey, 1, 1677000000).is_ok());
 
         // additional test: verify a value from inside the tag
         assert_eq!(
@@ -433,7 +433,7 @@ mod test {
         );
 
         // additional test: try validation with invalid values, invalid event kind
-        match verify_delegation_tag(&tag, delegatee_pubkey, 5, 1677000000)
+        match validate_delegation_tag(&tag, delegatee_pubkey, 5, 1677000000)
             .err()
             .unwrap()
         {
@@ -570,7 +570,7 @@ mod test {
     }
 
     #[test]
-    fn test_verify_delegation_tag_negative() {
+    fn test_validate_delegation_tag_negative() {
         let delegator_secret_key = SecretKey::from_bech32(
             "nsec1ktekw0hr5evjs0n9nyyquz4sue568snypy2rwk5mpv6hl2hq3vtsk0kpae",
         )
@@ -585,7 +585,7 @@ mod test {
         let tag = create_delegation_tag(&delegator_keys, delegatee_pubkey, &conditions).unwrap();
 
         // positive
-        assert!(verify_delegation_tag(&tag, delegatee_pubkey, 1, 1677000000).is_ok());
+        assert!(validate_delegation_tag(&tag, delegatee_pubkey, 1, 1677000000).is_ok());
 
         // signature verification fails if wrong delegatee key is given
         let wrong_pubkey = XOnlyPublicKey::from_bech32(
@@ -593,7 +593,7 @@ mod test {
         )
         .unwrap();
         // Note: Error cannot be tested simply  using equality
-        match verify_delegation_tag(&tag, wrong_pubkey, 1, 1677000000)
+        match validate_delegation_tag(&tag, wrong_pubkey, 1, 1677000000)
             .err()
             .unwrap()
         {
@@ -602,7 +602,7 @@ mod test {
         }
 
         // wrong event kind
-        match verify_delegation_tag(&tag, delegatee_pubkey, 9, 1677000000)
+        match validate_delegation_tag(&tag, delegatee_pubkey, 9, 1677000000)
             .err()
             .unwrap()
         {
@@ -611,7 +611,7 @@ mod test {
         };
 
         // wrong creation time
-        match verify_delegation_tag(&tag, delegatee_pubkey, 1, 1679000000)
+        match validate_delegation_tag(&tag, delegatee_pubkey, 1, 1679000000)
             .err()
             .unwrap()
         {

--- a/crates/nostr/src/nips/nip26.rs
+++ b/crates/nostr/src/nips/nip26.rs
@@ -11,6 +11,7 @@ use secp256k1::schnorr::Signature;
 use secp256k1::{KeyPair, Message, XOnlyPublicKey};
 use serde_json::{json, Value};
 
+#[cfg(feature = "base")]
 use crate::event::Event;
 use crate::key::{self, Keys};
 use crate::SECP256K1;
@@ -374,6 +375,7 @@ impl EventProperties {
     }
 
     /// Create from an Event
+    #[cfg(feature = "base")]
     pub fn from_event(event: &Event) -> Self {
         EventProperties {
             kind: event.kind.as_u64(),

--- a/crates/nostr/src/nips/nip26.rs
+++ b/crates/nostr/src/nips/nip26.rs
@@ -12,7 +12,6 @@ use secp256k1::{KeyPair, Message, XOnlyPublicKey};
 use serde_json::json;
 
 use crate::key::{self, Keys};
-use crate::nips::nip19::ToBech32;
 //use crate::event::Kind;  // TODO use Kind instead of u64
 use crate::SECP256K1;
 
@@ -117,12 +116,11 @@ impl DelegationTag {
     // TODO from_string()
 
     /// Convert to JSON string.
-    // TODO use json methods
     pub(crate) fn to_json(&self) -> Result<String, Error> {
-        let delegator_npub = self.delegator_pubkey.to_bech32()?;
+        let delegator_pubkey_hex = self.delegator_pubkey.to_string();
         let tag = json!([
             "delegation",
-            delegator_npub,
+            delegator_pubkey_hex,
             self.conditions.to_string(),
             self.signature.to_string(),
         ]);
@@ -435,7 +433,7 @@ mod test {
             signature,
         };
         let tag = d.to_json().unwrap();
-        assert_eq!(tag, "[\"delegation\",\"npub1rfze4zn25ezp6jqt5ejlhrajrfx0az72ed7cwvq0spr22k9rlnjq93lmd4\",\"kind=1&created_at<1678659553\",\"435091ab4c4a11e594b1a05e0fa6c2f6e3b6eaa87c53f2981a3d6980858c40fdcaffde9a4c461f352a109402a4278ff4dbf90f9ebd05f96dac5ae36a6364a976\"]");
+        assert_eq!(tag, "[\"delegation\",\"1a459a8a6aa6441d480ba665fb8fb21a4cfe8bcacb7d87300f8046a558a3fce4\",\"kind=1&created_at<1678659553\",\"435091ab4c4a11e594b1a05e0fa6c2f6e3b6eaa87c53f2981a3d6980858c40fdcaffde9a4c461f352a109402a4278ff4dbf90f9ebd05f96dac5ae36a6364a976\"]");
     }
 
     #[test]
@@ -464,7 +462,7 @@ mod test {
 
         // signature changes, cannot compare to expected constant, use signature from result
         let expected = format!(
-            "[\"delegation\",\"npub1rfze4zn25ezp6jqt5ejlhrajrfx0az72ed7cwvq0spr22k9rlnjq93lmd4\",\"kind=1&created_at>1676067553&created_at<1678659553\",\"{}\"]",
+            "[\"delegation\",\"1a459a8a6aa6441d480ba665fb8fb21a4cfe8bcacb7d87300f8046a558a3fce4\",\"kind=1&created_at>1676067553&created_at<1678659553\",\"{}\"]",
             &tag.signature.to_string());
         assert_eq!(tag.to_string(), expected);
     }

--- a/crates/nostr/src/nips/nip26.rs
+++ b/crates/nostr/src/nips/nip26.rs
@@ -324,7 +324,6 @@ impl FromStr for Condition {
 }
 
 impl Conditions {
-    #[cfg(test)]
     pub fn new() -> Self {
         Conditions { cond: Vec::new() }
     }
@@ -358,6 +357,9 @@ impl FromStr for Conditions {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.is_empty() {
+            return Ok(Conditions::new());
+        }
         let cond = s
             .split('&')
             .map(Condition::from_str)
@@ -682,6 +684,14 @@ mod test {
             c.to_string(),
             "kind=1&created_at>1674834236&created_at<1677426236"
         );
+
+        // special: empty string
+        let c_empty = Conditions::from_str("").unwrap();
+        assert_eq!(c_empty.to_string(), "");
+
+        // one condition
+        let c_one = Conditions::from_str("created_at<10000").unwrap();
+        assert_eq!(c_one.to_string(), "created_at<10000");
     }
 
     #[test]

--- a/crates/nostr/src/nips/nip26.rs
+++ b/crates/nostr/src/nips/nip26.rs
@@ -12,7 +12,8 @@ use secp256k1::{KeyPair, Message, XOnlyPublicKey};
 
 use crate::key::{self, Keys};
 use crate::nips::nip19::ToBech32;
-use crate::{Kind, SECP256K1};
+use crate::prelude::kind::Kind;
+use crate::SECP256K1;
 
 use core::fmt;
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

Add support for complete NIP-26 delegation tags: create a delegation tag, validate a delegation tag.
- API change of (recently added) `verify_delegation_signature`:  First parameter is only public key, not keypair, as secret key is NOT needed for validation.

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->


- New NIP-26 delegation tag support: create, parse, validate a delegation tag (`nip26::DelegationTag`)
- API change in (recently added) `nip26::verify_delegation_signature()` (first parameter changed from KeyPair to XOnlyPublicKey).

### Checklists

* [x] Add create delegation tag
* [x] Add validate delegation tag
* [x] Add parsing and evaluating condition strings

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](../CONTRIBUTING.md)
* [x] I ran `make precommit` before committing