### PR TITLE
Return `SubscriptionId` on `subscribe` and `req_events_of` functions

### DIFF
--- a/crates/nostr-sdk/src/client/blocking.rs
+++ b/crates/nostr-sdk/src/client/blocking.rs
@@ -9,7 +9,9 @@ use std::time::Duration;
 
 use nostr::key::XOnlyPublicKey;
 use nostr::url::Url;
-use nostr::{ChannelId, ClientMessage, Contact, Event, EventId, Filter, Keys, Metadata, Tag};
+use nostr::{
+    ChannelId, ClientMessage, Contact, Event, EventId, Filter, Keys, Metadata, SubscriptionId, Tag,
+};
 use tokio::sync::broadcast;
 
 use super::{Error, Options};
@@ -114,10 +116,8 @@ impl Client {
         RUNTIME.block_on(async { self.client.disconnect().await })
     }
 
-    pub fn subscribe(&self, filters: Vec<Filter>) {
-        RUNTIME.block_on(async {
-            self.client.subscribe(filters).await;
-        })
+    pub fn subscribe(&self, filters: Vec<Filter>) -> Vec<SubscriptionId> {
+        RUNTIME.block_on(async { self.client.subscribe(filters).await })
     }
 
     pub fn unsubscribe(&self) {
@@ -134,10 +134,12 @@ impl Client {
         RUNTIME.block_on(async { self.client.get_events_of(filters, timeout).await })
     }
 
-    pub fn req_events_of(&self, filters: Vec<Filter>, timeout: Option<Duration>) {
-        RUNTIME.block_on(async {
-            self.client.req_events_of(filters, timeout).await;
-        })
+    pub fn req_events_of(
+        &self,
+        filters: Vec<Filter>,
+        timeout: Option<Duration>,
+    ) -> Vec<SubscriptionId> {
+        RUNTIME.block_on(async { self.client.req_events_of(filters, timeout).await })
     }
 
     pub fn send_msg(&self, msg: ClientMessage) -> Result<(), Error> {

--- a/crates/nostr-sdk/src/client/mod.rs
+++ b/crates/nostr-sdk/src/client/mod.rs
@@ -15,7 +15,7 @@ use nostr::key::XOnlyPublicKey;
 use nostr::url::Url;
 use nostr::{
     ChannelId, ClientMessage, Contact, Entity, Event, EventBuilder, EventId, Filter, Keys, Kind,
-    Metadata, Tag,
+    Metadata, SubscriptionId, Tag,
 };
 #[cfg(feature = "sqlite")]
 use nostr_sdk_sqlite::Store;
@@ -355,10 +355,10 @@ impl Client {
     /// client.subscribe(vec![subscription]).await;
     /// # }
     /// ```
-    pub async fn subscribe(&self, filters: Vec<Filter>) {
+    pub async fn subscribe(&self, filters: Vec<Filter>) -> Vec<SubscriptionId> {
         self.pool
             .subscribe(filters, self.opts.get_wait_for_send())
-            .await;
+            .await
     }
 
     /// Unsubscribe
@@ -399,8 +399,12 @@ impl Client {
 
     /// Request events of filters
     /// All events will be received on notification listener (`client.notifications()`)
-    pub async fn req_events_of(&self, filters: Vec<Filter>, timeout: Option<Duration>) {
-        self.pool.req_events_of(filters, timeout).await;
+    pub async fn req_events_of(
+        &self,
+        filters: Vec<Filter>,
+        timeout: Option<Duration>,
+    ) -> Vec<SubscriptionId> {
+        self.pool.req_events_of(filters, timeout).await
     }
 
     /// Send client message

--- a/crates/nostr-sdk/src/relay/mod.rs
+++ b/crates/nostr-sdk/src/relay/mod.rs
@@ -613,15 +613,15 @@ impl Relay {
     }
 
     /// Request events of filter. All events will be sent to notification listener
-    pub fn req_events_of(&self, filters: Vec<Filter>, timeout: Option<Duration>) {
+    pub fn req_events_of(&self, filters: Vec<Filter>, timeout: Option<Duration>) -> SubscriptionId {
         if !self.opts.read() {
             log::error!("{}", Error::ReadDisabled);
         }
 
         let relay = self.clone();
+        let subscription_id = SubscriptionId::generate();
+        let id = subscription_id.clone();
         thread::spawn(async move {
-            let id = SubscriptionId::generate();
-
             // Subscribe
             if let Err(e) = relay
                 .send_msg(ClientMessage::new_req(id.clone(), filters), false)
@@ -666,5 +666,7 @@ impl Relay {
                 );
             }
         });
+
+        subscription_id
     }
 }


### PR DESCRIPTION
### Description

I think this might be useful...

This PR makes it so that the `subscribe` and `req_events_of` functions on `Client` returns their generated `SubscriptionId`.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](../CONTRIBUTING.md)
* [ ] I ran `make precommit` before committing