### PR TITLE
Refine secret_key parsing and adjust client error handling

### DIFF
--- a/crates/nostr-sdk/src/client/mod.rs
+++ b/crates/nostr-sdk/src/client/mod.rs
@@ -67,7 +67,7 @@ pub enum Error {
     /// NIP57 error
     #[cfg(feature = "nip57")]
     #[error(transparent)]
-    NIP57(#[from] nostr::nips::nip57::Error),
+    NIP57(#[from] nip57::Error),
     /// LNURL Pay
     #[cfg(feature = "nip57")]
     #[error(transparent)]

--- a/crates/nostr-sdk/src/client/options.rs
+++ b/crates/nostr-sdk/src/client/options.rs
@@ -155,7 +155,7 @@ impl Options {
 
     /// Skip disconnected relays during send methods (default: true)
     ///
-    /// If the relay made just 1 attempt, the relay will not be skipped
+    /// If the relay made just one attempt, the relay will not be skipped
     pub fn skip_disconnected_relays(self, skip: bool) -> Self {
         Self {
             skip_disconnected_relays: Arc::new(AtomicBool::new(skip)),

--- a/crates/nostr/src/key/secret_key.rs
+++ b/crates/nostr/src/key/secret_key.rs
@@ -56,12 +56,13 @@ impl SecretKey {
         S: AsRef<str>,
     {
         let secret_key: &str = secret_key.as_ref();
-        match Self::from_hex(secret_key) {
-            Ok(secret_key) => Ok(secret_key),
-            Err(_) => match Self::from_bech32(secret_key) {
+        if let Ok(secret_key) = Self::from_hex(secret_key) {
+            Ok(secret_key)
+        } else {
+            match Self::from_bech32(secret_key) {
                 Ok(secret_key) => Ok(secret_key),
                 Err(_) => Err(Error::InvalidSecretKey),
-            },
+            }
         }
     }
 


### PR DESCRIPTION
Improved the secret_key string decoding in the nostr crate by sequentially trying hexadecimal decoding before resorting to bech32 decoding. This eliminates needless conversions and bolsters error management. Tweaked Error handling in the nostr-sdk's client module, alongside a slight text amendment in the client options.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

<!-- Add the changelog -->

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [x] I ran `just precommit` or `just check` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR