### PR TITLE
Make encrypt_private_zap_message pub

### DIFF
--- a/crates/nostr/src/nips/nip57.rs
+++ b/crates/nostr/src/nips/nip57.rs
@@ -311,7 +311,8 @@ pub fn create_encryption_key(
     Ok(SecretKey::from_slice(hash.as_byte_array())?)
 }
 
-fn encrypt_private_zap_message<R, T>(
+/// Encrypt a private zap message using the given keys
+pub fn encrypt_private_zap_message<R, T>(
     rng: &mut R,
     secret_key: &SecretKey,
     public_key: &PublicKey,


### PR DESCRIPTION
Working on adding public/private zaps for mutiny. Since we support the NIP-07 signer we need to be able to create private zap events manually, to do so we need this function public.

Also would like to make it so `private_zap_request` doesn't take in a `&Keys`, seems like it is only needed for `create_encryption_key` but don't really see why it is done that way, could just use `Keys::generate`, I guess the main reason is so we can decrypt it ourself