### PR TITLE
Create EventBuilder helper for zaps

### DIFF
--- a/crates/nostr/src/event/builder.rs
+++ b/crates/nostr/src/event/builder.rs
@@ -408,6 +408,42 @@ impl EventBuilder {
     {
         Self::new(Kind::Reporting, content, tags)
     }
+
+    /// Create zap event
+    ///
+    /// <https://github.com/nostr-protocol/nips/blob/master/57.md>
+    pub fn new_zap<S>(bolt11: S, amount: u64, preimage: S, zap_request: Event) -> Self
+    where
+        S: Into<String>,
+    {
+        let mut tags = vec![
+            Tag::Preimage(preimage.into()),
+            Tag::Bolt11(bolt11.into()),
+            Tag::Amount(amount),
+            Tag::Description(zap_request.as_json()),
+        ];
+
+        // add e tag
+        if let Some(tag) = zap_request
+            .tags
+            .clone()
+            .into_iter()
+            .find(|t| t.kind() == TagKind::E)
+        {
+            tags.push(tag);
+        }
+
+        // add p tag
+        if let Some(tag) = zap_request
+            .tags
+            .into_iter()
+            .find(|t| t.kind() == TagKind::P)
+        {
+            tags.push(tag);
+        }
+
+        Self::new(Kind::Zap, "", &tags)
+    }
 }
 
 #[cfg(test)]

--- a/crates/nostr/src/event/tag.rs
+++ b/crates/nostr/src/event/tag.rs
@@ -320,6 +320,40 @@ impl Tag {
     pub fn as_vec(&self) -> Vec<String> {
         self.clone().into()
     }
+
+    /// Get [`TagKind`]
+    pub fn kind(&self) -> TagKind {
+        match self {
+            Tag::Generic(kind, ..) => kind.clone(),
+            Tag::Event(..) => TagKind::E,
+            Tag::PubKey(..) => TagKind::P,
+            Tag::EventReport(..) => TagKind::E,
+            Tag::PubKeyReport(..) => TagKind::P,
+            Tag::Reference(..) => TagKind::R,
+            Tag::RelayMetadata(..) => TagKind::R,
+            Tag::Hashtag(..) => TagKind::T,
+            Tag::Geohash(..) => TagKind::G,
+            Tag::Identifier(..) => TagKind::D,
+            Tag::A { .. } => TagKind::A,
+            Tag::Relay(..) => TagKind::Relay,
+            Tag::ContactList { .. } => TagKind::P,
+            Tag::POW { .. } => TagKind::Nonce,
+            Tag::Delegation { .. } => TagKind::Delegation,
+            Tag::ContentWarning { .. } => TagKind::ContentWarning,
+            Tag::Expiration(..) => TagKind::Expiration,
+            Tag::Subject(..) => TagKind::Subject,
+            Tag::Challenge(..) => TagKind::Challenge,
+            Tag::Title(..) => TagKind::Title,
+            Tag::Image(..) => TagKind::Image,
+            Tag::Summary(..) => TagKind::Summary,
+            Tag::PublishedAt(..) => TagKind::PublishedAt,
+            Tag::Description(..) => TagKind::Description,
+            Tag::Bolt11(..) => TagKind::Bolt11,
+            Tag::Preimage(..) => TagKind::Preimage,
+            Tag::Relays(..) => TagKind::Relays,
+            Tag::Amount(..) => TagKind::Amount,
+        }
+    }
 }
 
 impl<S> TryFrom<Vec<S>> for Tag


### PR DESCRIPTION
### Notes to the reviewers

How I get the e and p tags is pretty ugly, not sure if there is a cleaner way to do it. Would be nice if there were some helper functions on `Event` to give it a `TagKind` and it returns all the `Tag`s.

Sorry for double PR, screwed up something with #71

### Changelog notice

Added some helper functions for creating zap events.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](../CONTRIBUTING.md)
* [x] I ran `make precommit` before committing