### PR TITLE
nostr: impl `fmt::LowerHex` for `EventId`

### DIFF
--- a/crates/nostr/src/event/id.rs
+++ b/crates/nostr/src/event/id.rs
@@ -128,9 +128,17 @@ impl AsRef<[u8]> for EventId {
     }
 }
 
+impl fmt::LowerHex for EventId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.to_hex())?;
+
+        Ok(())
+    }
+}
+
 impl fmt::Display for EventId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.to_hex())
+        fmt::LowerHex::fmt(self, f)
     }
 }
 


### PR DESCRIPTION
### Description

For consistency with `secp256k1::XOnlyPublicKey`, which also [implements](https://docs.rs/secp256k1/latest/src/secp256k1/key.rs.html#1119-1131) it. This is to make it a little easier to work with the `GenericTagValue` enum.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](../CONTRIBUTING.md)
* [x] I ran `make precommit` before committing