### PR TITLE
book: add NIP-06 python examples

### DIFF
--- a/book/snippets/nostr/python/main.py
+++ b/book/snippets/nostr/python/main.py
@@ -5,6 +5,7 @@ from src.event.json import event_json
 from src.event.builder import event_builder
 from src.nip01 import nip01
 from src.nip05 import nip05
+from src.nip06 import nip06
 from src.nip44 import nip44
 from src.nip59 import nip59
 
@@ -17,6 +18,7 @@ def main():
     event_builder()
     nip01()
     nip05()
+    nip06()
     nip44()
     nip59()
 

--- a/book/snippets/nostr/python/requirements.txt
+++ b/book/snippets/nostr/python/requirements.txt
@@ -1,1 +1,2 @@
 nostr-protocol==0.12.0
+mnemonic==0.21

--- a/book/snippets/nostr/python/src/keys.py
+++ b/book/snippets/nostr/python/src/keys.py
@@ -11,11 +11,10 @@ def generate():
     print(" Public keys:")
     print(f"     hex:    {public_key.to_hex()}")
     print(f"     bech32: {public_key.to_bech32()}")
-    print("\n Secret keys:")
+    print()
+    print(" Secret keys:")
     print(f"     hex:    {secret_key.to_hex()}")
     print(f"     bech32: {secret_key.to_bech32()}")
-
-
 # ANCHOR_END: generate
 
 # ANCHOR: restore
@@ -27,14 +26,13 @@ def restore():
 
     secret_key = SecretKey.from_bech32("nsec1j4c6269y9w0q2er2xjw8sv2ehyrtfxq3jwgdlxj6qfn8z4gjsq5qfvfk99")
     keys = Keys(secret_key)
-
-
 # ANCHOR_END: restore
 
+print()
 # ANCHOR: vanity
 def vanity():
     keys = Keys.vanity(["yuk0"], True, 8)
-    print("\n Vanity:")
+    print(" Vanity:")
     print(f"     Public keys: {keys.public_key().to_bech32()}")
     print(f"     Secret keys: {keys.secret_key().to_bech32()}")
 # ANCHOR_END: vanity

--- a/book/snippets/nostr/python/src/nip01.py
+++ b/book/snippets/nostr/python/src/nip01.py
@@ -3,6 +3,7 @@ def nip01():
     # Generate random keys
     keys = Keys.generate()
 
+    print()
     # ANCHOR: create-event
     # Create metadata object with desired content
     metadata_content = Metadata()\
@@ -18,7 +19,7 @@ def nip01():
     builder = EventBuilder.metadata(metadata_content)
 
     # Signed event and print details
-    print("\nCreating Metadata Event:")
+    print("Creating Metadata Event:")
     event = builder.to_event(keys)
 
     print(" Event Details:")
@@ -31,9 +32,10 @@ def nip01():
     print(f"     JSON      : {event.as_json()}")
     # ANCHOR_END: create-event
 
+    print()
     # ANCHOR: create-metadata
     # Deserialize Metadata from event
-    print("\nDeserializing Metadata Event:")
+    print("Deserializing Metadata Event:")
     metadata = Metadata().from_json(event.content())
     
     print(" Metadata Details:")

--- a/book/snippets/nostr/python/src/nip06.py
+++ b/book/snippets/nostr/python/src/nip06.py
@@ -1,0 +1,65 @@
+# Leverages Python-Mnemonic package (ref implementation of BIP39) https://github.com/trezor/python-mnemonic
+from mnemonic import Mnemonic
+from nostr_protocol import Keys
+
+def nip06():
+    # ANCHOR: keys-from-seed24
+    # Generate random Seed Phrase (24 words e.g. 256 bits entropy)
+    print("\nKeys from 24 word Seed Phrase:")
+    words = Mnemonic("english").generate(strength=256)
+    passphrase = ""
+
+    # Use Seed Phrase to generate basic Nostr keys
+    keys = Keys.from_mnemonic(words, passphrase)
+
+    print(f" Seed Words (24)  : {words}")
+    print(f" Public key bech32: {keys.public_key().to_bech32()}")
+    print(f" Secret key bech32: {keys.secret_key().to_bech32()}")
+    # ANCHOR_END: keys-from-seed24
+  
+
+    # ANCHOR: keys-from-seed12
+    # Generate random Seed Phrase (12 words e.g. 128 bits entropy)
+    print("\nKeys from 12 word Seed Phrase:")
+    words = Mnemonic("english").generate(strength=128)
+    passphrase = ""
+
+    # Use Seed Phrase to generate basic Nostr keys
+    keys = Keys.from_mnemonic(words, passphrase)
+
+    print(f" Seed Words (12)  : {words}")
+    print(f" Public key bech32: {keys.public_key().to_bech32()}")
+    print(f" Secret key bech32: {keys.secret_key().to_bech32()}")
+    # ANCHOR_END: keys-from-seed12
+
+
+    # ANCHOR: keys-from-seed-accounts
+    # Advanced (with accounts) from the example wordlist
+    words = "leader monkey parrot ring guide accident before fence cannon height naive bean"
+    passphrase = ""
+
+    print("\nAccounts (0-5) from 12 word Seed Phrase (with passphrase):")
+    print(f" Seed Words (12): {words}")
+    print(" Accounts (0-5) :")
+
+    # Use Seed Phrase and account to multiple Nostr keys
+    for account in range(0,6):
+        nsec = Keys.from_mnemonic_with_account(words,passphrase,account).secret_key().to_bech32()
+        print(f"     Account #{account} bech32: {nsec}")
+    # ANCHOR_END: keys-from-seed-accounts
+
+
+    # ANCHOR: keys-from-seed-accounts-pass
+    # Advanced (with accounts) from the same wordlist with in inclusion of passphrase
+    words = "leader monkey parrot ring guide accident before fence cannon height naive bean"
+    passphrase = "RustNostr"
+    print("\nAccounts (0-5) from 12 word Seed Phrase (with passphrase):")
+    print(f" Seed Words (12): {words}")
+    print(f" Passphrase     : {passphrase}")
+    print(" Accounts (0-5) :")
+
+    # Use Seed Phrase and account to multiple Nostr keys
+    for account in range(0,6):
+        nsec = Keys.from_mnemonic_with_account(words,passphrase,account).secret_key().to_bech32()
+        print(f"     Account #{account} bech32: {nsec}")
+    # ANCHOR_END: keys-from-seed-accounts-pass

--- a/book/snippets/nostr/python/src/nip06.py
+++ b/book/snippets/nostr/python/src/nip06.py
@@ -3,9 +3,10 @@ from mnemonic import Mnemonic
 from nostr_protocol import Keys
 
 def nip06():
+    print()
     # ANCHOR: keys-from-seed24
     # Generate random Seed Phrase (24 words e.g. 256 bits entropy)
-    print("\nKeys from 24 word Seed Phrase:")
+    print("Keys from 24 word Seed Phrase:")
     words = Mnemonic("english").generate(strength=256)
     passphrase = ""
 
@@ -17,10 +18,10 @@ def nip06():
     print(f" Secret key bech32: {keys.secret_key().to_bech32()}")
     # ANCHOR_END: keys-from-seed24
   
-
+    print()
     # ANCHOR: keys-from-seed12
     # Generate random Seed Phrase (12 words e.g. 128 bits entropy)
-    print("\nKeys from 12 word Seed Phrase:")
+    print("Keys from 12 word Seed Phrase:")
     words = Mnemonic("english").generate(strength=128)
     passphrase = ""
 
@@ -32,13 +33,13 @@ def nip06():
     print(f" Secret key bech32: {keys.secret_key().to_bech32()}")
     # ANCHOR_END: keys-from-seed12
 
-
+    print()
     # ANCHOR: keys-from-seed-accounts
     # Advanced (with accounts) from the example wordlist
     words = "leader monkey parrot ring guide accident before fence cannon height naive bean"
     passphrase = ""
 
-    print("\nAccounts (0-5) from 12 word Seed Phrase (with passphrase):")
+    print("Accounts (0-5) from 12 word Seed Phrase (with passphrase):")
     print(f" Seed Words (12): {words}")
     print(" Accounts (0-5) :")
 
@@ -48,12 +49,12 @@ def nip06():
         print(f"     Account #{account} bech32: {nsec}")
     # ANCHOR_END: keys-from-seed-accounts
 
-
+    print()
     # ANCHOR: keys-from-seed-accounts-pass
     # Advanced (with accounts) from the same wordlist with in inclusion of passphrase
     words = "leader monkey parrot ring guide accident before fence cannon height naive bean"
     passphrase = "RustNostr"
-    print("\nAccounts (0-5) from 12 word Seed Phrase (with passphrase):")
+    print("Accounts (0-5) from 12 word Seed Phrase (with passphrase):")
     print(f" Seed Words (12): {words}")
     print(f" Passphrase     : {passphrase}")
     print(" Accounts (0-5) :")

--- a/book/src/nostr/06-nip06.md
+++ b/book/src/nostr/06-nip06.md
@@ -4,7 +4,7 @@ In accordance with the [Bitcoin Improvement Proposal 0039 (BIP-39)](https://gith
 
 The default functionality is to generate a single key-pair at the derivation path `0`. However, it is also possible to perform more advanced derivations by incrementing the `account`, enabling generation of many sets of keys from a single seed. More granular derivation path control (over `account`, `type` and `index`) exists within the `from_mnemonic_advanced` method. 
 
-For more examples of key generation please refer back to the [Keys section](https://rust-nostr.org/nostr/03-keys.html) of this book.
+For more examples of key generation please refer back to the [Keys section](03-keys.md) of this book.
 
 ### Key derivation from mnemonic seed phrase (NIP-06)
 
@@ -25,25 +25,25 @@ Using the `from_mnemonic()` function in conjunction with the `Keys` class to der
 Note that this example uses the `Mnemonic` class from the [python-mnemonic](https://github.com/trezor/python-mnemonic) package (the reference implementation of BIP-39) to randomly generate example seed phrases.
 
 ```python,ignore
-{{#include ../../snippets/nostr/python/src/nip05.py:keys-from-seed24}}
+{{#include ../../snippets/nostr/python/src/nip06.py:keys-from-seed24}}
 ```
 
 As well as deriving basic keys from a 24 word seed we can also use seed phrases of other lengths such as 18 words or, as in this example, 12 words.
 
 ```python,ignore
-{{#include ../../snippets/nostr/python/src/nip05.py:keys-from-seed12}}
+{{#include ../../snippets/nostr/python/src/nip06.py:keys-from-seed12}}
 ```
 
 Advanced key derivation functionality (for accounts) can be accessed by the `from_mnemonic_with_account()` function. To do this we use the `account` argument which accepts an integer to specify the derivation path.
 
 ```python,ignore
-{{#include ../../snippets/nostr/python/src/nip05.py:keys-from-seed-accounts}}
+{{#include ../../snippets/nostr/python/src/nip06.py:keys-from-seed-accounts}}
 ```
 
 This final example utilizes the same seed as for the previous example, but also includes a `passphrase`. It illustrates the effect of inclusion of a passphrase on the key derivation.
 
 ```python,ignore
-{{#include ../../snippets/nostr/python/src/nip05.py:keys-from-seed-accounts-pass}}
+{{#include ../../snippets/nostr/python/src/nip06.py:keys-from-seed-accounts-pass}}
 ```
 
 </section>

--- a/book/src/nostr/06-nip06.md
+++ b/book/src/nostr/06-nip06.md
@@ -1,1 +1,71 @@
-# NIP-06
+## NIP-06
+
+In accordance with the [Bitcoin Improvement Proposal 0039 (BIP-39)](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) we can derive Nostr keys using seed phrases as a source of entropy. This is handled by the [FromMnemonic](https://docs.rs/nostr/latest/nostr/nips/nip06/trait.FromMnemonic.html) Trait and its associated methods.
+
+The default functionality is to generate a single key-pair at the derivation path `0`. However, it is also possible to perform more advanced derivations by incrementing the `account`, enabling generation of many sets of keys from a single seed. More granular derivation path control (over `account`, `type` and `index`) exists within the `from_mnemonic_advanced` method. 
+
+For more examples of key generation please refer back to the [Keys section](https://rust-nostr.org/nostr/03-keys.html) of this book.
+
+### Key derivation from mnemonic seed phrase (NIP-06)
+
+<custom-tabs category="lang">
+
+<div slot="title">Rust</div>
+<section>
+
+TODO
+
+</section>
+
+<div slot="title">Python</div>
+<section>
+
+Using the `from_mnemonic()` function in conjunction with the `Keys` class to derived a basic set of Nostr keys from a 24 word seed phrase.
+
+Note that this example uses the `Mnemonic` class from the [python-mnemonic](https://github.com/trezor/python-mnemonic) package (the reference implementation of BIP-39) to randomly generate example seed phrases.
+
+```python,ignore
+{{#include ../../snippets/nostr/python/src/nip05.py:keys-from-seed24}}
+```
+
+As well as deriving basic keys from a 24 word seed we can also use seed phrases of other lengths such as 18 words or, as in this example, 12 words.
+
+```python,ignore
+{{#include ../../snippets/nostr/python/src/nip05.py:keys-from-seed12}}
+```
+
+Advanced key derivation functionality (for accounts) can be accessed by the `from_mnemonic_with_account()` function. To do this we use the `account` argument which accepts an integer to specify the derivation path.
+
+```python,ignore
+{{#include ../../snippets/nostr/python/src/nip05.py:keys-from-seed-accounts}}
+```
+
+This final example utilizes the same seed as for the previous example, but also includes a `passphrase`. It illustrates the effect of inclusion of a passphrase on the key derivation.
+
+```python,ignore
+{{#include ../../snippets/nostr/python/src/nip05.py:keys-from-seed-accounts-pass}}
+```
+
+</section>
+
+<div slot="title">JavaScript</div>
+<section>
+
+TODO
+
+</section>
+
+<div slot="title">Kotlin</div>
+<section>
+
+TODO
+
+</section>
+
+<div slot="title">Swift</div>
+<section>
+
+TODO
+
+</section>
+</custom-tabs>


### PR DESCRIPTION
### Description

Added NIP-06 examples:
- Derive from seed (24 words)
- Derive from seed (12 words)
- Derive from seed (with accounts)
- Derive from seed (with accounts & passphrase)

### Notes to the reviewers

Thanks in advance for the review. I'll be honest I flip-flopped on the last example as I could have added the `from_mnemonic_advanced()` function but I wondered if it was just enough to reference it in the introduction text. Let me know if you think it should be added and I'll tweak the last bit.

Additionally, I added to the requirements file the reference implementation for generating seed words (as linked on the BIP39 [wiki page](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki)). It seemed a safe option as it is well known, but if you think we should just hardcode some 12/24 words (as in example 3 & 4) then let me know and I'll correct this.

Finally, please feel free to let me know if I need to slow down with these updates. I'm sure you're busy enough. I've just been stepping through the NIPs so that I can understand the how to use the package from my side (hence dropping the PRs).

### Checklist

* [x] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [x] I ran `just precommit` or `just check` before committing
* [ ] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
