### PR TITLE
Multiple clients pointing to the same relay share subscriptions

### DIFF
--- a/crates/nostr-sdk/src/relay/mod.rs
+++ b/crates/nostr-sdk/src/relay/mod.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use futures_util::{Future, SinkExt, StreamExt};
+use log::info;
 #[cfg(feature = "nip11")]
 use nostr::nips::nip11::RelayInformationDocument;
 use nostr::{ClientMessage, Event, Filter, RelayMessage, SubscriptionId, Url};
@@ -23,7 +24,6 @@ pub mod pool;
 
 use self::net::Message as WsMessage;
 use self::pool::RelayPoolMessage;
-use self::pool::SUBSCRIPTION;
 use crate::thread;
 use crate::RelayPoolNotification;
 #[cfg(feature = "blocking")]
@@ -148,6 +148,15 @@ impl RelayOptions {
     }
 }
 
+/// Relay instance's actual subscription with its unique id
+#[derive(Debug, Clone)]
+pub struct ActiveSubscription {
+    /// SubscriptionId to update or cancel subscription
+    pub id: SubscriptionId,
+    /// Subscriptions filters
+    pub filters: Vec<Filter>,
+}
+
 /// Relay
 #[derive(Debug, Clone)]
 pub struct Relay {
@@ -162,6 +171,7 @@ pub struct Relay {
     relay_sender: Sender<Message>,
     relay_receiver: Arc<Mutex<Receiver<Message>>>,
     notification_sender: broadcast::Sender<RelayPoolNotification>,
+    subscriptions: Arc<Mutex<ActiveSubscription>>,
 }
 
 impl PartialEq for Relay {
@@ -193,6 +203,10 @@ impl Relay {
             relay_sender,
             relay_receiver: Arc::new(Mutex::new(relay_receiver)),
             notification_sender,
+            subscriptions: Arc::new(Mutex::new(ActiveSubscription {
+                id: SubscriptionId::generate(),
+                filters: vec![],
+            })),
         }
     }
 
@@ -428,9 +442,9 @@ impl Relay {
 
                 // Subscribe to relay
                 if self.opts.read() {
-                    if let Err(e) = self.subscribe(false).await {
+                    if let Err(e) = self.resubscribe(false).await {
                         match e {
-                            Error::FiltersEmpty => (),
+                            Error::FiltersEmpty => info!("Filters empty!"),
                             _ => log::error!(
                                 "Impossible to subscribe to {}: {}",
                                 self.url(),
@@ -516,26 +530,37 @@ impl Relay {
         }
     }
 
-    /// Subscribe
-    pub async fn subscribe(&self, wait: bool) -> Result<SubscriptionId, Error> {
+    // Subscribes relay with existing filter
+    async fn resubscribe(&self, wait: bool) -> Result<SubscriptionId, Error> {
         if !self.opts.read() {
             return Err(Error::ReadDisabled);
         }
+        let subscription = self.subscriptions.lock().await.clone();
 
-        let mut subscription = SUBSCRIPTION.lock().await;
-        let filters = subscription.get_filters();
+        self.send_msg(
+            ClientMessage::new_req(subscription.id.clone(), subscription.filters),
+            wait,
+        )
+        .await?;
+        Ok(subscription.id)
+    }
+
+    /// Subscribe
+    pub async fn subscribe(
+        &self,
+        filters: Vec<Filter>,
+        wait: bool,
+    ) -> Result<SubscriptionId, Error> {
+        if !self.opts.read() {
+            return Err(Error::ReadDisabled);
+        }
 
         if filters.is_empty() {
             return Err(Error::FiltersEmpty);
         }
 
-        let channel = subscription.get_channel(&self.url());
-        let channel_id = channel.id();
-
-        self.send_msg(ClientMessage::new_req(channel_id.clone(), filters), wait)
-            .await?;
-
-        Ok(channel_id)
+        self.subscriptions.lock().await.filters = filters;
+        self.resubscribe(wait).await
     }
 
     /// Unsubscribe
@@ -544,11 +569,9 @@ impl Relay {
             return Err(Error::ReadDisabled);
         }
 
-        let mut subscription = SUBSCRIPTION.lock().await;
-        if let Some(channel) = subscription.remove_channel(&self.url()) {
-            self.send_msg(ClientMessage::close(channel.id()), wait)
-                .await?;
-        }
+        let subscription_id = self.subscriptions.lock().await.id.clone();
+        self.send_msg(ClientMessage::close(subscription_id), wait)
+            .await?;
         Ok(())
     }
 

--- a/crates/nostr-sdk/src/relay/pool.rs
+++ b/crates/nostr-sdk/src/relay/pool.rs
@@ -14,17 +14,12 @@ use nostr::url::Url;
 use nostr::{ClientMessage, Event, EventId, Filter, RelayMessage};
 #[cfg(feature = "sqlite")]
 use nostr_sdk_sqlite::Store;
-use once_cell::sync::Lazy;
 use tokio::sync::mpsc::{self, Receiver, Sender};
 use tokio::sync::{broadcast, Mutex};
 use tokio::time;
 
 use super::{Error as RelayError, Relay, RelayOptions};
-use crate::subscription::Subscription;
 use crate::thread;
-
-pub(crate) static SUBSCRIPTION: Lazy<Mutex<Subscription>> =
-    Lazy::new(|| Mutex::new(Subscription::new()));
 
 /// [`RelayPool`] error
 #[derive(Debug, thiserror::Error)]
@@ -184,6 +179,7 @@ pub struct RelayPool {
     relays: Arc<Mutex<HashMap<Url, Relay>>>,
     pool_task_sender: Sender<RelayPoolMessage>,
     notification_sender: broadcast::Sender<RelayPoolNotification>,
+    subscriptions: Arc<Mutex<Vec<Filter>>>,
     #[cfg(feature = "sqlite")]
     store: Option<Store>,
 }
@@ -209,6 +205,7 @@ impl RelayPool {
             relays: Arc::new(Mutex::new(HashMap::new())),
             pool_task_sender,
             notification_sender,
+            subscriptions: Arc::new(Mutex::new(Vec::new())),
             #[cfg(feature = "sqlite")]
             store: None,
         }
@@ -237,6 +234,7 @@ impl RelayPool {
             relays: Arc::new(Mutex::new(HashMap::new())),
             pool_task_sender,
             notification_sender,
+            subscriptions: Arc::new(Mutex::new(Vec::new())),
             #[cfg(feature = "sqlite")]
             store,
         })
@@ -260,9 +258,8 @@ impl RelayPool {
     }
 
     /// Get subscriptions
-    pub async fn subscription(&self) -> Subscription {
-        let subscription = SUBSCRIPTION.lock().await;
-        subscription.clone()
+    pub async fn subscription(&self) -> Vec<Filter> {
+        self.subscriptions.lock().await.clone()
     }
 
     /// Add new relay
@@ -362,13 +359,10 @@ impl RelayPool {
     pub async fn subscribe(&self, filters: Vec<Filter>, wait: bool) {
         let relays = self.relays().await;
 
-        {
-            let mut subscription = SUBSCRIPTION.lock().await;
-            subscription.update_filters(filters.clone());
-        }
+        *self.subscriptions.lock().await = filters.clone();
 
         for relay in relays.values() {
-            if let Err(e) = relay.subscribe(wait).await {
+            if let Err(e) = relay.subscribe(filters.clone(), wait).await {
                 log::error!("{e}");
             }
         }
@@ -445,6 +439,12 @@ impl RelayPool {
     /// Connect to relay
     pub async fn connect_relay(&self, relay: &Relay, wait_for_connection: bool) {
         relay.connect(wait_for_connection).await;
+        if let Err(error) = relay
+            .subscribe(self.subscriptions.lock().await.clone(), wait_for_connection)
+            .await
+        {
+            log::error!("Cannot subscribe new relay to existing subscriptions: {error}");
+        }
         #[cfg(feature = "sqlite")]
         if let Some(store) = &self.store {
             if let Err(e) = store.enable_relay(relay.url()) {


### PR DESCRIPTION
### Description
I was playing a bit with nostr-sdk and noticed that multiple independent clients connected to the same relay start getting messages from each others subscriptions.  
[Reproduced it minimally here](https://gist.github.com/arkaitzj/aaf87af9fb64a62f71f0b9b20c3ad385)

It seems to stem from the fact that there is a single, [global Subscription object for everyone](https://github.com/rust-nostr/nostr/blob/228b00c7671dfa0b41e862876af151572767d8ef/crates/nostr-sdk/src/relay/pool.rs#L26).  

I understand, correct me if I am wrong, that this is not the expected behaviour?

I added changes that allow relay objects, one per client, to have their own filters, with their own ids and use them on every reconnection.  
Pools also keep their own copy of the subscription object to supply it to new relays assuming all relays from a pool should be subscribed to the same filters. Each client has its own pool so this also keeps clients isolated. 

### Notes to the reviewers
There are several subscription structs, like Subscription and Channel that are no longer used with this change since each relay and pool keep their last-used subscriptions, however I did not deleted them on this PR, waiting for some feedback here.

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](../CONTRIBUTING.md)
* [x] I ran `make precommit` before committing