### PR TITLE
nostr: fix Filter::id(s) doc comments

### DIFF
--- a/crates/nostr/src/message/subscription.rs
+++ b/crates/nostr/src/message/subscription.rs
@@ -97,7 +97,7 @@ impl Filter {
         }
     }
 
-    /// Set subscription id
+    /// Set event id or prefix
     pub fn id(self, id: impl Into<String>) -> Self {
         Self {
             ids: Some(vec![id.into()]),
@@ -105,7 +105,7 @@ impl Filter {
         }
     }
 
-    /// Set subscription ids
+    /// Set event ids or prefixes
     pub fn ids(self, ids: impl Into<Vec<String>>) -> Self {
         Self {
             ids: Some(ids.into()),


### PR DESCRIPTION
### Description

This PR is to fix the doc comments for Filter::id. Ref: <https://github.com/nostr-protocol/nips/blob/master/01.md>.

```json
{
  "ids": <a list of event ids or prefixes>,
  "authors": <a list of pubkeys or prefixes, the pubkey of an event must be one of these>,
  "kinds": <a list of a kind numbers>,
  "#e": <a list of event ids that are referenced in an "e" tag>,
  "#p": <a list of pubkeys that are referenced in a "p" tag>,
  "since": <an integer unix timestamp, events must be newer than this to pass>,
  "until": <an integer unix timestamp, events must be older than this to pass>,
  "limit": <maximum number of events to be returned in the initial query>
}
```

### Notes to the reviewers

### Changelog notice

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](../CONTRIBUTING.md)
* [x] I ran `make precommit` before committing