### PR TITLE
Add `Nip19` for decoding any nip19 object

### DIFF
--- a/crates/nostr/src/nips/nip19.rs
+++ b/crates/nostr/src/nips/nip19.rs
@@ -227,22 +227,8 @@ impl Nip19Event {
             relays: relays.into_iter().map(|u| u.into()).collect(),
         }
     }
-}
 
-impl FromBech32 for Nip19Event {
-    type Err = Error;
-    fn from_bech32<S>(s: S) -> Result<Self, Self::Err>
-    where
-        S: Into<String>,
-    {
-        let (hrp, data, checksum) = bech32::decode(&s.into())?;
-
-        if hrp != PREFIX_BECH32_EVENT || checksum != Variant::Bech32 {
-            return Err(Error::WrongPrefixOrVariant);
-        }
-
-        let mut data: Vec<u8> = Vec::from_base32(&data)?;
-
+    fn from_bech32_data(mut data: Vec<u8>) -> Result<Nip19Event, Error> {
         let mut event_id: Option<EventId> = None;
         let mut relays: Vec<String> = Vec::new();
 
@@ -272,6 +258,23 @@ impl FromBech32 for Nip19Event {
             event_id: event_id.ok_or_else(|| Error::FieldMissing("event id".to_string()))?,
             relays,
         })
+    }
+}
+
+impl FromBech32 for Nip19Event {
+    type Err = Error;
+    fn from_bech32<S>(s: S) -> Result<Self, Self::Err>
+    where
+        S: Into<String>,
+    {
+        let (hrp, data, checksum) = bech32::decode(&s.into())?;
+
+        if hrp != PREFIX_BECH32_EVENT || checksum != Variant::Bech32 {
+            return Err(Error::WrongPrefixOrVariant);
+        }
+
+        let data: Vec<u8> = Vec::from_base32(&data)?;
+        Nip19Event::from_bech32_data(data)
     }
 }
 

--- a/crates/nostr/src/nips/nip19.rs
+++ b/crates/nostr/src/nips/nip19.rs
@@ -48,6 +48,8 @@ pub enum Error {
     EventId(id::Error),
     /// Wrong prefix or variant
     WrongPrefixOrVariant,
+    /// Not implemented
+    NotImplemented,
     /// Field missing
     FieldMissing(String),
     /// TLV error
@@ -71,6 +73,7 @@ impl fmt::Display for Error {
             Self::FieldMissing(name) => write!(f, "Field missing: {name}"),
             Self::TLV => write!(f, "TLV (type-length-value) error"),
             Self::TryFromSlice => write!(f, "Impossible to perform conversion from slice"),
+            Self::NotImplemented => write!(f, "Not implemented"),
         }
     }
 }


### PR DESCRIPTION
### Description

Add `Nip19` for decoding any bech32 nip19 nostr object in a single go.
This is important when you don't necessarily know the object you are
decoding, such as when someone enters an object into a search field.

#### All Submissions:

* [ ] I've signed all my commits

I don't use pgp anymore. Please judge my submission based on my code and not my identity.

* [x] I followed the [contribution guidelines](../CONTRIBUTING.md)
* [x] I ran `make precommit` before committing
