### PR TITLE
ffi: fix links in `bindings` README.md

### DIFF
--- a/bindings/README.md
+++ b/bindings/README.md
@@ -1,11 +1,11 @@
 # Nostr bindings
 
 - UniFFI (Kotlin, Swift, Python, Ruby):
-    * [nostr-ffi](./nostr-ffi/): UniFFI bindings of the [nostr][] crate
-    * [nostr-sdk-ffi](./nostr-sdk-ffi/): UniFFI bindings of the [nostr-sdk][] crate
+    * [nostr-ffi](./nostr-ffi/): UniFFI bindings of the [nostr] crate
+    * [nostr-sdk-ffi](./nostr-sdk-ffi/): UniFFI bindings of the [nostr-sdk] crate
 - JavaScript:
     * [nostr-js](./nostr-js/): JavaScript bindings of the [nostr] crate (WIP)
-    * [nostr-sdk-js](./nostr-sdk-js/): JavaScript bindings of the [nostr-sdk][] crate (WIP)
+    * [nostr-sdk-js](./nostr-sdk-js/): JavaScript bindings of the [nostr-sdk] crate (WIP)
 
-[nostr]: ./crates/nostr/
-[nostr-sdk]: ./crates/nostr-sdk/
+[nostr]: ../crates/nostr/
+[nostr-sdk]: ../crates/nostr-sdk/


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->
Links now direct to `crates/nostr` instead of `bindings/crates/nostr` which does not exist.


### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](../CONTRIBUTING.md)
* [ ] I ran `make precommit` before committing