### PR TITLE
Split `get_events_of` into variants

### DIFF
--- a/bindings/nostr-sdk-js/src/client/mod.rs
+++ b/bindings/nostr-sdk-js/src/client/mod.rs
@@ -112,15 +112,18 @@ impl JsClient {
         self.inner.unsubscribe().await;
     }
 
-    /// Get events of filters
-    #[wasm_bindgen(js_name = getEventsOf)]
-    pub async fn get_events_of(&self, filters: Array, timeout: Option<u64>) -> Result<Array> {
+    #[wasm_bindgen(js_name = getStoredEventsOf)]
+    pub async fn get_stored_events_of(
+        &self,
+        filters: Array,
+        timeout: Option<u64>,
+    ) -> Result<Array> {
         let filters = filters
             .iter()
             .map(|v| Ok(util::downcast::<JsFilter>(&v, "Filter")?.inner()))
             .collect::<Result<Vec<Filter>, JsError>>()?;
         let timeout = timeout.map(Duration::from_secs);
-        match self.inner.get_events_of(filters, timeout).await {
+        match self.inner.get_stored_events_of(filters, timeout).await {
             Ok(events) => {
                 let events: Vec<JsEvent> = events.into_iter().map(|e| e.into()).collect();
                 let events = events.into_iter().map(JsValue::from).collect();
@@ -130,17 +133,17 @@ impl JsClient {
         }
     }
 
-    /// Request events of filters.
+    /// Request stored events of filters.
     /// All events will be received on notification listener
     /// until the EOSE "end of stored events" message is received from the relay.
-    #[wasm_bindgen(js_name = reqEventsOf)]
-    pub async fn req_events_of(&self, filters: Array, timeout: Option<u64>) -> Result<()> {
+    #[wasm_bindgen(js_name = reqStoredEventsOf)]
+    pub async fn req_stored_events_of(&self, filters: Array, timeout: Option<u64>) -> Result<()> {
         let filters = filters
             .iter()
             .map(|v| Ok(util::downcast::<JsFilter>(&v, "Filter")?.inner()))
             .collect::<Result<Vec<Filter>, JsError>>()?;
         let timeout = timeout.map(Duration::from_secs);
-        self.inner.req_events_of(filters, timeout).await;
+        self.inner.req_stored_events_of(filters, timeout).await;
         Ok(())
     }
 

--- a/crates/nostr-sdk/src/client/blocking.rs
+++ b/crates/nostr-sdk/src/client/blocking.rs
@@ -168,17 +168,17 @@ impl Client {
         })
     }
 
-    pub fn get_events_of(
+    pub fn get_stored_events_of(
         &self,
         filters: Vec<Filter>,
         timeout: Option<Duration>,
     ) -> Result<Vec<Event>, Error> {
-        RUNTIME.block_on(async { self.client.get_events_of(filters, timeout).await })
+        RUNTIME.block_on(async { self.client.get_stored_events_of(filters, timeout).await })
     }
 
-    pub fn req_events_of(&self, filters: Vec<Filter>, timeout: Option<Duration>) {
+    pub fn req_stored_events_of(&self, filters: Vec<Filter>, timeout: Option<Duration>) {
         RUNTIME.block_on(async {
-            self.client.req_events_of(filters, timeout).await;
+            self.client.req_stored_events_of(filters, timeout).await;
         })
     }
 

--- a/crates/nostr-sdk/src/client/mod.rs
+++ b/crates/nostr-sdk/src/client/mod.rs
@@ -495,6 +495,38 @@ impl Client {
             .await;
     }
 
+    /// Query the relays for all events matching the given filters, stored and new, received within
+    /// the `wait_duration`.
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// use std::time::Duration;
+    ///
+    /// use nostr_sdk::prelude::*;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// #   let my_keys = Keys::generate();
+    /// #   let client = Client::new(&my_keys);
+    /// let subscription = Filter::new()
+    ///     .pubkeys(vec![my_keys.public_key()])
+    ///     .since(Timestamp::now());
+    ///
+    /// let wait_duration = Duration::from_secs(10);
+    /// let _events = client
+    ///     .get_all_events_of(vec![subscription], wait_duration)
+    ///     .await
+    ///     .unwrap();
+    /// # }
+    /// ```
+    pub async fn get_all_events_of(
+        &self,
+        filters: Vec<Filter>,
+        wait_duration: Duration,
+    ) -> Result<Vec<Event>, Error> {
+        Ok(self.pool.get_all_events_of(filters, wait_duration).await?)
+    }
+
     /// Query the relays for stored events matching the given filters.
     ///
     /// Stored events are those already known to the relays at the moment this query was made.

--- a/crates/nostr-sdk/src/relay/mod.rs
+++ b/crates/nostr-sdk/src/relay/mod.rs
@@ -791,8 +791,8 @@ impl Relay {
         Ok(())
     }
 
-    /// Get events of filters with custom callback
-    pub async fn get_events_of_with_callback<F>(
+    /// Get stored events of filters with custom callback
+    pub async fn get_stored_events_of_with_callback<F>(
         &self,
         filters: Vec<Filter>,
         timeout: Option<Duration>,
@@ -828,7 +828,7 @@ impl Relay {
                                 break;
                             }
                         }
-                        _ => log::debug!("Receive unhandled message {msg:?} on get_events_of"),
+                        _ => log::debug!("Receive unhandled message {msg:?} on get_stored_events_of_with_callback"),
                     };
                 }
             }
@@ -842,14 +842,14 @@ impl Relay {
         Ok(())
     }
 
-    /// Get events of filters
-    pub async fn get_events_of(
+    /// Get stored events of filters
+    pub async fn get_stored_events_of(
         &self,
         filters: Vec<Filter>,
         timeout: Option<Duration>,
     ) -> Result<Vec<Event>, Error> {
         let events: Mutex<Vec<Event>> = Mutex::new(Vec::new());
-        self.get_events_of_with_callback(filters, timeout, |event| async {
+        self.get_stored_events_of_with_callback(filters, timeout, |event| async {
             let mut events = events.lock().await;
             events.push(event);
         })
@@ -859,7 +859,7 @@ impl Relay {
 
     /// Request events of filter. All events will be sent to notification listener,
     /// until the EOSE "end of stored events" message is received from the relay.
-    pub fn req_events_of(&self, filters: Vec<Filter>, timeout: Option<Duration>) {
+    pub fn req_stored_events_of(&self, filters: Vec<Filter>, timeout: Option<Duration>) {
         if !self.opts.read() {
             log::error!("{}", Error::ReadDisabled);
         }

--- a/crates/nostr-sdk/src/relay/pool.rs
+++ b/crates/nostr-sdk/src/relay/pool.rs
@@ -415,8 +415,8 @@ impl RelayPool {
         }
     }
 
-    /// Get events of filters
-    pub async fn get_events_of(
+    /// Get stored events of filters
+    pub async fn get_stored_events_of(
         &self,
         filters: Vec<Filter>,
         timeout: Option<Duration>,
@@ -429,7 +429,7 @@ impl RelayPool {
             let events = events.clone();
             let handle = thread::spawn(async move {
                 if let Err(e) = relay
-                    .get_events_of_with_callback(filters, timeout, |event| async {
+                    .get_stored_events_of_with_callback(filters, timeout, |event| async {
                         events.lock().await.push(event);
                     })
                     .await
@@ -447,12 +447,12 @@ impl RelayPool {
         Ok(events.lock_owned().await.clone())
     }
 
-    /// Request events of filter. All events will be sent to notification listener
+    /// Request stored events of filter. All events will be sent to notification listener
     /// until the EOSE "end of stored events" message is received from the relay.
-    pub async fn req_events_of(&self, filters: Vec<Filter>, timeout: Option<Duration>) {
+    pub async fn req_stored_events_of(&self, filters: Vec<Filter>, timeout: Option<Duration>) {
         let relays = self.relays().await;
         for relay in relays.values() {
-            relay.req_events_of(filters.clone(), timeout);
+            relay.req_stored_events_of(filters.clone(), timeout);
         }
     }
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

Implementing #119:
- [x] Rename `get_events_of` to `get_stored_events_of`
- [x] Rename `req_events_of` to `req_stored_events_of`
- [x] Add `get_all_events_of`

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

- Split `get_events_of` in two variants, one handling stored events and one handling  stored and new events

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](../CONTRIBUTING.md)
* [x] I ran `make precommit` before committing