### PR TITLE
Add Other Report variant

### DIFF
--- a/bindings/nostr-ffi/src/event/tag.rs
+++ b/bindings/nostr-ffi/src/event/tag.rs
@@ -74,6 +74,8 @@ pub enum Report {
     Spam,
     /// Someone pretending to be someone else
     Impersonation,
+    /// Reports that don't fit in the above categories
+    Other,
 }
 
 impl From<Report> for tag::Report {
@@ -84,6 +86,7 @@ impl From<Report> for tag::Report {
             Report::Illegal => Self::Illegal,
             Report::Spam => Self::Spam,
             Report::Impersonation => Self::Impersonation,
+            Report::Other => Self::Other,
         }
     }
 }
@@ -96,6 +99,7 @@ impl From<tag::Report> for Report {
             tag::Report::Illegal => Self::Illegal,
             tag::Report::Spam => Self::Spam,
             tag::Report::Impersonation => Self::Impersonation,
+            tag::Report::Other => Self::Other,
         }
     }
 }

--- a/crates/nostr/src/event/tag.rs
+++ b/crates/nostr/src/event/tag.rs
@@ -215,6 +215,8 @@ pub enum Report {
     Spam,
     /// Someone pretending to be someone else
     Impersonation,
+    ///  Reports that don't fit in the above categories
+    Other,
 }
 
 impl fmt::Display for Report {
@@ -225,6 +227,7 @@ impl fmt::Display for Report {
             Self::Illegal => write!(f, "illegal"),
             Self::Spam => write!(f, "spam"),
             Self::Impersonation => write!(f, "impersonation"),
+            Self::Other => write!(f, "other"),
         }
     }
 }
@@ -239,6 +242,7 @@ impl FromStr for Report {
             "illegal" => Ok(Self::Illegal),
             "spam" => Ok(Self::Spam),
             "impersonation" => Ok(Self::Impersonation),
+            "other" => Ok(Self::Other),
             _ => Err(Error::UnknownReportType),
         }
     }
@@ -2199,6 +2203,22 @@ mod tests {
                 )
                 .unwrap(),
                 Report::Impersonation
+            )
+        );
+
+        assert_eq!(
+            Tag::parse(&[
+                "p",
+                "13adc511de7e1cfcf1c6b7f6365fb5a03442d7bcacf565ea57fa7770912c023d",
+                "other"
+            ])
+            .unwrap(),
+            Tag::PubKeyReport(
+                PublicKey::from_str(
+                    "13adc511de7e1cfcf1c6b7f6365fb5a03442d7bcacf565ea57fa7770912c023d"
+                )
+                .unwrap(),
+                Report::Other
             )
         );
 


### PR DESCRIPTION
### Description
Adds a new `Report::Other` variant to sync with new [nip-56](https://github.com/nostr-protocol/nips/blob/master/56.md) 

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [ ] I ran `just precommit` or `just check` before committing

#### New Features:

* [x] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR