### PR TITLE
Use nostr-ots without default feautres, avoid ureq dep

### DIFF
--- a/crates/nostr/Cargo.toml
+++ b/crates/nostr/Cargo.toml
@@ -35,7 +35,7 @@ bitcoin = { version = "0.29", optional = true }
 bitcoin_hashes = { version = "0.11", features = ["serde"] }
 cbc = { version = "0.1", features = ["alloc"], optional = true }
 log = { version = "0.4", optional = true }
-nostr-ots = "0.2"
+nostr-ots = { git="https://github.com/RCasatta/nostr-ots", branch="ureq_optional", default-features = false }
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls-webpki-roots", "socks"], optional = true }
 secp256k1 = { version = "0.24", features = ["global-context", "rand-std", "serde"] }
 serde = { version = "1.0", features = ["derive"], optional = true }


### PR DESCRIPTION
By providing a Stamper trait impl with the http library already in the dep tree

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

I didn't like to add another HTTP dep to a library that already has one, with https://github.com/RCasatta/nostr-ots/pull/8 is possible to provide a Stamper trait to perform the needed HTTP request

### Notes to the reviewers

The code is still a draft, but wanted to share the idea to receive early feedback

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [ ] I followed the [contribution guidelines](../CONTRIBUTING.md)
* [ ] I ran `make precommit` before committing