### PR TITLE
pool: fix spurious send_event timeout error

### DIFF
--- a/crates/nostr-relay-pool/src/relay/internal.rs
+++ b/crates/nostr-relay-pool/src/relay/internal.rs
@@ -1060,6 +1060,8 @@ impl InternalRelay {
             msgs.push(ClientMessage::event(event));
         }
 
+        let mut notifications = self.internal_notification_sender.subscribe();
+
         // Batch send messages
         self.batch_msg(msgs, opts).await?;
 
@@ -1067,7 +1069,6 @@ impl InternalRelay {
         time::timeout(Some(opts.timeout), async {
             let mut published: HashSet<EventId> = HashSet::new();
             let mut not_published: HashMap<EventId, String> = HashMap::new();
-            let mut notifications = self.internal_notification_sender.subscribe();
             while let Ok(notification) = notifications.recv().await {
                 match notification {
                     RelayNotification::Message {


### PR DESCRIPTION
start to listen for OK msg immediately before event is sent

this prevents the OK msg from being recieved
before we start listening for it

this bug was introduced in v0.28 and discovered when upgrading
v0.27 ~> v0.29 in ngit (https://https://gitworkshop.dev/ngit)
as it caused many intergration tests to fail

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

<!-- Add the changelog -->

### Checklists

#### All Submissions:

* [ ] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [ ] I ran `just precommit` or `just check` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR