### PR TITLE
add standard build methods for easier discovery

### DIFF
--- a/crates/nostr/src/event/builder.rs
+++ b/crates/nostr/src/event/builder.rs
@@ -303,10 +303,22 @@ impl EventBuilder {
         self.to_event_with_ctx(&SECP256K1, &mut rand::thread_rng(), &Instant::now(), keys)
     }
 
+    /// Build, sign, and return the [`Event`]
+    #[cfg(feature = "std")]
+    pub fn sign(self, keys: &Keys) -> Result<Event, Error> {
+        self.to_event(keys)
+    }
+
     /// Build [`UnsignedEvent`]
     #[cfg(feature = "std")]
     pub fn to_unsigned_event(self, pubkey: XOnlyPublicKey) -> UnsignedEvent {
         self.to_unsigned_event_with_supplier(&Instant::now(), pubkey)
+    }
+
+    /// Build [`UnsignedEvent`]
+    #[cfg(feature = "std")]
+    pub fn build(self, pubkey: XOnlyPublicKey) -> UnsignedEvent {
+        self.to_unsigned_event(pubkey)
     }
 
     /// Build POW [`Event`]
@@ -321,10 +333,22 @@ impl EventBuilder {
         )
     }
 
+    /// Build, sign and the [`Event`] with POW
+    #[cfg(feature = "std")]
+    pub fn sign_pow(self, keys: &Keys, difficulty: u8) -> Result<Event, Error> {
+        self.to_pow_event(keys, difficulty)
+    }
+
     /// Build unsigned POW [`Event`]
     #[cfg(feature = "std")]
     pub fn to_unsigned_pow_event(self, pubkey: XOnlyPublicKey, difficulty: u8) -> UnsignedEvent {
         self.to_unsigned_pow_event_with_supplier(&Instant::now(), pubkey, difficulty)
+    }
+
+    /// Build unsigned POW [`Event`]
+    #[cfg(feature = "std")]
+    pub fn build_pow(self, pubkey: XOnlyPublicKey, difficulty: u8) -> UnsignedEvent {
+        self.to_unsigned_pow_event(pubkey, difficulty)
     }
 }
 

--- a/crates/nostr/src/event/mod.rs
+++ b/crates/nostr/src/event/mod.rs
@@ -159,6 +159,15 @@ impl Event {
         }
     }
 
+    /// Create a new [EventBuilder] instance
+    pub fn builder<S, I>(kind: Kind, content: S, tags: I) -> EventBuilder
+    where
+        S: Into<String>,
+        I: IntoIterator<Item = Tag>,
+    {
+        EventBuilder::new(kind, content, tags)
+    }
+
     /// Deserialize [`Event`] from [`Value`]
     ///
     /// **This method NOT verify the signature!**


### PR DESCRIPTION
### Description

Add standard `builder` and `build` methods for easier crate discovery for new developers.

### Notes to the reviewers

Completely unasked for. Just something I happen to run into while writing some documentation and thought it'd be a nice addition. Purely for quality of life. No underlying functionality changes. Actually these just delegate the calls to existing methods. If this is wanted, we could discuss deprecating existing methods for new ones if you want to prevent confusion with multiple methods doing the same thing.

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [x] I ran `make precommit` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [x] I've added docs for the new feature