### PR TITLE
Make nostr-sdk signing events public

### DIFF
--- a/crates/nostr-sdk/src/client/mod.rs
+++ b/crates/nostr-sdk/src/client/mod.rs
@@ -717,7 +717,8 @@ impl Client {
         Ok(self.pool.send_event_to(url, event, opts).await?)
     }
 
-    async fn internal_sign_event_builder(&self, builder: EventBuilder) -> Result<Event, Error> {
+    /// Signs the [`EventBuilder`] into an [`Event`] using the [`ClientSigner`]
+    pub async fn sign_event_builder(&self, builder: EventBuilder) -> Result<Event, Error> {
         match self.signer().await? {
             ClientSigner::Keys(keys) => {
                 let difficulty: u8 = self.opts.get_difficulty();
@@ -770,7 +771,7 @@ impl Client {
     ///
     /// Rise an error if the [`ClientSigner`] is not set.
     pub async fn send_event_builder(&self, builder: EventBuilder) -> Result<EventId, Error> {
-        let event: Event = self.internal_sign_event_builder(builder).await?;
+        let event: Event = self.sign_event_builder(builder).await?;
         self.send_event(event).await
     }
 
@@ -786,7 +787,7 @@ impl Client {
         U: TryIntoUrl,
         pool::Error: From<<U as TryIntoUrl>::Err>,
     {
-        let event: Event = self.internal_sign_event_builder(builder).await?;
+        let event: Event = self.sign_event_builder(builder).await?;
         self.send_event_to(url, event).await
     }
 

--- a/crates/nostr-sdk/src/client/zapper.rs
+++ b/crates/nostr-sdk/src/client/zapper.rs
@@ -316,7 +316,7 @@ impl Client {
                 match details.r#type {
                     ZapType::Public => {
                         let builder = EventBuilder::public_zap_request(data);
-                        Some(self.internal_sign_event_builder(builder).await?.as_json())
+                        Some(self.sign_event_builder(builder).await?.as_json())
                     }
                     ZapType::Private => None,
                     ZapType::Anonymous => Some(nip57::anonymous_zap_request(data)?.as_json()),


### PR DESCRIPTION
Using the `ClientSigner` in mutiny now want to be able to sign arbitrary events, need this to be public