### PR TITLE
book: add NIP-21 python examples

### DIFF
--- a/book/snippets/nostr/python/main.py
+++ b/book/snippets/nostr/python/main.py
@@ -7,6 +7,7 @@ from src.nip01 import nip01
 from src.nip05 import nip05
 from src.nip06 import nip06
 from src.nip19 import nip19
+from src.nip21 import nip21
 from src.nip44 import nip44
 from src.nip59 import nip59
 
@@ -21,6 +22,7 @@ def main():
     nip05()
     nip06()
     nip19()
+    nip21()
     nip44()
     nip59()
 

--- a/book/snippets/nostr/python/src/nip19.py
+++ b/book/snippets/nostr/python/src/nip19.py
@@ -1,4 +1,4 @@
-from nostr_protocol import Keys, EventBuilder, Nip19Profile, Nip19, Nip19Event, Coordinate, Kind, Nip19Enum
+from nostr_protocol import Keys, EventBuilder, Nip19Profile, Nip19, Nip19Event, Coordinate, Kind
 def nip19():
     keys = Keys.generate()
 

--- a/book/snippets/nostr/python/src/nip21.py
+++ b/book/snippets/nostr/python/src/nip21.py
@@ -1,0 +1,84 @@
+from nostr_protocol import Keys, PublicKey, EventBuilder, EventId, Nip21, Nip19Profile, Nip19Event, Kind, Coordinate
+
+def nip21():
+    print()
+    print("Nostr URIs:")
+    # ANCHOR: nip21-npub
+    keys = Keys.generate()
+
+    # URI npub
+    pk_uri = keys.public_key().to_nostr_uri()
+    print(f" Public key (URI):    {pk_uri}")
+
+    # bech32 npub
+    pk_parse = Nip21.parse(pk_uri)
+    if pk_parse.as_enum().is_pubkey():
+        pk_bech32 = PublicKey.from_nostr_uri(pk_uri).to_bech32()
+        print(f" Public key (bech32): {pk_bech32}")
+    # ANCHOR_END: nip21-npub
+
+    print()
+
+    # ANCHOR: nip21-note
+    event = EventBuilder.text_note("Hello from Rust Nostr Python bindings!", []).to_event(keys)
+
+    # URI note
+    note_uri = event.id().to_nostr_uri()
+    print(f" Event (URI):    {note_uri}")
+
+    # bech32 note
+    note_pasre = Nip21.parse(note_uri)
+    if note_pasre.as_enum().is_note():
+        event_bech32 = EventId.from_nostr_uri(note_uri).to_bech32()
+        print(f" Event (bech32): {event_bech32}")
+    # ANCHOR_END: nip21-note
+    
+    print()
+
+    # ANCHOR: nip21-nprofile
+    relays = ["wss://relay.damus.io"]
+    nprofile = Nip19Profile(keys.public_key(),relays)
+
+    # URI nprofile
+    nprofile_uri = nprofile.to_nostr_uri()
+    print(f" Profile (URI):    {nprofile_uri}")
+
+    # bech32 nprofile
+    nprofile_parse = Nip21.parse(nprofile_uri)
+    if nprofile_parse.as_enum().is_profile():
+        nprofile_bech32 = Nip19Profile.from_nostr_uri(nprofile_uri).to_bech32()
+        print(f" Profile (bech32): {nprofile_bech32}")
+    # ANCHOR_END: nip21-nprofile
+
+    print()
+
+    # ANCHOR: nip21-nevent
+    relays = ["wss://relay.damus.io"]
+    nevent = Nip19Event(event.id(),keys.public_key(),relays)
+
+    # URI nevent
+    nevent_uri = nevent.to_nostr_uri()
+    print(f" Event (URI):    {nevent_uri}")
+
+    # bech32 nevent
+    nevent_parse = Nip21.parse(nevent_uri)
+    if nevent_parse.as_enum().is_event():
+        nevent_bech32 = Nip19Event.from_nostr_uri(nevent_uri).to_bech32()
+        print(f" Event (bech32): {nevent_bech32}")
+    # ANCHOR_END: nip21-nevent
+
+    print()
+
+    # ANCHOR: nip21-naddr
+    coord = Coordinate(Kind(0),keys.public_key())
+
+    # URI naddr
+    coord_uri = coord.to_nostr_uri()
+    print(f" Coordinate (URI):    {coord_uri}")
+
+    # bech32 naddr
+    coord_parse = Nip21.parse(coord_uri)
+    if coord_parse.as_enum().is_coord():
+        coord_bech32 = Coordinate.from_nostr_uri(coord_uri).to_bech32()
+        print(f" Coordinate (bech32): {coord_bech32}")
+    # ANCHOR_END: nip21-naddr

--- a/book/src/nostr/06-nip05.md
+++ b/book/src/nostr/06-nip05.md
@@ -17,7 +17,7 @@ TODO
 <div slot="title">Python</div>
 <section>
 
-Using the `Metadata` class to build the metadata object and incorporate the NIP-05 identifier with the `set_nip05()` function. 
+Using the `Metadata` class to build the metadata object and incorporate the NIP-05 identifier with the `set_nip05()` method. 
 
 For more details on metadata (or general) events please refer back to the [examples](06-nip01.md) provided for NIP-01.
 

--- a/book/src/nostr/06-nip06.md
+++ b/book/src/nostr/06-nip06.md
@@ -20,7 +20,7 @@ TODO
 <div slot="title">Python</div>
 <section>
 
-Using the `from_mnemonic()` function in conjunction with the `Keys` class to derived a basic set of Nostr keys from a 24 word seed phrase.
+Using the `from_mnemonic()` method in conjunction with the `Keys` class to derived a basic set of Nostr keys from a 24 word seed phrase.
 
 Note that this example uses the `Mnemonic` class from the [python-mnemonic](https://github.com/trezor/python-mnemonic) package (the reference implementation of BIP-39) to randomly generate example seed phrases.
 
@@ -34,7 +34,7 @@ As well as deriving basic keys from a 24 word seed we can also use seed phrases 
 {{#include ../../snippets/nostr/python/src/nip06.py:keys-from-seed12}}
 ```
 
-Advanced key derivation functionality (for accounts) can be accessed by the `from_mnemonic_with_account()` function. To do this we use the `account` argument which accepts an integer to specify the derivation path.
+Advanced key derivation functionality (for accounts) can be accessed by the `from_mnemonic_with_account()` method. To do this we use the `account` argument which accepts an integer to specify the derivation path.
 
 ```python,ignore
 {{#include ../../snippets/nostr/python/src/nip06.py:keys-from-seed-accounts}}

--- a/book/src/nostr/06-nip19.md
+++ b/book/src/nostr/06-nip19.md
@@ -23,7 +23,7 @@ TODO
 <div slot="title">Python</div>
 <section>
 
-For most of these examples you will see that the `to_bech32()` and `from_bech32()` functions generally facilitate encoding or decoding objects per the NIP-19 standard.
+For most of these examples you will see that the `to_bech32()` and `from_bech32()` methods generally facilitate encoding or decoding objects per the NIP-19 standard.
 
 Public and Private (or secret) keys in `npub` and `nsec` formats.
 

--- a/book/src/nostr/06-nip21.md
+++ b/book/src/nostr/06-nip21.md
@@ -1,1 +1,77 @@
-# NIP-21
+## NIP-21
+
+This NIP is intended to extend the interoperability of the network be defining the URI scheme for Nostr as `nostr:`. This prefix is then followed by identifiers as specified in NIP-19 (with the exclusion of `nsec`). For more information on the bech32 encoding used for NIP-19 please refer to the ealier [examples](06-nip19.md).
+
+The [nip21 module](https://docs.rs/nostr/latest/nostr/nips/nip21/index.html) and associated `NostrURI` trait can be used to handle data encoded with this format.
+
+### URI Scheme (NIP-21)
+
+<custom-tabs category="lang">
+
+<div slot="title">Rust</div>
+<section>
+
+TODO
+
+</section>
+
+<div slot="title">Python</div>
+<section>
+
+Generally speaking the simplest way for handling NIP-21 objects is by the `to_nostr_uri()` and `from_nostr_uri()` methods for encoding or decoding data, respectively. 
+
+Additionally, if it is unclear what type of Nip21 object we're handling then the `Nip21` class, in conjunction with the `parse()` and `as_enum()` methods, can be used to parse these objects without knowing ahead of what they are.
+
+Public key example.
+
+```python,ignore
+{{#include ../../snippets/nostr/python/src/nip19.py:nip21-npub}}
+```
+
+Note example.
+
+```python,ignore
+{{#include ../../snippets/nostr/python/src/nip19.py:nip21-note}}
+```
+
+Profile identifier example.
+
+```python,ignore
+{{#include ../../snippets/nostr/python/src/nip19.py:nip21-nprofile}}
+```
+
+Event identifier example.
+
+```python,ignore
+{{#include ../../snippets/nostr/python/src/nip19.py:nip21-nevent}}
+```
+
+Coordinate identifier example.
+
+```python,ignore
+{{#include ../../snippets/nostr/python/src/nip19.py:nip21-naddr}}
+```
+
+</section>
+
+<div slot="title">JavaScript</div>
+<section>
+
+TODO
+
+</section>
+
+<div slot="title">Kotlin</div>
+<section>
+
+TODO
+
+</section>
+
+<div slot="title">Swift</div>
+<section>
+
+TODO
+
+</section>
+</custom-tabs>


### PR DESCRIPTION
### Description

Updates and additions:
- Added nip-21 python examples (including: npub, note, nprofile, nevent, naddr)
- Removed unnecessary class import reference in nip19.py
- Corrected terminology for book where "function" was used instead of "method".

### Notes to the reviewers

Almost at the end of the first batch, will continue to work through any other examples that still need to be done on the python side then may take a run at some other languages.

### Checklist

* [x] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [x] I ran `just precommit` or `just check` before committing
* [ ] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
