### PR TITLE
nostr: Also accept `displayName` in metadata

### DIFF
--- a/crates/nostr/src/types/metadata.rs
+++ b/crates/nostr/src/types/metadata.rs
@@ -21,7 +21,7 @@ pub struct Metadata {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     /// Display name
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "displayName")]
     pub display_name: Option<String>,
     /// Description
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -186,6 +186,16 @@ mod tests {
                 .name("myname")
                 .about("Description")
                 .display_name("")
+        );
+
+        let content = r#"{"name":"myname","about":"Description","displayName":"Jack"}"#;
+        let metadata = Metadata::from_json(content).unwrap();
+        assert_eq!(
+            metadata,
+            Metadata::new()
+                .name("myname")
+                .about("Description")
+                .display_name("Jack")
         );
     }
 }


### PR DESCRIPTION
### Description

In metadata, both `displayName` and `display_name` are common. The library should be able to parse both versions.

### Changelog notice

Changed

  - `displayName` in metadata also accepted besides `display_name`

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](../CONTRIBUTING.md)
* [x] I ran `make precommit` before committing