### PR TITLE
Correct key method calls in README example

### DIFF
--- a/bindings/nostr-js/README.md
+++ b/bindings/nostr-js/README.md
@@ -26,12 +26,12 @@ async function main() {
     let keys = Keys.generate();
 
     // Hex keys
-    console.log("Public key (hex): ", keys.publicKey().toHex());
-    console.log("Secret key (hex): ", keys.secretKey().toHex());
+    console.log("Public key (hex): ", keys.publicKey.toHex());
+    console.log("Secret key (hex): ", keys.secretKey.toHex());
 
     // Bech32 keys
-    console.log("Public key (bech32): ", keys.publicKey().toBech32());
-    console.log("Secret key (bech32): ", keys.secretKey().toBech32());
+    console.log("Public key (bech32): ", keys.publicKey.toBech32());
+    console.log("Secret key (bech32): ", keys.secretKey.toBech32());
 }
 
 main();


### PR DESCRIPTION
The commit replaces incorrect function calls on the keys object in the README's code example, instead referencing them as properties. This aligns the documentation's example accurately with the implementation of public and secret key methods.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

<!-- Add the changelog -->

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [x] I ran `just precommit` or `just check` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR