### PR TITLE
Handle no nwc request params better

### DIFF
--- a/crates/nostr/src/nips/nip47.rs
+++ b/crates/nostr/src/nips/nip47.rs
@@ -395,6 +395,7 @@ struct RequestTemplate {
     /// Request method
     method: Method,
     /// Params
+    #[serde(default)] // handle no params as `Value::Null`
     params: Value,
 }
 


### PR DESCRIPTION
Seems like alby is trying these requests without the params empty object which is understandable, this will better handle