### PR TITLE
nostr: attempt to erase `SecretKey` when dropped

### DIFF
--- a/crates/nostr/src/key/mod.rs
+++ b/crates/nostr/src/key/mod.rs
@@ -263,3 +263,11 @@ impl FromPkStr for Keys {
         }
     }
 }
+
+impl Drop for Keys {
+    fn drop(&mut self) {
+        if let Some(mut sk) = self.secret_key {
+            sk.non_secure_erase()
+        }
+    }
+}


### PR DESCRIPTION
### Description

This isn't a silver bullet for clearing SecretKey from memory it will help.

#### All Submissions:

* [ x ] I've signed all my commits
* [ x ] I followed the [contribution guidelines](../CONTRIBUTING.md)
* [ x ] I ran `make precommit` before committing