### PR TITLE
pool: use per-purpose dedicated relay channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@
 
 ### Changed
 
-* ffi(sdk): convert `RelayPool::handle_notifications` method to async/future
+* pool: use per-purpose dedicated relay channels ([Yuki Kishimoto])
+* ffi(sdk): convert `RelayPool::handle_notifications` method to async/future ([Yuki Kishimoto])
 
 ### Added
 

--- a/crates/nostr-relay-pool/src/relay/error.rs
+++ b/crates/nostr-relay-pool/src/relay/error.rs
@@ -41,6 +41,12 @@ pub enum Error {
     /// Generic timeout
     #[error("timeout")]
     Timeout,
+    /// Message response timeout
+    #[error("Can't send message to the '{channel}' channel")]
+    CantSendChannelMessage {
+        /// Name of channel
+        channel: String,
+    },
     /// Message not sent
     #[error("message not sent")]
     MessageNotSent,


### PR DESCRIPTION
Add per-purpose dedicated relay channels: 1 for `nostr` messages, 1 for `ping/pong` and 1 for `shutdown/stop`.