### PR TITLE
Include rest of the REQ event as filters

### DIFF
--- a/crates/nostr/src/message/client.rs
+++ b/crates/nostr/src/message/client.rs
@@ -129,7 +129,7 @@ impl ClientMessage {
             if v_len == 2 {
                 let subscription_id: SubscriptionId = serde_json::from_value(v[1].clone())?;
                 return Ok(Self::new_req(subscription_id, Vec::new()));
-            } else if v_len == 3 {
+            } else if v_len >= 3 {
                 let subscription_id: SubscriptionId = serde_json::from_value(v[1].clone())?;
                 let filters: Vec<Filter> = serde_json::from_value(Value::Array(v[2..].to_vec()))?;
                 return Ok(Self::new_req(subscription_id, filters));


### PR DESCRIPTION
### Description
As of nostr v0.19.1 REQ events in form of
``` json
[
    "REQ",
    "id",
    {
        "ids": [],
        "kinds": [
            1,
            42
        ]
    },
    {
        "kinds": [
            1,
            5,
            6,
            7,
            9735
        ],
        "#e": []
    }
]
```
return error _MessageHandleError::InvalidMessageFormat_
This PR fixes this behavior
