### PR TITLE
Fix parsing metadata with non-string types

### DIFF
--- a/bindings/nostr-ffi/src/types/metadata.rs
+++ b/bindings/nostr-ffi/src/types/metadata.rs
@@ -149,6 +149,6 @@ impl Metadata {
     }
 
     pub fn get_custom_field(&self, key: String) -> Option<String> {
-        self.inner.custom.get(&key).cloned()
+        self.inner.custom.get(&key).cloned().map(|s| s.to_string())
     }
 }


### PR DESCRIPTION
Found this when trying to parse @dergigi's metadata, it has some fields that are not strings so it would fail. This makes it so it skips over non-string items that we don't understand

example:

```
{
  "id": "6cae3971652c112a5cf75042cc98c4bb186b8a9b03577c244364bc884bd5f58e",
  "pubkey": "6e468422dfb74a5738702a8823b9b28168abab8655faacb6853cd0ee15deee93",
  "created_at": 1701643922,
  "kind": 0,
  "tags": [],
  "content": "{\"reactions\":false,\"about\":\"building opensats.org • writing 21waysbook.com • shipping sovereignengineering.io • painting twentyone.world • maintaining bitcoin-resources.com & nostr-resources.com • starting toomanyprojects.xyz 🥔\",\"picture\":\"https://dergigi.com/assets/images/avatar-laser.jpg\",\"damus_donation_v2\":0,\"banner\":\"https://cdn.nostr.build/i/0aeb7560c271bbb1cef00760989acd9dd3f37bdc42b37852eecb0d0b70a3e862.jpg\",\"nip05\":\"_@dergigi.com\",\"lud16\":\"dergigi@getalby.com\",\"username\":\"dergigi\",\"display_name\":\"Gigi ⚡🧡\",\"website\":\"https://dergigi.com\",\"lud06\":\"\",\"displayName\":\"Gigi ⚡🧡\",\"name\":\"Gigi ⚡🧡\"}",
  "sig": "bbdc06539a4bc0201bad8006c54d6b0edb55177d223e6d8d92997fa8e7c779fb0159ecdb318e1258460d2f687218994af55e93eb003dd64b817c746ba7a9e5a8"
}
```

Closes #236