### PR TITLE
NIP-47 - Handle null expires_at

### DIFF
--- a/bindings/nostr-ffi/src/nips/nip47.rs
+++ b/bindings/nostr-ffi/src/nips/nip47.rs
@@ -653,7 +653,7 @@ pub struct LookupInvoiceResponseResult {
     /// Creation timestamp in seconds since epoch
     pub created_at: Arc<Timestamp>,
     /// Expiration timestamp in seconds since epoch
-    pub expires_at: Arc<Timestamp>,
+    pub expires_at: Option<Arc<Timestamp>>,
     /// Settled timestamp in seconds since epoch
     pub settled_at: Option<Arc<Timestamp>>,
     /// Optional metadata about the payment
@@ -672,7 +672,7 @@ impl From<nip47::LookupInvoiceResponseResult> for LookupInvoiceResponseResult {
             amount: value.amount,
             fees_paid: value.fees_paid,
             created_at: Arc::new(value.created_at.into()),
-            expires_at: Arc::new(value.expires_at.into()),
+            expires_at: value.expires_at.map(|t| Arc::new(t.into())),
             settled_at: value.settled_at.map(|t| Arc::new(t.into())),
             metadata: value.metadata.and_then(|m| m.try_into().ok()),
         }
@@ -691,7 +691,7 @@ impl From<LookupInvoiceResponseResult> for nip47::LookupInvoiceResponseResult {
             amount: value.amount,
             fees_paid: value.fees_paid,
             created_at: **value.created_at,
-            expires_at: **value.expires_at,
+            expires_at: value.expires_at.map(|t| **t),
             settled_at: value.settled_at.map(|t| **t),
             metadata: value.metadata.and_then(|m| m.try_into().ok()),
         }

--- a/crates/nostr/src/nips/nip47.rs
+++ b/crates/nostr/src/nips/nip47.rs
@@ -586,7 +586,8 @@ pub struct LookupInvoiceResponseResult {
     /// Creation timestamp in seconds since epoch
     pub created_at: Timestamp,
     /// Expiration timestamp in seconds since epoch
-    pub expires_at: Timestamp,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<Timestamp>,
     /// Settled timestamp in seconds since epoch
     #[serde(skip_serializing_if = "Option::is_none")]
     pub settled_at: Option<Timestamp>,
@@ -1101,7 +1102,7 @@ mod tests {
                     amount: 123,
                     fees_paid: 1,
                     created_at: Timestamp::from(123456),
-                    expires_at: Timestamp::from(1234567),
+                    expires_at: Some(Timestamp::from(1234567)),
                     description_hash: None,
                     payment_hash: String::new(),
                     metadata: None,


### PR DESCRIPTION
### Description
Fixes a bug where the response was not handling a `null` value in the response to the `list_transactions` NWC method.

### Notes to the reviewers

Feel free to close this, I am new to Rust, so not sure if this is the right way to fix this issue or not, but hopefully it is helpful :).

Note the `just precommit` command failed with `error: failed to run custom build command for secp256k1-sys v0.9.2`, not sure if that is due to my machine or not.

### Checklist

* [x] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [x] I ran `just precommit` or `just check` before committing
* [ ] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
