### PR TITLE
book: add NIP-65 python example

### DIFF
--- a/book/snippets/nostr/python/main.py
+++ b/book/snippets/nostr/python/main.py
@@ -10,6 +10,7 @@ from src.nip19 import nip19
 from src.nip21 import nip21
 from src.nip44 import nip44
 from src.nip59 import nip59
+from src.nip65 import nip65
 
 
 def main():
@@ -25,6 +26,7 @@ def main():
     nip21()
     nip44()
     nip59()
+    nip65()
 
 
 main()

--- a/book/snippets/nostr/python/src/nip65.py
+++ b/book/snippets/nostr/python/src/nip65.py
@@ -1,0 +1,24 @@
+from nostr_protocol import EventBuilder, Tag, Kind, Keys, RelayMetadata
+
+def nip65():
+    # Get Keys
+    keys = Keys.generate()
+
+    print()
+    print("Relay Metadata:")
+    # ANCHOR: relay-metadata
+    # Create relay metadata tags
+    tag1 = Tag.relay_metadata("wss://relay.damus.io", RelayMetadata.READ)
+    tag2 = Tag.relay_metadata("wss://relay.primal.net", RelayMetadata.WRITE)
+    tag3 = Tag.relay_metadata("wss://relay.nostr.band", None)
+
+    # Build/sign event
+    kind = Kind(10002)
+    content = ""
+    tags = [tag1,tag2,tag3]
+    builder = EventBuilder(kind,content,tags)
+    event = builder.to_event(keys)
+
+    # Print event as json
+    print(f" Event: {event.as_json()}")
+    # ANCHOR_END: relay-metadata

--- a/book/snippets/nostr/python/src/nip65.py
+++ b/book/snippets/nostr/python/src/nip65.py
@@ -6,7 +6,25 @@ def nip65():
 
     print()
     print("Relay Metadata:")
-    # ANCHOR: relay-metadata
+    # ANCHOR: relay-metadata-simple
+    # Create relay dictionary
+    relays_dict = {
+        "wss://relay.damus.io": RelayMetadata.READ,
+        "wss://relay.primal.net": RelayMetadata.WRITE,
+        "wss://relay.nostr.band": None
+    }
+    
+    # Build/sign event
+    builder = EventBuilder.relay_list(relays_dict)
+    event = builder.to_event(keys)
+
+    # Print event as json
+    print(f" Event: {event.as_json()}")
+    # ANCHOR_END: relay-metadata-simple
+
+    print()
+
+    # ANCHOR: relay-metadata-custom
     # Create relay metadata tags
     tag1 = Tag.relay_metadata("wss://relay.damus.io", RelayMetadata.READ)
     tag2 = Tag.relay_metadata("wss://relay.primal.net", RelayMetadata.WRITE)
@@ -21,4 +39,4 @@ def nip65():
 
     # Print event as json
     print(f" Event: {event.as_json()}")
-    # ANCHOR_END: relay-metadata
+    # ANCHOR_END: relay-metadata-custom

--- a/book/src/nostr/06-nip65.md
+++ b/book/src/nostr/06-nip65.md
@@ -1,6 +1,6 @@
 ## NIP-65
 
-The [Tag](https://docs.rs/nostr/latest/nostr/event/tag/struct.Tag.html) struct, in conjunction with the `relay_metadata()` function, can be used to construct NIP-65 compliant events (`kind:10002`) designed to advertise user's preferred relays from which content can be retrived and/or published.
+Either the [Event Builder](https://docs.rs/nostr/latest/nostr/event/builder/struct.EventBuilder.html) struct and associated `relay_list()` function, or, the [Tag](https://docs.rs/nostr/latest/nostr/event/tag/struct.Tag.html) struct and associated `relay_metadata()` function, can be used to construct NIP-65 compliant events (`kind:10002`), which are designed to advertise user's preferred relays from which content can be retrieved and/or published.
 
 ### Relay List Metadata (NIP-65)
 
@@ -16,12 +16,18 @@ TODO
 <div slot="title">Python</div>
 <section>
 
-The `Tag` class is instantiated and the `relay_metadata()` method is user to create tags for inclusion in the `kind:10002` event. The details of the tags are set as URL for the relay and, the READ/WRITE value is set using the `RelayMetadata` class. 
+The simpleist way to create relay metadata events is via the `relay_list()` method and `EventBuilder` class. To do this we pass the method a dictionary containing the relay URL (key) and READ/WRITE (value), which is set using the `RelayMetadata` class.
 
 Note that the where no read or write value is specified (e.g. `None`), these should be handled as both read and write by clients (as indicated in the NIP-65 specification).
 
 ```python,ignore
-{{#include ../../snippets/nostr/python/src/nip65.py:relay-metadata}}
+{{#include ../../snippets/nostr/python/src/nip65.py:relay-metadata-simple}}
+```
+
+As an alternative approach, the `Tag` class and `relay_metadata()` method can be used to create individual tag objects for inclusion in a purpose built `kind:10002` event. 
+
+```python,ignore
+{{#include ../../snippets/nostr/python/src/nip65.py:relay-metadata-custom}}
 ```
 
 </section>

--- a/book/src/nostr/06-nip65.md
+++ b/book/src/nostr/06-nip65.md
@@ -1,1 +1,49 @@
-# NIP-65
+## NIP-65
+
+The [Tag](https://docs.rs/nostr/latest/nostr/event/tag/struct.Tag.html) struct, in conjunction with the `relay_metadata()` function, can be used to construct NIP-65 compliant events (`kind:10002`) designed to advertise user's preferred relays from which content can be retrived and/or published.
+
+### Relay List Metadata (NIP-65)
+
+<custom-tabs category="lang">
+
+<div slot="title">Rust</div>
+<section>
+
+TODO
+
+</section>
+
+<div slot="title">Python</div>
+<section>
+
+The `Tag` class is instantiated and the `relay_metadata()` method is user to create tags for inclusion in the `kind:10002` event. The details of the tags are set as URL for the relay and, the READ/WRITE value is set using the `RelayMetadata` class. 
+
+Note that the where no read or write value is specified (e.g. `None`), these should be handled as both read and write by clients (as indicated in the NIP-65 specification).
+
+```python,ignore
+{{#include ../../snippets/nostr/python/src/nip65.py:relay-metadata}}
+```
+
+</section>
+
+<div slot="title">JavaScript</div>
+<section>
+
+TODO
+
+</section>
+
+<div slot="title">Kotlin</div>
+<section>
+
+TODO
+
+</section>
+
+<div slot="title">Swift</div>
+<section>
+
+TODO
+
+</section>
+</custom-tabs>


### PR DESCRIPTION
### Description

Added short python example of a NIP-65 Relay Metadata event.

### Notes to the reviewers

N/A

### Checklist

* [x] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [x] I ran `just precommit` or `just check` before committing
* [ ] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
