### PR TITLE
book: add NIP-05 python examples

### DIFF
--- a/book/snippets/nostr/python/main.py
+++ b/book/snippets/nostr/python/main.py
@@ -4,6 +4,7 @@ from src.keys import generate, restore, vanity
 from src.event.json import event_json
 from src.event.builder import event_builder
 from src.nip01 import nip01
+from src.nip05 import nip05
 from src.nip44 import nip44
 from src.nip59 import nip59
 
@@ -15,6 +16,7 @@ def main():
     event_json()
     event_builder()
     nip01()
+    nip05()
     nip44()
     nip59()
 

--- a/book/snippets/nostr/python/src/event/json.py
+++ b/book/snippets/nostr/python/src/event/json.py
@@ -7,4 +7,5 @@ def event_json():
 
     # Serialize as json
     json = event.as_json()
-    print(f"{json}")
+    print("\nEvent JSON:")
+    print(f" {json}")

--- a/book/snippets/nostr/python/src/keys.py
+++ b/book/snippets/nostr/python/src/keys.py
@@ -11,7 +11,7 @@ def generate():
     print(" Public keys:")
     print(f"     hex:    {public_key.to_hex()}")
     print(f"     bech32: {public_key.to_bech32()}")
-    print(" Secret keys:")
+    print("\n Secret keys:")
     print(f"     hex:    {secret_key.to_hex()}")
     print(f"     bech32: {secret_key.to_bech32()}")
 
@@ -34,7 +34,7 @@ def restore():
 # ANCHOR: vanity
 def vanity():
     keys = Keys.vanity(["yuk0"], True, 8)
-
-    print(f"Public keys: {keys.public_key().to_bech32()}")
-    print(f"Secret keys: {keys.secret_key().to_bech32()}")
+    print("\n Vanity:")
+    print(f"     Public keys: {keys.public_key().to_bech32()}")
+    print(f"     Secret keys: {keys.secret_key().to_bech32()}")
 # ANCHOR_END: vanity

--- a/book/snippets/nostr/python/src/nip05.py
+++ b/book/snippets/nostr/python/src/nip05.py
@@ -1,0 +1,33 @@
+from nostr_protocol import Keys, Metadata, EventBuilder
+
+def nip05():
+    # Generate random keys
+    keys = Keys.generate()
+
+    # ANCHOR: create-event
+    # Create metadata object with name and NIP05
+    metadata_content = Metadata()\
+        .set_name("TestName")\
+        .set_nip05("TestName@rustNostr.com")
+
+    # Build event and assign metadata
+    builder = EventBuilder.metadata(metadata_content)
+
+    # Signed event (Normal)
+    print("\nCreating Metadata Event:")
+    event = builder.to_event(keys)
+
+    print(" Event Details:")
+    print(f"     Kind      : {event.kind().as_u16()}")
+    print(f"     Content   : {event.content()}")
+    # ANCHOR_END: create-event
+
+    # ANCHOR: create-metadata
+    # Deserialize Metadata from event
+    print("\nDeserializing Metadata Event:")
+    metadata = Metadata().from_json(event.content())
+
+    print(" Metadata Details:")
+    print(f"     Name      : {metadata.get_name()}")
+    print(f"     NIP05     : {metadata.get_nip05()}")
+    # ANCHOR_END: create-metadata

--- a/book/snippets/nostr/python/src/nip44.py
+++ b/book/snippets/nostr/python/src/nip44.py
@@ -1,12 +1,13 @@
 from nostr_protocol import Keys, PublicKey, nip44_encrypt, nip44_decrypt, Nip44Version
 
 def nip44():
+    print("\nEncrypting and Decrypting Messages (NIP-44):")
     keys = Keys.generate()
 
     pk = PublicKey.from_hex("79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798")
 
     ciphertext = nip44_encrypt(keys.secret_key(), pk, "my message", Nip44Version.V2)
-    print(f"Encrypted: {ciphertext}")
+    print(f" Encrypted: {ciphertext}")
 
     plaintext = nip44_decrypt(keys.secret_key(), pk, ciphertext)
-    print(f"Decrypted: {plaintext}")
+    print(f" Decrypted: {plaintext}")

--- a/book/snippets/nostr/python/src/nip59.py
+++ b/book/snippets/nostr/python/src/nip59.py
@@ -2,6 +2,7 @@ from nostr_protocol import Keys, EventBuilder, Event, gift_wrap, UnwrappedGift, 
 
 
 def nip59():
+    print("\nGift Wrapping (NIP-59):")
     # Sender Keys
     alice_keys = Keys.parse("5c0c523f52a5b6fad39ed2403092df8cebc36318b39383bca6c00808626fab3a")
 
@@ -13,11 +14,12 @@ def nip59():
 
     # Build gift wrap with sender keys
     gw: Event = gift_wrap(alice_keys, bob_keys.public_key(), rumor, None)
-    print(f"Gift Wrap: {gw.as_json()}")
+    print(f" Gift Wrap:\n{gw.as_json()}")
 
     # Extract rumor from gift wrap with receiver keys
+    print("\n Unwrapped Gift:")
     unwrapped_gift = UnwrappedGift.from_gift_wrap(bob_keys, gw)
     sender = unwrapped_gift.sender()
     rumor: UnsignedEvent = unwrapped_gift.rumor()
-    print(f"Sender: {sender.to_bech32()}")
-    print(f"Rumor: {rumor.as_json()}")
+    print(f"     Sender: {sender.to_bech32()}")
+    print(f"     Rumor: {rumor.as_json()}")

--- a/book/src/nostr/06-nip05.md
+++ b/book/src/nostr/06-nip05.md
@@ -1,1 +1,55 @@
-# NIP-05
+## NIP-05
+
+As a part of the kind 0 metadata events the optional key `nip05` is used to set and internet identifier value (e.g. TestName@rustNostr.com). Clients can then use this information to make GET requests with the form `https://<domain>/.well-known/nostr.json?name=<local-part>`. 
+
+For additional documentation on the `Metadata` struct attributes, check out [the Metadata documentation](https://docs.rs/nostr/latest/nostr/types/metadata/struct.Metadata.html).
+
+### Mapping Nostr keys to DNS-based internet identifiers (NIP-05)
+
+<custom-tabs category="lang">
+
+<div slot="title">Rust</div>
+<section>
+
+TODO
+
+</section>
+
+<div slot="title">Python</div>
+<section>
+
+Using the `Metadata` class to build the metadata object and incorporate the NIP-05 indentifier using the `set_nip05()` function.
+
+```python,ignore
+{{#include ../../snippets/nostr/python/src/nip05.py:create-event}}
+```
+
+When deserializing metdata from an event the `get_nip05()` can be used with an instance of the `Metadata` class to return the NIP-05 value.
+
+```python,ignore
+{{#include ../../snippets/nostr/python/src/nip05.py:create-metadata}}
+```
+
+</section>
+
+<div slot="title">JavaScript</div>
+<section>
+
+TODO
+
+</section>
+
+<div slot="title">Kotlin</div>
+<section>
+
+TODO
+
+</section>
+
+<div slot="title">Swift</div>
+<section>
+
+TODO
+
+</section>
+</custom-tabs>


### PR DESCRIPTION
### Description
- Added NIP-05 Python Example
- Updated book page for NIP-05
- Included minor print statement updates to: 
   - json.py
   - keys.py
   - nip44.py
   - nip59.py

### Notes to the reviewers
The minor updates to the existing python examples simply make the `just test` easier to review and keep consistent indentation with the previous examples.

Please take a look at the content of the book page as I've added a couple of sentences there to summarize the NIP-05 functionality, but this will def need a review.

### Checklist

* [x] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [x] I ran `just precommit` or `just check` before committing
* [ ] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
