### PR TITLE
docs: clarify req_events_of behavior

### DIFF
--- a/bindings/nostr-sdk-js/src/client/mod.rs
+++ b/bindings/nostr-sdk-js/src/client/mod.rs
@@ -130,8 +130,9 @@ impl JsClient {
         }
     }
 
-    /// Request events of filters
+    /// Request events of filters.
     /// All events will be received on notification listener
+    /// until the EOSE "end of stored events" message is received from the relay.
     #[wasm_bindgen(js_name = reqEventsOf)]
     pub async fn req_events_of(&self, filters: Array, timeout: Option<u64>) -> Result<()> {
         let filters = filters

--- a/bindings/nostr-sdk-nodejs/src/client/mod.rs
+++ b/bindings/nostr-sdk-nodejs/src/client/mod.rs
@@ -144,8 +144,9 @@ impl JsClient {
         }
     }
 
-    /// Request events of filters
+    /// Request events of filters.
     /// All events will be received on notification listener
+    /// until the EOSE "end of stored events" message is received from the relay.
     #[napi]
     pub async fn req_events_of(&self, filters: Vec<&JsFilter>, timeout: Option<u32>) {
         let filters = filters.into_iter().map(|f| f.into()).collect();

--- a/crates/nostr-sdk/src/client/mod.rs
+++ b/crates/nostr-sdk/src/client/mod.rs
@@ -570,6 +570,7 @@ impl Client {
 
     /// Request events of filters
     /// All events will be received on notification listener (`client.notifications()`)
+    /// until the EOSE "end of stored events" message is received from the relay.
     pub async fn req_events_of(&self, filters: Vec<Filter>, timeout: Option<Duration>) {
         let timeout = match timeout {
             Some(t) => Some(t),

--- a/crates/nostr-sdk/src/relay/mod.rs
+++ b/crates/nostr-sdk/src/relay/mod.rs
@@ -781,7 +781,8 @@ impl Relay {
         Ok(events.into_inner())
     }
 
-    /// Request events of filter. All events will be sent to notification listener
+    /// Request events of filter. All events will be sent to notification listener,
+    /// until the EOSE "end of stored events" message is received from the relay.
     pub fn req_events_of(&self, filters: Vec<Filter>, timeout: Option<Duration>) {
         if !self.opts.read() {
             log::error!("{}", Error::ReadDisabled);

--- a/crates/nostr-sdk/src/relay/pool.rs
+++ b/crates/nostr-sdk/src/relay/pool.rs
@@ -432,6 +432,7 @@ impl RelayPool {
     }
 
     /// Request events of filter. All events will be sent to notification listener
+    /// until the EOSE "end of stored events" message is received from the relay.
     pub async fn req_events_of(&self, filters: Vec<Filter>, timeout: Option<Duration>) {
         let relays = self.relays().await;
         for relay in relays.values() {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

Awesome crate!

I found the behavior of `req_events_of` to be a bit confusing. At first, I didn't realize that it stops pushing events onto the client `notifications()` channel once `EOSE` has been received from the relay. After digging around the code and actually looking at the examples, I saw that `subscribe` is the better method to use for real-time streaming of events.

Perhaps the method should have a different name in the future? I'm not exactly sure what it could be, but I'm hoping this addition to the docs will clarify for users.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](../CONTRIBUTING.md)
* [x] I ran `make precommit` before committing