### PR TITLE
Disable default features for rust-bitcoin

### DIFF
--- a/crates/nostr/Cargo.toml
+++ b/crates/nostr/Cargo.toml
@@ -31,7 +31,7 @@ aes = { version = "0.8", optional = true }
 base64 = { version = "0.21", optional = true }
 bech32 = { version = "0.9", optional = true }
 bip39 = { version = "2.0", optional = true }
-bitcoin = { version = "0.30", optional = true }
+bitcoin = { version = "0.30", optional = true, default-features = false }
 bitcoin_hashes = { version = "0.12", features = ["serde"] }
 cbc = { version = "0.1", features = ["alloc"], optional = true }
 log = "0.4"
@@ -51,6 +51,7 @@ csv = "1.1.5"
 env_logger = "0.10.0"
 num_cpus = "1.15.0"
 tungstenite = { version = "0.19", features = ["rustls-tls-webpki-roots"] }
+bitcoin = "0.30"
 
 [[example]]
 name = "keys"


### PR DESCRIPTION
This makes it so you can use no-std bitcoin in dependent libraries much easier