### PR TITLE
nostr: filter out `GenericTagValue` variants that do not adhere to the spec

### DIFF
--- a/crates/nostr/src/message/subscription.rs
+++ b/crates/nostr/src/message/subscription.rs
@@ -737,7 +737,14 @@ where
                 if let (Some('#'), Some(ch), None) = (chars.next(), chars.next(), chars.next()) {
                     let tag: Alphabet = Alphabet::from_str(ch.to_string().as_str())
                         .map_err(serde::de::Error::custom)?;
-                    let values = map.next_value()?;
+                    let mut values: AllocSet<GenericTagValue> = map.next_value()?;
+
+                    match tag {
+                        Alphabet::P => values.retain(|v| matches!(v, GenericTagValue::Pubkey(_))),
+                        Alphabet::E => values.retain(|v| matches!(v, GenericTagValue::EventId(_))),
+                        _ => {}
+                    }
+
                     generic_tags.insert(tag, values);
                 } else {
                     map.next_value::<serde::de::IgnoredAny>()?;


### PR DESCRIPTION
### Description

An attempt to make it fall more in line with the restrictions laid out in NIP-01. I don't know whether this should be restricted further, because at that point I think it would be best to put standardized tags into their own fields within the `Filter` struct.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](../CONTRIBUTING.md)
* [x] I ran `make precommit` before committing