### PR TITLE
Add asynchronous save_event method to database.rs

### DIFF
--- a/bindings/nostr-sdk-js/src/database.rs
+++ b/bindings/nostr-sdk-js/src/database.rs
@@ -45,13 +45,9 @@ impl JsNostrDatabase {
         })
     }
 
-    // /// Save [`Event`] into store
-    //
-    // Return `true` if event was successfully saved into database.
-    // pub fn save_event(&self, event: &JsEvent) -> Result<bool> {
-    // block_on(async move { Ok(self.inner.save_event(event.as_ref().deref()).await?) })
-    // }
-
+    pub async fn save_event(&self, event: &JsEvent) -> Result<bool> {
+        self.inner.save_event(event).await.map_err(into_err)
+    }
     /// Get list of relays that have seen the [`EventId`]
     #[wasm_bindgen(js_name = eventSeenOnRelays)]
     pub async fn event_seen_on_relays(


### PR DESCRIPTION
This commit introduces an asynchronous save_event function within database.rs in the nostr-sdk-js bindings. This new method enhances the previous 'inner' save_event functionality by offering improved error handling.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

<!-- Add the changelog -->

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [x] I ran `just precommit` or `just check` before committing

#### New Features:

* [x] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR