### PR TITLE
Add deserialization for RelayMessage::Auth

### DIFF
--- a/crates/nostr/src/message/relay.rs
+++ b/crates/nostr/src/message/relay.rs
@@ -187,6 +187,17 @@ impl RelayMessage {
 
             return Ok(Self::new_ok(event_id, status, message));
         }
+        
+        // OK (NIP-42)
+        // Relay response format: ["AUTH", <challenge>]
+        if v[0] == "AUTH" {
+            if v_len != 2 {
+                return Err(MessageHandleError::InvalidMessageFormat);
+            }
+
+            let challenge: String = serde_json::from_value(v[1].clone())?;
+            return Ok(Self::Auth { challenge });
+        }
 
         Err(MessageHandleError::InvalidMessageFormat)
     }

--- a/crates/nostr/src/message/relay.rs
+++ b/crates/nostr/src/message/relay.rs
@@ -187,7 +187,7 @@ impl RelayMessage {
 
             return Ok(Self::new_ok(event_id, status, message));
         }
-        
+
         // OK (NIP-42)
         // Relay response format: ["AUTH", <challenge>]
         if v[0] == "AUTH" {


### PR DESCRIPTION
### Description

There was no implementation for deserialization of `RelayMessage::Auth`

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](../CONTRIBUTING.md)
* [x] I ran `make precommit` before committing