### PR TITLE
Fix: Relay Tag seralization 

### DIFF
--- a/bindings/nostr-ffi/src/contact.rs
+++ b/bindings/nostr-ffi/src/contact.rs
@@ -24,7 +24,10 @@ impl Deref for Contact {
 impl Contact {
     pub fn new(pk: String, relay_url: Option<String>, alias: Option<String>) -> Result<Self> {
         let pk = XOnlyPublicKey::from_str(&pk)?;
-        let relay_url = relay_url.map(|u| UncheckedUrl::from_str(&u).unwrap());
+        let relay_url = match relay_url {
+            Some(relay_url) => Some(UncheckedUrl::from_str(&relay_url)?),
+            None => None,
+        };
         Ok(Self {
             contact: ContactSdk::new(pk, relay_url, alias),
         })

--- a/bindings/nostr-ffi/src/contact.rs
+++ b/bindings/nostr-ffi/src/contact.rs
@@ -4,6 +4,7 @@
 use std::ops::Deref;
 use std::str::FromStr;
 
+use nostr::prelude::tag::UncheckedUrl;
 use nostr::secp256k1::XOnlyPublicKey;
 use nostr::Contact as ContactSdk;
 
@@ -23,6 +24,7 @@ impl Deref for Contact {
 impl Contact {
     pub fn new(pk: String, relay_url: Option<String>, alias: Option<String>) -> Result<Self> {
         let pk = XOnlyPublicKey::from_str(&pk)?;
+        let relay_url = relay_url.map(|u| UncheckedUrl::from_str(&u).unwrap());
         Ok(Self {
             contact: ContactSdk::new(pk, relay_url, alias),
         })
@@ -37,6 +39,6 @@ impl Contact {
     }
 
     pub fn relay_url(&self) -> Option<String> {
-        self.contact.relay_url.clone()
+        self.contact.relay_url.clone().map(|u| u.to_string())
     }
 }

--- a/bindings/nostr-js/src/types/contact.rs
+++ b/bindings/nostr-js/src/types/contact.rs
@@ -2,8 +2,9 @@
 // Distributed under the MIT software license
 
 use std::ops::Deref;
+use std::str::FromStr;
 
-use nostr::prelude::*;
+use nostr::prelude::{tag::UncheckedUrl, *};
 use wasm_bindgen::prelude::*;
 
 use crate::key::JsPublicKey;
@@ -36,6 +37,7 @@ impl From<&JsContact> for Contact {
 impl JsContact {
     #[wasm_bindgen(constructor)]
     pub fn new(public_key: &JsPublicKey, relay_url: Option<String>, alias: Option<String>) -> Self {
+        let relay_url = relay_url.map(|u| UncheckedUrl::from_str(&u).unwrap());
         Self {
             inner: Contact::new(public_key.into(), relay_url, alias),
         }

--- a/bindings/nostr-js/src/types/contact.rs
+++ b/bindings/nostr-js/src/types/contact.rs
@@ -37,7 +37,13 @@ impl From<&JsContact> for Contact {
 impl JsContact {
     #[wasm_bindgen(constructor)]
     pub fn new(public_key: &JsPublicKey, relay_url: Option<String>, alias: Option<String>) -> Self {
-        let relay_url = relay_url.map(|u| UncheckedUrl::from_str(&u).unwrap());
+        let relay_url = match relay_url {
+            Some(relay_url) => match UncheckedUrl::from_str(&relay_url) {
+                Ok(url) => Some(url),
+                Err(_) => None,
+            },
+            None => None,
+        };
         Self {
             inner: Contact::new(public_key.into(), relay_url, alias),
         }

--- a/bindings/nostr-js/src/types/contact.rs
+++ b/bindings/nostr-js/src/types/contact.rs
@@ -4,7 +4,7 @@
 use std::ops::Deref;
 use std::str::FromStr;
 
-use nostr::prelude::{tag::UncheckedUrl, *};
+use nostr::prelude::*;
 use wasm_bindgen::prelude::*;
 
 use crate::key::JsPublicKey;

--- a/bindings/nostr-nodejs/src/types/contact.rs
+++ b/bindings/nostr-nodejs/src/types/contact.rs
@@ -36,7 +36,14 @@ impl From<&JsContact> for Contact {
 impl JsContact {
     #[napi(constructor)]
     pub fn new(public_key: &JsPublicKey, relay_url: Option<String>, alias: Option<String>) -> Self {
-        let relay_url = relay_url.map(|u| UncheckedUrl::from_str(&u).unwrap());
+        let relay_url = match relay_url {
+            Some(relay_url) => match UncheckedUrl::from_str(&relay_url) {
+                Ok(url) => Some(url),
+                Err(_) => None,
+            },
+            None => None,
+        };
+
         Self {
             inner: Contact::new(public_key.into(), relay_url, alias),
         }

--- a/bindings/nostr-nodejs/src/types/contact.rs
+++ b/bindings/nostr-nodejs/src/types/contact.rs
@@ -2,8 +2,9 @@
 // Distributed under the MIT software license
 
 use std::ops::Deref;
+use std::str::FromStr;
 
-use nostr::prelude::*;
+use nostr::prelude::{tag::UncheckedUrl, *};
 
 use crate::key::JsPublicKey;
 
@@ -35,6 +36,7 @@ impl From<&JsContact> for Contact {
 impl JsContact {
     #[napi(constructor)]
     pub fn new(public_key: &JsPublicKey, relay_url: Option<String>, alias: Option<String>) -> Self {
+        let relay_url = relay_url.map(|u| UncheckedUrl::from_str(&u).unwrap());
         Self {
             inner: Contact::new(public_key.into(), relay_url, alias),
         }

--- a/crates/nostr-sdk/src/client/mod.rs
+++ b/crates/nostr-sdk/src/client/mod.rs
@@ -825,7 +825,7 @@ impl Client {
             for tag in event.tags.into_iter() {
                 match tag {
                     Tag::PubKey(pk, relay_url) => {
-                        contact_list.push(Contact::new(pk, relay_url, None))
+                        contact_list.push(Contact::new::<String>(pk, relay_url, None))
                     }
                     Tag::ContactList {
                         pk,

--- a/crates/nostr/src/event/builder.rs
+++ b/crates/nostr/src/event/builder.rs
@@ -182,6 +182,8 @@ impl EventBuilder {
     /// # Example
     /// ```rust,no_run
     /// use nostr::{EventBuilder, Tag, Timestamp, EventId};
+    /// use nostr::prelude::tag::UncheckedUrl;
+    /// use std::str::FromStr;
     ///
     /// let event_id = EventId::from_hex("b3e392b11f5d4f28321cedd09303a748acfd0487aea5a7450b3481c60b6e4f87").unwrap();
     /// let content: &str = "Lorem [ipsum][4] dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\n\nRead more at #[3].";
@@ -190,7 +192,7 @@ impl EventBuilder {
     ///     Tag::Title("Lorem Ipsum".to_string()),
     ///     Tag::PublishedAt(Timestamp::from(1296962229)),
     ///     Tag::Hashtag("placeholder".to_string()),
-    ///     Tag::Event(event_id, Some("wss://relay.example.com".to_string()), None),
+    ///     Tag::Event(event_id, Some(UncheckedUrl::from_str("wss://relay.example.com").unwrap()), None),
     /// ];
     /// let builder = EventBuilder::long_form_text_note("My first text note from Nostr SDK!", &[]);
     /// ```
@@ -293,7 +295,7 @@ impl EventBuilder {
             metadata.as_json(),
             &[Tag::Event(
                 channel_id.into(),
-                relay_url.map(|u| u.to_string()),
+                relay_url.map(|u| u.into()),
                 None,
             )],
         )
@@ -311,7 +313,7 @@ impl EventBuilder {
             content,
             &[Tag::Event(
                 channel_id.into(),
-                Some(relay_url.to_string()),
+                Some(relay_url.into()),
                 Some(Marker::Root),
             )],
         )

--- a/crates/nostr/src/event/tag.rs
+++ b/crates/nostr/src/event/tag.rs
@@ -257,33 +257,33 @@ where
 }
 
 /// Unchecked Relay Url
-#[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord)]
-pub struct UncheckedRelayUrl(String);
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, PartialOrd, Ord)]
+pub struct UncheckedUrl(String);
 
-impl FromStr for UncheckedRelayUrl {
+impl FromStr for UncheckedUrl {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(UncheckedRelayUrl(s.to_owned()))
+        Ok(Self(s.to_owned()))
     }
 }
 
-impl From<Url> for UncheckedRelayUrl {
+impl From<Url> for UncheckedUrl {
     fn from(url: Url) -> Self {
         let url_string = url.to_string();
-        UncheckedRelayUrl(url_string)
+        Self(url_string)
     }
 }
 
-impl TryFrom<UncheckedRelayUrl> for Url {
+impl TryFrom<UncheckedUrl> for Url {
     type Error = Error;
 
-    fn try_from(unchecked_url: UncheckedRelayUrl) -> Result<Url, Self::Error> {
-        Ok(Url::parse(&unchecked_url.0)?)
+    fn try_from(unchecked_url: UncheckedUrl) -> Result<Url, Self::Error> {
+        Ok(Self::parse(&unchecked_url.0)?)
     }
 }
 
-impl fmt::Display for UncheckedRelayUrl {
+impl fmt::Display for UncheckedUrl {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
@@ -335,7 +335,7 @@ pub enum Tag {
     Description(String),
     Bolt11(String),
     Preimage(String),
-    Relays(Vec<UncheckedRelayUrl>),
+    Relays(Vec<UncheckedUrl>),
     Amount(u64),
     PublishedAt(Timestamp),
 }
@@ -409,8 +409,8 @@ where
             let urls = tag
                 .iter()
                 .skip(1)
-                .filter_map(|tag_str| UncheckedRelayUrl::from_str(tag_str).ok())
-                .collect::<Vec<UncheckedRelayUrl>>();
+                .filter_map(|tag_str| UncheckedUrl::from_str(tag_str).ok())
+                .collect::<Vec<UncheckedUrl>>();
 
             Ok(Self::Relays(urls))
         } else if tag_len == 1 {
@@ -1138,10 +1138,10 @@ mod tests {
                 "wss//nostr.fmt.wiz.biz"
             ])?,
             Tag::Relays(vec![
-                UncheckedRelayUrl::from_str("wss://relay.damus.io/")?,
-                UncheckedRelayUrl::from_str("wss://nostr-relay.wlvs.space/")?,
-                UncheckedRelayUrl::from_str("wss://nostr.fmt.wiz.biz")?,
-                UncheckedRelayUrl::from_str("wss//nostr.fmt.wiz.biz")?
+                UncheckedUrl::from_str("wss://relay.damus.io/")?,
+                UncheckedUrl::from_str("wss://nostr-relay.wlvs.space/")?,
+                UncheckedUrl::from_str("wss://nostr.fmt.wiz.biz")?,
+                UncheckedUrl::from_str("wss//nostr.fmt.wiz.biz")?
             ])
         );
 
@@ -1182,9 +1182,9 @@ mod tests {
 
         println!("{}", relay_url.to_string());
 
-        let unchecked_relay_url = UncheckedRelayUrl::from(relay_url.clone());
+        let unchecked_relay_url = UncheckedUrl::from(relay_url.clone());
 
-        assert_eq!(unchecked_relay_url, UncheckedRelayUrl::from_str(relay)?);
+        assert_eq!(unchecked_relay_url, UncheckedUrl::from_str(relay)?);
 
         assert_eq!(Url::try_from(unchecked_relay_url.clone())?, relay_url);
 

--- a/crates/nostr/src/event/tag.rs
+++ b/crates/nostr/src/event/tag.rs
@@ -302,7 +302,7 @@ pub enum Tag {
     Description(String),
     Bolt11(String),
     Preimage(String),
-    Relays(Vec<Url>),
+    Relays(Vec<String>),
     Amount(u64),
     PublishedAt(Timestamp),
 }
@@ -372,11 +372,8 @@ where
 
         if tag_kind.eq(&TagKind::Relays) {
             // Relays vec is of unknown length so checked here based on kind
-            let urls = tag
-                .iter()
-                .skip(1)
-                .filter_map(|tag_str| Url::parse(tag_str).ok())
-                .collect::<Vec<Url>>();
+            let mut urls = tag;
+            urls.remove(0);
 
             Ok(Self::Relays(urls))
         } else if tag_len == 1 {
@@ -584,11 +581,7 @@ impl From<Tag> for Vec<String> {
             }
             Tag::Relays(relays) => vec![TagKind::Relays.to_string()]
                 .into_iter()
-                .chain(
-                    relays
-                        .iter()
-                        .map(|relay| relay.to_string().trim_end_matches('/').to_string()),
-                )
+                .chain(relays.iter().map(|relay| relay.to_string().to_string()))
                 .collect::<Vec<_>>(),
             Tag::Amount(amount) => {
                 vec![TagKind::Amount.to_string(), amount.to_string()]
@@ -1103,13 +1096,13 @@ mod tests {
             Tag::parse(vec![
                 "relays",
                 "wss://relay.damus.io/",
-                "wss://nostr-relay.wlvs.space",
+                "wss://nostr-relay.wlvs.space/",
                 "wss://nostr.fmt.wiz.biz"
             ])?,
             Tag::Relays(vec![
-                Url::from_str("wss://relay.damus.io")?,
-                Url::from_str("wss://nostr-relay.wlvs.space")?,
-                Url::from_str("wss://nostr.fmt.wiz.biz")?
+                "wss://relay.damus.io/".to_string(),
+                "wss://nostr-relay.wlvs.space/".to_string(),
+                "wss://nostr.fmt.wiz.biz".to_string()
             ])
         );
 

--- a/crates/nostr/src/prelude.rs
+++ b/crates/nostr/src/prelude.rs
@@ -16,6 +16,11 @@ pub use serde_json::*;
 pub use url::*;
 
 // Internal modules
+pub use crate::event::builder::*;
+pub use crate::event::id::*;
+pub use crate::event::kind::*;
+pub use crate::event::tag::*;
+pub use crate::event::unsigned::*;
 pub use crate::event::*;
 pub use crate::key::*;
 pub use crate::message::*;

--- a/crates/nostr/src/types/contact.rs
+++ b/crates/nostr/src/types/contact.rs
@@ -3,6 +3,7 @@
 
 //! Contact
 
+use crate::event::tag::UncheckedUrl;
 use secp256k1::XOnlyPublicKey;
 
 /// Contact
@@ -11,20 +12,20 @@ pub struct Contact {
     /// Public key
     pub pk: XOnlyPublicKey,
     /// Relay url
-    pub relay_url: Option<String>,
+    pub relay_url: Option<UncheckedUrl>,
     /// Alias
     pub alias: Option<String>,
 }
 
 impl Contact {
     /// Create new [`Contact`]
-    pub fn new<S>(pk: XOnlyPublicKey, relay_url: Option<S>, alias: Option<S>) -> Self
+    pub fn new<S>(pk: XOnlyPublicKey, relay_url: Option<UncheckedUrl>, alias: Option<S>) -> Self
     where
         S: Into<String>,
     {
         Self {
             pk,
-            relay_url: relay_url.map(|a| a.into()),
+            relay_url,
             alias: alias.map(|a| a.into()),
         }
     }

--- a/crates/nostr/src/types/contact.rs
+++ b/crates/nostr/src/types/contact.rs
@@ -3,8 +3,9 @@
 
 //! Contact
 
-use crate::event::tag::UncheckedUrl;
 use secp256k1::XOnlyPublicKey;
+
+use crate::event::tag::UncheckedUrl;
 
 /// Contact
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Deserialize, Serialize)]


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

Since the relays tag is part of what is signed, the exact string is important. I added this `RelayUrl` struct to keep both a `Url` and the original string. However, I'm not convinced its needed and may just be simpler to be a string like relays in the contact list tag. Let me know what you think is better as the currant implementation will make signature verification fail when a zap is serialize/deseralized.

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

Add

- `RealyUrl` struct

Change
- Relays Tag from `Vec<Url>` to `Vec<RelayUrl>`


### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](../CONTRIBUTING.md)
* [x] I ran `make precommit` before committing