### PR TITLE
Add a tag to zap receipts

### DIFF
--- a/crates/nostr/src/event/builder.rs
+++ b/crates/nostr/src/event/builder.rs
@@ -916,6 +916,21 @@ impl EventBuilder {
             tags.push(tag);
         }
 
+        // add a tag
+        if let Some(tag) = zap_request
+            .iter_tags()
+            .find(|t| {
+                t.kind()
+                    == TagKind::SingleLetter(SingleLetterTag {
+                        character: Alphabet::A,
+                        uppercase: false,
+                    })
+            })
+            .cloned()
+        {
+            tags.push(tag);
+        }
+
         // add p tag
         if let Some(tag) = zap_request
             .iter_tags()


### PR DESCRIPTION
Adds the `a` tag defined in [nip57](https://github.com/nostr-protocol/nips/blob/master/57.md#appendix-e-zap-receipt-event)