### PR TITLE
Remove amount tag from zap receipt event builder

### DIFF
--- a/crates/nostr/src/event/builder.rs
+++ b/crates/nostr/src/event/builder.rs
@@ -402,14 +402,13 @@ impl EventBuilder {
     /// Create zap event
     ///
     /// <https://github.com/nostr-protocol/nips/blob/master/57.md>
-    pub fn new_zap<S>(bolt11: S, amount: u64, preimage: S, zap_request: Event) -> Self
+    pub fn new_zap<S>(bolt11: S, preimage: S, zap_request: Event) -> Self
     where
         S: Into<String>,
     {
         let mut tags = vec![
             Tag::Preimage(preimage.into()),
             Tag::Bolt11(bolt11.into()),
-            Tag::Amount(amount),
             Tag::Description(zap_request.as_json()),
         ];
 


### PR DESCRIPTION
### Description

The amount tag doesn't seem to be a part of the kind 9735 event so I removed it. Seems like this was confused with the kind 9734 event which does actually have the amount tag.

### Changelog notice

```md
# removed
- "amount" parameter from zap receipt event builder
```

### Checklists

#### All Submissions:

* [ ] I've signed all my commits
* [x] I followed the [contribution guidelines](../CONTRIBUTING.md)
* [x] I ran `make precommit` before committing