### PR TITLE
Custom time of reconnect options added

### DIFF
--- a/crates/nostr-sdk/examples/client-with-opts.rs
+++ b/crates/nostr-sdk/examples/client-with-opts.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<()> {
     client.add_relay("wss://relay.damus.io", None).await?;
     client.add_relay("wss://nostr.openchain.fr", None).await?;
     client
-        .add_relay_with_opts("wss://nostr.mom", None, RelayOptions::new(true, false))
+        .add_relay_with_opts("wss://nostr.mom", None, RelayOptions::new(true, false, 10))
         .await?;
     client
         .add_relay(

--- a/crates/nostr-sdk/src/client/mod.rs
+++ b/crates/nostr-sdk/src/client/mod.rs
@@ -332,7 +332,8 @@ impl Client {
     /// #   let client = Client::new(&my_keys);
     /// let read = true;
     /// let write = false;
-    /// let opts = RelayOptions::new(read, write);
+    /// let retry_sec = 10;
+    /// let opts = RelayOptions::new(read, write, retry_sec);
     /// client
     ///     .add_relay_with_opts("wss://relay.nostr.info", None, opts)
     ///     .await

--- a/crates/nostr-sdk/src/relay/mod.rs
+++ b/crates/nostr-sdk/src/relay/mod.rs
@@ -679,7 +679,7 @@ impl Relay {
                         _ => (),
                     };
 
-                    thread::sleep(Duration::from_secs(10)).await;
+                    thread::sleep(Duration::from_secs(relay.opts().retry_sec())).await;
                 }
 
                 relay.set_auto_connect_loop_running(false);


### PR DESCRIPTION
### Description

Small improvement to have in `RelayOptions` also a `retry_sec `field to use for custom retry time for connection to relay.
Duration is in seconds and default is left as before to 10 secs

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists
Not tested at the moment. Will try ASAP, need to check if different retry time is effective.

#### All Submissions:

* [ x] I've signed all my commits
* [ x] I followed the [contribution guidelines](../CONTRIBUTING.md)
* [ ] I ran `make precommit` before committing