### PR TITLE
nostr: construct `GenericTagValue` based on `SingleLetterTag` in `deserialize_generic_tags`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * nostr: change `Tag::parse` arg from `Vec<S>` to `&[S]` ([Yuki Kishimoto])
 * nostr: allow to parse public key from NIP21 uri with `PublicKey::parse` ([Yuki Kishimoto])
 * nostr: allow to parse event ID from NIP21 uri with `EventId::parse` ([Yuki Kishimoto])
+* nostr: construct `GenericTagValue` based on `SingleLetterTag` in `deserialize_generic_tags` ([Yuki Kishimoto])
 * nostr: bump `bitcoin` to `0.31` ([Yuki Kishimoto])
 * sdk: bump `lnurl-pay` to `0.4` ([Yuki Kishimoto])
 * nwc: avoid to open and close subscription for every request ([Yuki Kishimoto])
@@ -28,7 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * nostr: `Tag::content` return always `None` when `Tag::Generic` ([Yuki Kishimoto])
-* nostr: fix `GenericTagValue` deserialization ([Yuki Kishimoto])
 
 ### Removed
 

--- a/crates/nostr/src/event/tag.rs
+++ b/crates/nostr/src/event/tag.rs
@@ -1157,7 +1157,7 @@ impl Tag {
             Self::Geohash(val, ..) => Some(val.into_generic_tag_value()),
             Self::Identifier(val, ..) => Some(val.into_generic_tag_value()),
             Self::ExternalIdentity(..) => None,
-            Self::A { coordinate, .. } => Some(coordinate.clone().into_generic_tag_value()),
+            Self::A { coordinate, .. } => Some(coordinate.to_string().into_generic_tag_value()),
             Self::Kind(kind) => Some(kind.to_string().into_generic_tag_value()),
             Self::Relay(url) => Some(url.to_string().into_generic_tag_value()),
             Self::POW { nonce, .. } => Some(nonce.to_string().into_generic_tag_value()),
@@ -1595,13 +1595,9 @@ mod tests {
         .unwrap();
         assert_eq!(
             t.content(),
-            Some(GenericTagValue::Fixed32Bytes(
-                PublicKey::from_hex(
-                    "f86c44a2de95d9149b51c6a29afeabba264c18e2fa7c49de93424a0c56947785"
-                )
-                .unwrap()
-                .to_bytes()
-            ))
+            Some(GenericTagValue::String(String::from(
+                "f86c44a2de95d9149b51c6a29afeabba264c18e2fa7c49de93424a0c56947785"
+            )))
         );
 
         // Test extract event ID
@@ -1612,13 +1608,9 @@ mod tests {
         .unwrap();
         assert_eq!(
             t.content(),
-            Some(GenericTagValue::Fixed32Bytes(
-                EventId::from_hex(
-                    "2be17aa3031bdcb006f0fce80c146dea9c1c0268b0af2398bb673365c6444d45"
-                )
-                .unwrap()
-                .to_bytes()
-            ))
+            Some(GenericTagValue::String(String::from(
+                "2be17aa3031bdcb006f0fce80c146dea9c1c0268b0af2398bb673365c6444d45"
+            )))
         );
     }
 


### PR DESCRIPTION
* Remove `impl<'de> Deserialize<'de> for GenericTagValue`
* Remove `impl<S> From<S> for GenericTagValue`
* Partially revert 526dbfdf4dfbf7b8039b422aee864179ad430a8f

https://github.com/rust-nostr/nostr/issues/372
