### PR TITLE
nostr: expose nip49 log_n

### DIFF
--- a/crates/nostr/src/nips/nip49.rs
+++ b/crates/nostr/src/nips/nip49.rs
@@ -318,6 +318,12 @@ impl EncryptedSecretKey {
         self.version
     }
 
+    /// Get encryption log_n value
+    #[inline]
+    pub fn log_n(&self) -> u8 {
+        self.log_n
+    }
+
     /// Get encrypted secret key security
     #[inline]
     pub fn key_security(&self) -> KeySecurity {


### PR DESCRIPTION
so that decryption time can be estimated and
applications can warn users if needed
