### PR TITLE
 chore: Bump base64 dependency to version 0.22.1 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,6 +274,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1608,7 +1614,7 @@ name = "nostr"
 version = "0.32.0"
 dependencies = [
  "aes",
- "base64",
+ "base64 0.22.1",
  "bip39",
  "bitcoin",
  "cbc",
@@ -1717,7 +1723,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39c8647a2c4202362420b59e7a3b52f6c541446ab6c5b28fd9fae22bc7d75a7"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bitcoin_hashes 0.12.0",
  "opentimestamps",
  "thiserror",
@@ -2240,7 +2246,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d66674f2b6fb864665eea7a3c1ac4e3dfacd2fda83cf6f935a612e01b0e3338"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bytes",
  "futures-core",
  "futures-util",
@@ -2394,7 +2400,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64",
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -3225,7 +3231,7 @@ version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8cdd25c339e200129fe4de81451814e5228c9b771d57378817d6117cc2b3f97"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "flate2",
  "log",
  "once_cell",

--- a/crates/nostr/Cargo.toml
+++ b/crates/nostr/Cargo.toml
@@ -46,12 +46,29 @@ alloc = [
     "serde/alloc",
     "serde_json/alloc",
 ]
-all-nips = ["nip04", "nip05", "nip06", "nip07", "nip11", "nip44", "nip46", "nip47", "nip49", "nip57", "nip59"]
+all-nips = [
+    "nip04",
+    "nip05",
+    "nip06",
+    "nip07",
+    "nip11",
+    "nip44",
+    "nip46",
+    "nip47",
+    "nip49",
+    "nip57",
+    "nip59",
+]
 nip03 = ["dep:nostr-ots"]
 nip04 = ["dep:aes", "dep:base64", "dep:cbc"]
 nip05 = ["dep:reqwest"]
 nip06 = ["dep:bip39"]
-nip07 = ["dep:js-sys", "dep:wasm-bindgen", "dep:wasm-bindgen-futures", "dep:web-sys"]
+nip07 = [
+    "dep:js-sys",
+    "dep:wasm-bindgen",
+    "dep:wasm-bindgen-futures",
+    "dep:web-sys",
+]
 nip11 = ["dep:reqwest"]
 nip44 = ["dep:base64", "dep:chacha20"]
 nip46 = ["nip04", "nip44"]
@@ -62,23 +79,36 @@ nip59 = ["nip44"]
 
 [dependencies]
 aes = { version = "0.8", optional = true }
-base64 = { version = "0.21", default-features = false, optional = true }
+base64 = { version = "0.22.1", default-features = false, optional = true }
 bip39 = { version = "2.0", default-features = false, optional = true }
-bitcoin = { version = "0.31", default-features = false, features = ["rand", "serde"] }
+bitcoin = { version = "0.31", default-features = false, features = [
+    "rand",
+    "serde",
+] }
 cbc = { version = "0.1", optional = true }
 chacha20 = { version = "0.9", optional = true }
-chacha20poly1305 = { version = "0.10", default-features = false, features = ["getrandom"], optional = true }
+chacha20poly1305 = { version = "0.10", default-features = false, features = [
+    "getrandom",
+], optional = true }
 negentropy = { version = "0.3", default-features = false }
 nostr-ots = { version = "0.2", optional = true }
 once_cell.workspace = true
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "socks"], optional = true }
+reqwest = { version = "0.12", default-features = false, features = [
+    "json",
+    "rustls-tls",
+    "socks",
+], optional = true }
 scrypt = { version = "0.11", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json.workspace = true
 tracing.workspace = true
 unicode-normalization = { version = "0.1", default-features = false, optional = true }
-url = { version = "2.5", default-features = false, features = ["serde"], optional = true } # Used in std
-url-fork = { version = "3.0", default-features = false, features = ["serde"], optional = true } # Used for no_std
+url = { version = "2.5", default-features = false, features = [
+    "serde",
+], optional = true } # Used in std
+url-fork = { version = "3.0", default-features = false, features = [
+    "serde",
+], optional = true } # Used for no_std
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Checklist

* [x] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [ ] I ran `just precommit` or `just check` before committing
* [ ] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
