### PR TITLE
Add more docs for RelayPoolNotification

### DIFF
--- a/crates/nostr-sdk/src/relay/pool.rs
+++ b/crates/nostr-sdk/src/relay/pool.rs
@@ -65,9 +65,9 @@ pub enum RelayPoolMessage {
 /// Relay Pool Notification
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RelayPoolNotification {
-    /// Received an [`Event`]
+    /// Received an [`Event`]. Does not include events sent by this client.
     Event(Url, Event),
-    /// Received a [`RelayMessage`]
+    /// Received a [`RelayMessage`]. Includes messages wrapping events that were sent by this client.
     Message(Url, RelayMessage),
     /// Shutdown
     Shutdown,


### PR DESCRIPTION
### Description

Simple PR documenting one distinction between `RelayPoolNotification::Event` and `RelayPoolNotification::Message`.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](../CONTRIBUTING.md)
* [x] I ran `make precommit` before committing