### PR TITLE
sdk: add client `set_keys` method

### DIFF
--- a/crates/nostr-sdk/src/client/mod.rs
+++ b/crates/nostr-sdk/src/client/mod.rs
@@ -206,6 +206,25 @@ impl Client {
         self.keys.clone()
     }
 
+    /// Replace current [`Keys`]
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// use nostr_sdk::prelude::*;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// #   let keys1 = Keys::generate();
+    /// #   let keys2 = Keys::generate();
+    /// #   let mut client = Client::new(&keys1);
+    /// #   client.set_keys(&keys2);
+    /// #   assert_eq!(keys2, client.keys());
+    /// # }
+    /// ```
+    pub fn set_keys(&mut self, keys: &Keys) {
+        self.keys = keys.clone()
+    }
+
     /// Get [`RelayPool`]
     pub fn pool(&self) -> RelayPool {
         self.pool.clone()


### PR DESCRIPTION
### Description

Some applications want to connect relays and create subscriptions before a secret key has been decrypted and then later swap in the user's secret key.

This method makes doing so convenient.

### Changelog notice

change keys used by an existing client,
z
#### All Submissions:

[ x ] I've signed all my commits
[ x ] I followed the [contribution guidelines](../CONTRIBUTING.md)
[ x ] I ran `make precommit` before committing