### PR TITLE
Feature/add nip 58 support in eventbuilder

### DIFF
--- a/crates/nostr/src/nips/nip58.rs
+++ b/crates/nostr/src/nips/nip58.rs
@@ -4,20 +4,24 @@
 
 use core::fmt;
 
+use crate::{Event, Kind, Tag, UncheckedUrl};
 use secp256k1::XOnlyPublicKey;
-
-use crate::event::builder::Error as BuilderError;
-use crate::{Event, EventBuilder, Keys, Kind, Tag, UncheckedUrl};
 
 #[derive(Debug)]
 /// [`BadgeAward`] error
 pub enum Error {
+    /// Invalid length
+    InvalidLength,
     /// Invalid kind
     InvalidKind,
     /// Identifier tag not found
     IdentifierTagNotFound,
-    /// Event builder error
-    EventBuilder(crate::event::builder::Error),
+    /// Mismatched badge definition or award
+    MismatchedBadgeDefinitionOrAward,
+    /// Badge awards lack the awarded public key
+    BadgeAwardsLackAwardedPublicKey,
+    /// Badge awards lack the awarded public key
+    BadgeAwardMissingATag,
 }
 
 impl std::error::Error for Error {}
@@ -25,487 +29,43 @@ impl std::error::Error for Error {}
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::InvalidKind => {
-                write!(f, "invalid kind")
-            }
-            Self::IdentifierTagNotFound => {
-                write!(f, "identifier tag not found")
-            }
-            Self::EventBuilder(e) => write!(f, "{e}"),
-        }
-    }
-}
-
-impl From<crate::event::builder::Error> for Error {
-    fn from(e: crate::event::builder::Error) -> Self {
-        Self::EventBuilder(e)
-    }
-}
-
-/// Simple struct to hold `width` x `height.
-pub struct ImageDimensions(u64, u64);
-
-/// [`BadgeDefinition`] event builder
-pub struct BadgeDefinitionBuilder {
-    badge_id: String,
-    name: Option<String>,
-    image: Option<String>,
-    image_dimensions: Option<ImageDimensions>,
-    description: Option<String>,
-    thumbs: Option<Vec<(String, Option<ImageDimensions>)>>,
-}
-
-impl BadgeDefinitionBuilder {
-    /// New [`BadgeDefinitionBuilder`]
-    pub fn new(badge_id: String) -> Self {
-        Self {
-            badge_id,
-            name: None,
-            image: None,
-            image_dimensions: None,
-            description: None,
-            thumbs: None,
-        }
-    }
-
-    /// Set name
-    pub fn name(mut self, name: String) -> Self {
-        self.name = Some(name);
-        self
-    }
-
-    /// Set image
-    pub fn image(mut self, image: String) -> Self {
-        self.image = Some(image);
-        self
-    }
-
-    /// Set `[ImageDimensions]`
-    pub fn image_dimensions(mut self, image_dimensions: ImageDimensions) -> Self {
-        self.image_dimensions = Some(image_dimensions);
-        self
-    }
-
-    /// Set description
-    pub fn description(mut self, description: String) -> Self {
-        self.description = Some(description);
-        self
-    }
-
-    /// Set thumbnails with their optional `[ImageDimensions]`
-    pub fn thumbs(mut self, thumbs: Vec<(String, Option<ImageDimensions>)>) -> Self {
-        self.thumbs = Some(thumbs);
-        self
-    }
-
-    /// Build [`Event`]
-    pub fn build(self, keys: &Keys) -> Result<BadgeDefinition, BuilderError> {
-        let mut tags: Vec<Tag> = Vec::new();
-        let badge_id = Tag::Identifier(self.badge_id);
-        tags.push(badge_id);
-
-        if let Some(name) = self.name {
-            let name_tag = Tag::Name(name);
-            tags.push(name_tag);
-        };
-
-        if let Some(image) = self.image {
-            let image_tag = if let Some(width_height) = self.image_dimensions {
-                let ImageDimensions(width, height) = width_height;
-                Tag::Image(image, Some((width, height)))
-            } else {
-                Tag::Image(image, None)
-            };
-            tags.push(image_tag);
-        }
-
-        if let Some(description) = self.description {
-            let description_tag = Tag::Description(description);
-            tags.push(description_tag);
-        }
-        if let Some(thumbs) = self.thumbs {
-            for thumb in thumbs {
-                let thumb_url = thumb.0;
-                let thumb_tag = if let Some(width_height) = thumb.1 {
-                    let ImageDimensions(width, height) = width_height;
-                    Tag::Thumb(thumb_url, Some((width, height)))
-                } else {
-                    Tag::Thumb(thumb_url, None)
-                };
-                tags.push(thumb_tag);
-            }
-        }
-
-        let event_builder = EventBuilder::new(Kind::BadgeDefinition, String::new(), &tags);
-        let event = event_builder.to_event(keys)?;
-        Ok(BadgeDefinition(event))
-    }
-}
-
-/// Badge definition event as specified in NIP-58
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct BadgeDefinition(Event);
-
-/// Badge award event as specified in NIP-58
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct BadgeAward(Event);
-
-impl BadgeAward {
-    ///
-    pub fn new(
-        badge_definition: &Event,
-        awarded_pub_keys: Vec<Tag>,
-        keys: &Keys,
-    ) -> Result<BadgeAward, Error> {
-        let badge_id = match badge_definition.kind {
-            Kind::BadgeDefinition => badge_definition.tags.iter().find_map(|t| match t {
-                Tag::Identifier(id) => Some(id),
-                _ => None,
-            }),
-            _ => return Err(Error::InvalidKind),
-        }
-        .ok_or(Error::IdentifierTagNotFound)?;
-
-        let awarded_pub_keys: Vec<Tag> = awarded_pub_keys
-            .into_iter()
-            .filter(|e| matches!(e, Tag::PubKey(..)))
-            .collect();
-
-        if awarded_pub_keys.is_empty() {
-            return Err(Error::InvalidKind);
-        }
-
-        let a_tag = Tag::A {
-            kind: Kind::BadgeDefinition,
-            public_key: keys.public_key(),
-            identifier: badge_id.to_owned(),
-            relay_url: None,
-        };
-        let mut tags = vec![a_tag];
-        tags.extend(awarded_pub_keys);
-
-        let event_builder = EventBuilder::new(Kind::BadgeAward, String::new(), &tags);
-        let event = event_builder.to_event(keys)?;
-
-        Ok(BadgeAward(event))
-    }
-}
-
-///  Profile Badges event as specified in NIP-58
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct ProfileBadgesEvent(Event);
-
-/// [`ProfileBadgesEvent`] errors
-#[derive(Debug)]
-pub enum ProfileBadgesEventError {
-    /// Invalid length
-    InvalidLength,
-    /// Invalid kind
-    InvalidKind,
-    /// Mismatched badge definition or award
-    MismatchedBadgeDefinitionOrAward,
-    /// Badge awards lack the awarded public key
-    BadgeAwardsLackAwardedPublicKey,
-    /// Badge awards lack the awarded public key
-    BadgeAwardMissingATag,
-    /// Badge Definition Event error
-    BadgeDefinition(Error),
-    /// Event builder Error
-    EventBuilder(crate::event::builder::Error),
-}
-
-impl std::error::Error for ProfileBadgesEventError {}
-
-impl fmt::Display for ProfileBadgesEventError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
             Self::InvalidLength => write!(f, "invalid length"),
             Self::InvalidKind => write!(f, "invalid kind"),
+            Self::IdentifierTagNotFound => write!(f, "identifier tag not found"),
             Self::MismatchedBadgeDefinitionOrAward => write!(f, "mismatched badge definition/award"),
             Self::BadgeAwardsLackAwardedPublicKey => write!(f, "badge award events lack the awarded public keybadge award events lack the awarded public key"),
             Self::BadgeAwardMissingATag => write!(f, "badge award event lacks `a` tag"),
-            Self::BadgeDefinition(e) => write!(f, "{e}"),
-            Self::EventBuilder(e) => write!(f, "{e}"),
         }
     }
 }
 
-impl From<Error> for ProfileBadgesEventError {
-    fn from(e: Error) -> Self {
-        Self::BadgeDefinition(e)
-    }
+/// Simple struct to hold `width` x `height`.
+pub struct ImageDimensions(pub u64, pub u64);
+
+/// Helper function to filter events for a specific [`Kind`]
+pub fn filter_for_kind(events: Vec<Event>, kind_needed: &Kind) -> Vec<Event> {
+    events
+        .into_iter()
+        .filter(|e| e.kind == *kind_needed)
+        .collect()
 }
 
-impl From<crate::event::builder::Error> for ProfileBadgesEventError {
-    fn from(e: crate::event::builder::Error) -> Self {
-        Self::EventBuilder(e)
-    }
+/// Helper function to extract an identifier tag from an array of tags
+pub fn extract_identifier(tags: Vec<Tag>) -> Option<Tag> {
+    tags.iter()
+        .find(|tag| matches!(tag, Tag::Identifier(_)))
+        .cloned()
 }
 
-impl ProfileBadgesEvent {
-    /// Helper function to filter events for a specific [`Kind`]
-    pub(crate) fn filter_for_kind(events: Vec<Event>, kind_needed: &Kind) -> Vec<Event> {
-        events
-            .into_iter()
-            .filter(|e| e.kind == *kind_needed)
-            .collect()
-    }
-
-    fn extract_identifier(tags: Vec<Tag>) -> Option<Tag> {
-        tags.iter()
-            .find(|tag| matches!(tag, Tag::Identifier(_)))
-            .cloned()
-    }
-
-    fn extract_awarded_public_key(
-        tags: &[Tag],
-        awarded_public_key: &XOnlyPublicKey,
-    ) -> Option<(XOnlyPublicKey, Option<UncheckedUrl>)> {
-        tags.iter().find_map(|t| match t {
-            Tag::PubKey(pub_key, unchecked_url) if pub_key == awarded_public_key => {
-                Some((*pub_key, unchecked_url.clone()))
-            }
-            _ => None,
-        })
-    }
-
-    /// Create a new [`ProfileBadgesEvent`] from badge definition and awards events
-    /// [`badge_definitions`] and [`badge_awards`] must be ordered, so on the same position they refer to the same badge
-    pub fn new(
-        badge_definitions: Vec<Event>,
-        badge_awards: Vec<Event>,
-        pubkey_awarded: &XOnlyPublicKey,
-        keys: &Keys,
-    ) -> Result<ProfileBadgesEvent, ProfileBadgesEventError> {
-        if badge_definitions.len() != badge_awards.len() {
-            return Err(ProfileBadgesEventError::InvalidLength);
+/// Helper function to extract the awarded public key from an array of PubKey tags
+pub fn extract_awarded_public_key(
+    tags: &[Tag],
+    awarded_public_key: &XOnlyPublicKey,
+) -> Option<(XOnlyPublicKey, Option<UncheckedUrl>)> {
+    tags.iter().find_map(|t| match t {
+        Tag::PubKey(pub_key, unchecked_url) if pub_key == awarded_public_key => {
+            Some((*pub_key, unchecked_url.clone()))
         }
-
-        let mut badge_awards = ProfileBadgesEvent::filter_for_kind(badge_awards, &Kind::BadgeAward);
-        if badge_awards.is_empty() {
-            return Err(ProfileBadgesEventError::InvalidKind);
-        }
-
-        for award in &badge_awards {
-            if !award.tags.iter().any(|t| match t {
-                Tag::PubKey(pub_key, _) => pub_key == pubkey_awarded,
-                _ => false,
-            }) {
-                return Err(ProfileBadgesEventError::BadgeAwardsLackAwardedPublicKey);
-            }
-        }
-
-        let mut badge_definitions =
-            ProfileBadgesEvent::filter_for_kind(badge_definitions, &Kind::BadgeDefinition);
-        if badge_definitions.is_empty() {
-            return Err(ProfileBadgesEventError::InvalidKind);
-        }
-
-        // Add identifier `d` tag
-        let id_tag = Tag::Identifier("profile_badges".to_owned());
-        let mut tags: Vec<Tag> = vec![id_tag];
-
-        let badge_definitions_identifiers = badge_definitions
-            .iter_mut()
-            .map(|event| {
-                let tags = core::mem::take(&mut event.tags);
-                let id = Self::extract_identifier(tags).ok_or(
-                    ProfileBadgesEventError::BadgeDefinition(Error::IdentifierTagNotFound),
-                )?;
-
-                Ok((event.clone(), id))
-            })
-            .collect::<Result<Vec<(Event, Tag)>, ProfileBadgesEventError>>();
-        let badge_definitions_identifiers = badge_definitions_identifiers
-            .map_err(|_| ProfileBadgesEventError::BadgeDefinition(Error::IdentifierTagNotFound))?;
-
-        let badge_awards_identifiers = badge_awards
-            .iter_mut()
-            .map(|event| {
-                let tags = core::mem::take(&mut event.tags);
-                let (_, relay_url) = Self::extract_awarded_public_key(&tags, pubkey_awarded)
-                    .ok_or(ProfileBadgesEventError::BadgeAwardsLackAwardedPublicKey)?;
-                let (id, a_tag) = tags
-                    .iter()
-                    .find_map(|t| match t {
-                        Tag::A { identifier, .. } => Some((identifier.clone(), t.clone())),
-                        _ => None,
-                    })
-                    .ok_or(ProfileBadgesEventError::BadgeAwardMissingATag)?;
-                Ok((event.clone(), id, a_tag, relay_url))
-            })
-            .collect::<Result<Vec<(Event, String, Tag, Option<UncheckedUrl>)>, ProfileBadgesEventError>>();
-        let badge_awards_identifiers = badge_awards_identifiers?;
-
-        // This collection has been filtered for the needed tags
-        let users_badges: Vec<(_, _)> =
-            core::iter::zip(badge_definitions_identifiers, badge_awards_identifiers).collect();
-
-        for (badge_definition, badge_award) in users_badges {
-            match (&badge_definition, &badge_award) {
-                ((_, Tag::Identifier(identifier)), (_, badge_id, ..)) if badge_id != identifier => {
-                    return Err(ProfileBadgesEventError::MismatchedBadgeDefinitionOrAward);
-                }
-                (
-                    (_, Tag::Identifier(identifier)),
-                    (badge_award_event, badge_id, a_tag, relay_url),
-                ) if badge_id == identifier => {
-                    let badge_definition_event_tag = a_tag.clone().to_owned();
-                    let badge_award_event_tag =
-                        Tag::Event(badge_award_event.id, relay_url.clone(), None);
-                    tags.extend_from_slice(&[badge_definition_event_tag, badge_award_event_tag]);
-                }
-                _ => {}
-            }
-        }
-
-        // Badge definitions and awards have been validated
-
-        let event_builder = EventBuilder::new(Kind::ProfileBadges, String::new(), &tags);
-        let event = event_builder.to_event(keys)?;
-
-        Ok(ProfileBadgesEvent(event))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::str::FromStr;
-
-    use super::*;
-
-    fn get_badge_with_id_only(id: String, keys: &Keys) -> BadgeDefinition {
-        let builder = BadgeDefinitionBuilder::new(id);
-        builder.build(keys).unwrap()
-    }
-
-    #[test]
-    fn test_badge_definition_builder() {
-        let example_event_json = r#"{"content":"","id":"378f145897eea948952674269945e88612420db35791784abf0616b4fed56ef7","sig":"fd0954de564cae9923c2d8ee9ab2bf35bc19757f8e328a978958a2fcc950eaba0754148a203adec29b7b64080d0cf5a32bebedd768ea6eb421a6b751bb4584a8","created_at":1671739153,"pubkey":"79dff8f82963424e0bb02708a22e44b4980893e3a4be0fa3cb60a43b946764e3","kind":30009,"tags":[["d","bravery"],["name","Medal of Bravery"],["image","https://nostr.academy/awards/bravery.png","1024x1024"],["description","Awarded to users demonstrating bravery"],["thumb","https://nostr.academy/awards/bravery_256x256.png","256x256"]]}"#;
-
-        let example_event: Event = serde_json::from_str(example_event_json).unwrap();
-
-        let mut builder = BadgeDefinitionBuilder::new("bravery".to_owned());
-        let image_dimensions = ImageDimensions(1024, 1024);
-        let thumb_size = ImageDimensions(256, 256);
-        let thumbs = vec![(
-            "https://nostr.academy/awards/bravery_256x256.png".to_owned(),
-            Some(thumb_size),
-        )];
-        builder = builder
-            .name("Medal of Bravery".to_owned())
-            .description("Awarded to users demonstrating bravery".to_owned())
-            .image("https://nostr.academy/awards/bravery.png".to_owned())
-            .image_dimensions(image_dimensions)
-            .thumbs(thumbs);
-
-        let keys = Keys::generate();
-        let badge_definition_event = builder.build(&keys).unwrap().0;
-
-        assert_eq!(badge_definition_event.kind, Kind::BadgeDefinition);
-        assert_eq!(badge_definition_event.tags, example_event.tags);
-    }
-    #[test]
-    fn test_badge_award() {
-        let keys = Keys::generate();
-        let pub_key = keys.public_key();
-
-        let example_event_json = format!(
-            r#"{{
-            "content": "",
-            "id": "378f145897eea948952674269945e88612420db35791784abf0616b4fed56ef7",
-            "kind": 8,
-            "pubkey": "{}",
-            "sig": "fd0954de564cae9923c2d8ee9ab2bf35bc19757f8e328a978958a2fcc950eaba0754148a203adec29b7b64080d0cf5a32bebedd768ea6eb421a6b751bb4584a8",
-            "created_at": 1671739153,
-            "tags": [
-                ["a", "30009:{}:bravery"],
-                ["p", "{}", "wss://relay"],
-                ["p", "{}", "wss://relay"]
-            ]
-            }}"#,
-            pub_key.to_string(),
-            pub_key.to_string(),
-            pub_key.to_string(),
-            pub_key.to_string()
-        );
-
-        let example_event: Event = serde_json::from_str(&example_event_json).unwrap();
-
-        let relay_url = UncheckedUrl::from_str("wss://relay").unwrap();
-        let badge_definition = get_badge_with_id_only("bravery".to_owned(), &keys).0;
-
-        let awarded_pub_keys = vec![
-            Tag::PubKey(pub_key.clone(), Some(relay_url.clone())),
-            Tag::PubKey(pub_key.clone(), Some(relay_url.clone())),
-        ];
-        let badge_award = BadgeAward::new(&badge_definition, awarded_pub_keys, &keys)
-            .unwrap()
-            .0;
-
-        assert_eq!(badge_award.kind, Kind::BadgeAward);
-        assert_eq!(badge_award.tags, example_event.tags);
-    }
-
-    #[test]
-    fn test_profile_badges() {
-        let keys = Keys::generate();
-        let pub_key = keys.public_key();
-
-        let relay_url = UncheckedUrl::from_str("wss://relay").unwrap();
-
-        let awarded_pub_keys = vec![
-            Tag::PubKey(pub_key.clone(), Some(relay_url.clone())),
-            Tag::PubKey(pub_key.clone(), Some(relay_url.clone())),
-        ];
-        let bravery_badge_event = get_badge_with_id_only("bravery".to_owned(), &keys).0;
-        let bravery_badge_award =
-            BadgeAward::new(&bravery_badge_event, awarded_pub_keys.clone(), &keys)
-                .unwrap()
-                .0;
-
-        let honor_badge_event = get_badge_with_id_only("honor".to_owned(), &keys).0;
-        let honor_badge_award = BadgeAward::new(&honor_badge_event, awarded_pub_keys, &keys)
-            .unwrap()
-            .0;
-        let badge_definitions = vec![bravery_badge_event, honor_badge_event];
-
-        let badge_awards = vec![bravery_badge_award.clone(), honor_badge_award.clone()];
-
-        let (bravery_badge_award_event_id, honor_badge_award_event_id) =
-            (bravery_badge_award.id, honor_badge_award.id);
-        let example_event_json = format!(
-            r#"{{
-            "content":"",
-            "id": "378f145897eea948952674269945e88612420db35791784abf0616b4fed56ef7",
-            "kind": 30008,
-            "pubkey": "{}",
-            "sig":"fd0954de564cae9923c2d8ee9ab2bf35bc19757f8e328a978958a2fcc950eaba0754148a203adec29b7b64080d0cf5a32bebedd768ea6eb421a6b751bb4584a8",
-            "created_at":1671739153,
-            "tags":[
-                ["d", "profile_badges"],
-                ["a", "30009:{}:bravery"],
-                ["e", "{}", "wss://relay"],
-                ["a", "30009:{}:honor"],
-                ["e", "{}", "wss://relay"]]
-            }}"#,
-            pub_key.to_string(),
-            pub_key.to_string(),
-            bravery_badge_award_event_id.to_string(),
-            pub_key.to_string(),
-            honor_badge_award_event_id.to_string(),
-        );
-        let example_event: Event = serde_json::from_str(&example_event_json).unwrap();
-
-        assert_eq!(badge_awards.len(), 2);
-        assert_eq!(badge_definitions.len(), 2);
-
-        let profile_badges =
-            ProfileBadgesEvent::new(badge_definitions, badge_awards, &pub_key, &keys)
-                .unwrap()
-                .0;
-
-        assert_eq!(profile_badges.kind, Kind::ProfileBadges);
-        assert_eq!(profile_badges.tags, example_event.tags);
-    }
+        _ => None,
+    })
 }


### PR DESCRIPTION
### Description

This PR adds convenience functions to the EventBuilder for creating a new badge and awarding a badge to a set of pubkeys. 

### Notes to the reviewers

I'd love to get a second look at the functions to verify that it makes sense as is.

I didn't add a function for [setting profile badges](https://github.com/nostr-protocol/nips/blob/master/58.md#profile-badges-event) (the last operation in NIP-58) because I simply couldn't figure out a good way to structure the function inputs so that we ensure a consecutive order in the `a` and `e` tags.

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->
```md
# Added
- EventBuilder for defining a badge
- EventBuilder for awarding a badge
```

### Checklists

#### All Submissions:

* [ ] I've signed all my commits
* [x] I followed the [contribution guidelines](../CONTRIBUTING.md)
* [x] I ran `make precommit` before committing