### PR TITLE
book: add NIP-19 python examples

### DIFF
--- a/book/snippets/nostr/python/main.py
+++ b/book/snippets/nostr/python/main.py
@@ -6,6 +6,7 @@ from src.event.builder import event_builder
 from src.nip01 import nip01
 from src.nip05 import nip05
 from src.nip06 import nip06
+from src.nip19 import nip19
 from src.nip44 import nip44
 from src.nip59 import nip59
 
@@ -19,6 +20,7 @@ def main():
     nip01()
     nip05()
     nip06()
+    nip19()
     nip44()
     nip59()
 

--- a/book/snippets/nostr/python/src/nip19.py
+++ b/book/snippets/nostr/python/src/nip19.py
@@ -1,0 +1,59 @@
+from nostr_protocol import Keys, EventBuilder, Nip19Profile, Nip19, Nip19Event, Coordinate, Kind, Nip19Enum
+def nip19():
+    keys = Keys.generate()
+
+    print()
+    print("Bare keys and ids (bech32):")
+    # ANCHOR: nip19-npub
+    print(f" Public key: {keys.public_key().to_bech32()}")
+    # ANCHOR_END: nip19-npub
+
+    # ANCHOR: nip19-nsec
+    print(f" Secret key: {keys.secret_key().to_bech32()}")
+    # ANCHOR_END: nip19-nsec
+
+    # ANCHOR: nip19-note
+    event = EventBuilder.text_note("Hello from Rust Nostr Python bindings!", []).to_event(keys)
+    print(f" Event     : {event.id().to_bech32()}")
+    # ANCHOR_END: nip19-note
+
+    print()
+    print("Shareable identifiers with extra metadata (bech32):")
+    # ANCHOR: nip19-nprofile-encode
+    # Create NIP-19 profile including relays data
+    relays = ["wss://relay.damus.io"]
+    nprofile = Nip19Profile(keys.public_key(),relays)
+    print(f" Profile (encoded): {nprofile.to_bech32()}")
+    # ANCHOR_END: nip19-nprofile-encode
+
+    # ANCHOR: nip19-nprofile-decode
+    # Decode NIP-19 profile
+    decode_nprofile = Nip19.from_bech32(nprofile.to_bech32())
+    print(f" Profile (decoded): {decode_nprofile}")
+    # ANCHOR_END: nip19-nprofile-decode
+
+    print()
+    # ANCHOR: nip19-nevent-encode
+    # Create NIP-19 event including author and relays data
+    nevent = Nip19Event(event.id(),keys.public_key(),relays)
+    print(f" Event (encoded): {nevent.to_bech32()}")
+    # ANCHOR_END: nip19-nevent-encode
+
+    # ANCHOR: nip19-nevent-decode
+    # Decode NIP-19 event
+    decode_nevent = Nip19.from_bech32(nevent.to_bech32())
+    print(f" Event (decoded): {decode_nevent}")
+    # ANCHOR_END: nip19-nevent-decode
+  
+    print()
+    # ANCHOR: nip19-naddr-encode
+    # Create NIP-19 coordinate
+    coord = Coordinate(Kind(0),keys.public_key())
+    print(f" Coordinate (encoded): {coord.to_bech32()}")
+    # ANCHOR_END: nip19-naddr-encode
+
+    # ANCHOR: nip19-naddr-decode
+    # Decode NIP-19 coordinate
+    decode_coord = Nip19.from_bech32(coord.to_bech32())
+    print(f" Coordinate (decoded): {decode_coord}")
+    # ANCHOR_END: nip19-naddr-decode

--- a/book/src/nostr/06-nip19.md
+++ b/book/src/nostr/06-nip19.md
@@ -1,1 +1,95 @@
-# NIP-19
+## NIP-19
+
+Bech-32 encoding is utilized for the primary purpose of transportability between users/client/applications. In addition to bech-32 encoding of the data a series of prefixes are also used to help easily differentiate between different data objects. `npub`/`nsec` for public and private keys, respectively and `note` for note ids. 
+
+Extra metadata may be included when communicating between applications to make cross compatibility more streamlined. These follow a type-length-value structure and have the following possible prefixes; `nprofile`, `nevent`, `nrelay` and `naddr`. 
+
+The [nip19 module](https://docs.rs/nostr/latest/nostr/nips/nip19/index.html) and associated `Nip19Event` and `Nip19Profile` structs can be used to handle construction and interpretation of these data.
+
+### bech32-encoded entities (NIP-19)
+
+<custom-tabs category="lang">
+
+<div slot="title">Rust</div>
+<section>
+
+TODO
+
+</section>
+
+<div slot="title">Python</div>
+<section>
+
+For most of these examples you will see that the `to_bech32()` and `from_bech32()` functions generally facilitate encoding or decoding objects per the NIP-19 standard.
+
+Public and Private (or secret) keys in `npub` and `nsec` formats.
+
+```python,ignore
+{{#include ../../snippets/nostr/python/src/nip19.py:nip19-npub}}
+```
+
+```python,ignore
+{{#include ../../snippets/nostr/python/src/nip19.py:nip19-nsec}}
+```
+
+Simple note presented in NIP-19 format.
+
+```python,ignore
+{{#include ../../snippets/nostr/python/src/nip19.py:nip19-note}}
+```
+
+Using the `Nip19Profile` class to create a shareable `nprofile` that includes relay data to help other applications to locate the profile data.
+
+```python,ignore
+{{#include ../../snippets/nostr/python/src/nip19.py:nip19-nprofile-encode}}
+```
+
+Using the `Nip19` class to decode the previously shared profile data. This class helps generalize the decoding process for all NIP-19 objects.
+
+```python,ignore
+{{#include ../../snippets/nostr/python/src/nip19.py:nip19-nprofile-decode}}
+```
+
+Using the `Nip19Event` class to create a shareable `nevent` that includes author and relay data. This is followed by decoding the event object.
+
+```python,ignore
+{{#include ../../snippets/nostr/python/src/nip19.py:nip19-nevent-encode}}
+```
+
+```python,ignore
+{{#include ../../snippets/nostr/python/src/nip19.py:nip19-nevent-decode}}
+```
+
+Using the `Coordinate` class to generate the coordinates for a replaceable event (in this case Metadata). This is followed by decoding the object.
+
+```python,ignore
+{{#include ../../snippets/nostr/python/src/nip19.py:nip19-naddr-encode}}
+```
+
+```python,ignore
+{{#include ../../snippets/nostr/python/src/nip19.py:nip19-naddr-decode}}
+```
+
+</section>
+
+<div slot="title">JavaScript</div>
+<section>
+
+TODO
+
+</section>
+
+<div slot="title">Kotlin</div>
+<section>
+
+TODO
+
+</section>
+
+<div slot="title">Swift</div>
+<section>
+
+TODO
+
+</section>
+</custom-tabs>


### PR DESCRIPTION
### Description

Added NIP-19 examples for:
-  Basic (npub, nsec, note)
- nprofile (encode/decode)
- nevent (encode/decode)
- naddr (encode/decode)

### Notes to the reviewers

Hopefully I've not gone too simplistic on this one. I tried to follow the NIP and give some examples but didn't go into too much detail about the addition of metadata for nprofile/nevent/nrelay/naddr. Hope this is OK.

On a side note I had a couple of questions about this:
1. I didn't see how to add the optional relay to the coordinates (maybe I am blind). I tried constructing the Tag from scratch (e.g. `Tag.coordinate(Coordinate(Kind(0),pk))` but I couldn't see how to add the optional metadata for the `relay` as defined in the NIP-19 documentation.
2. I didn't see anywhere in the bindings code that `nrelay` were producible. Though I could see that the `Nip19` class would be able to handle these. I'll be honest I think it is the first time I've seen relays URLs to be shared as anything other than just a URL. Do we need an example for this or is it not common practice?

### Checklist

* [x] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [x] I ran `just precommit` or `just check` before committing
* [ ] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
