### PR TITLE
MMR tag: add merkle mountain range tag

### DIFF
--- a/crates/nostr/Cargo.toml
+++ b/crates/nostr/Cargo.toml
@@ -25,6 +25,7 @@ nip19 = ["dep:bech32"]
 nip21 = ["nip19"]
 nip46 = ["nip04"]
 nip47 = ["nip04"]
+mmr = []
 
 [dependencies]
 aes = { version = "0.8", optional = true }

--- a/crates/nostr/src/event/builder.rs
+++ b/crates/nostr/src/event/builder.rs
@@ -3,15 +3,15 @@
 
 //! Event builder
 
-use core::fmt;
-#[cfg(not(target_arch = "wasm32"))]
-use std::time::Instant;
-
+#[cfg(feature = "mmr")]
 use bitcoin_hashes::sha256::Hash;
+use core::fmt;
 #[cfg(target_arch = "wasm32")]
 use instant::Instant;
 use secp256k1::XOnlyPublicKey;
 use serde_json::{json, Value};
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::Instant;
 use url::Url;
 
 pub use super::kind::Kind;
@@ -172,6 +172,7 @@ impl EventBuilder {
     }
 
     /// Build MMR [`Event`]
+    #[cfg(feature = "mmr")]
     pub fn to_mmr_event(
         self,
         keys: &Keys,
@@ -186,6 +187,7 @@ impl EventBuilder {
     }
 
     /// Build unsigned MMR [`Event`]
+    #[cfg(feature = "mmr")]
     pub fn to_unsigned_mmr_event(
         self,
         pubkey: XOnlyPublicKey,

--- a/crates/nostr/src/event/tag.rs
+++ b/crates/nostr/src/event/tag.rs
@@ -7,6 +7,7 @@ use core::fmt;
 use core::num::ParseIntError;
 use core::str::FromStr;
 
+#[cfg(feature = "mmr")]
 use bitcoin_hashes::sha256::Hash;
 use secp256k1::schnorr::Signature;
 use secp256k1::XOnlyPublicKey;
@@ -243,6 +244,7 @@ pub enum TagKind {
     Lnurl,
     /// Name tag
     Name,
+    #[cfg(feature = "mmr")]
     /// Merkle mountain range
     Mmr,
     /// Custom tag kind
@@ -278,6 +280,7 @@ impl fmt::Display for TagKind {
             Self::Amount => write!(f, "amount"),
             Self::Lnurl => write!(f, "lnurl"),
             Self::Name => write!(f, "name"),
+            #[cfg(feature = "mmr")]
             Self::Mmr => write!(f, "mmr"),
             Self::Custom(tag) => write!(f, "{tag}"),
         }
@@ -317,6 +320,7 @@ where
             "amount" => Self::Amount,
             "lnurl" => Self::Lnurl,
             "name" => Self::Name,
+            #[cfg(feature = "mmr")]
             "mmr" => Self::Mmr,
             tag => Self::Custom(tag.to_string()),
         }
@@ -375,6 +379,7 @@ pub enum Tag {
     Lnurl(String),
     Name(String),
     PublishedAt(Timestamp),
+    #[cfg(feature = "mmr")]
     Mmr {
         prev_event_id: Hash,
         prev_mmr_root: Hash,
@@ -430,6 +435,7 @@ impl Tag {
             Tag::Amount(..) => TagKind::Amount,
             Tag::Name(..) => TagKind::Name,
             Tag::Lnurl(..) => TagKind::Lnurl,
+            #[cfg(feature = "mmr")]
             Tag::Mmr { .. } => TagKind::Mmr,
         }
     }
@@ -592,6 +598,7 @@ where
                     conditions: Conditions::from_str(&tag[2])?,
                     sig: Signature::from_str(&tag[3])?,
                 }),
+                #[cfg(feature = "mmr")]
                 TagKind::Mmr => Ok(Self::Mmr {
                     prev_event_id: Hash::from_str(tag[1].as_str())?,
                     prev_mmr_root: Hash::from_str(tag[2].as_str())?,
@@ -742,6 +749,7 @@ impl From<Tag> for Vec<String> {
             Tag::Lnurl(lnurl) => {
                 vec![TagKind::Lnurl.to_string(), lnurl]
             }
+            #[cfg(feature = "mmr")]
             Tag::Mmr {
                 prev_event_id,
                 prev_mmr_root,


### PR DESCRIPTION
### Description

Add merkle mountain range as an append only vector commitment to nostr events' metadata. This produces an authenticated event log. 

The NIP was briefly sketched [here](https://github.com/nostr-protocol/nips/issues/419)

The current PR fork is used [here](https://github.com/nostronaut/mmr-nostr)