### PR TITLE
Rework `get_events_of` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@
 * database: set a default logic for `NostrDatabase::negentropy_items` ([Yuki Kishimoto])
 * sdk: rename `Proxy` and `ProxyTarget` to `Connection` and `ConnectionTarget` ([Yuki Kishimoto])
 * sdk: allow to skip slow relays ([Yuki Kishimoto])
+* sdk: allow to specify the source of events for `Client::get_events_of` method ([Yuki Kishimoto])
+* sdk: deprecate `Client::get_events_of_with_opts` ([Yuki Kishimoto])
 * sqlite: use `ValueRef` instead of owned one ([Yuki Kishimoto])
 * cli: improve `sync` command ([Yuki Kishimoto])
 * cli: allow to specify relays in `open` command ([Yuki Kishimoto])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 * pool: remove IDs collection from `InternalRelayPool::get_events_from` ([Yuki Kishimoto])
 * pool: better checks before perform queries or send messages to relays ([Yuki Kishimoto])
 * pool: bump `async-wsocket` to `v0.6` ([Yuki Kishimoto])
+* pool: get events only from remote relay when calling `get_events_of` or `get_events_from` ([Yuki Kishimoto])
 * database: not match event if `Filter::search` field is set ([Yuki Kishimoto])
 * database: avoid to copy `EventId` in `Event::decode` ([Yuki Kishimoto])
 * database: use `Vec` instead of `BTreeSet` as inner value for `TagIndexValues` ([Yuki Kishimoto])

--- a/bindings/nostr-sdk-ffi/bindings-python/README.md
+++ b/bindings/nostr-sdk-ffi/bindings-python/README.md
@@ -19,8 +19,7 @@ pip install nostr-sdk
 ```python
 import asyncio
 from datetime import timedelta
-from nostr_sdk import Keys, Client, NostrSigner, EventBuilder, Filter, Metadata, Nip46Signer, init_logger, LogLevel
-import time
+from nostr_sdk import Keys, Client, NostrSigner, EventBuilder, Filter, Metadata, EventSource, init_logger, LogLevel
 
 
 async def main():
@@ -65,7 +64,8 @@ async def main():
     # Get events from relays
     print("Getting events from relays...")
     f = Filter().authors([keys.public_key(), custom_keys.public_key()])
-    events = await client.get_events_of([f], timedelta(seconds=10))
+    source = EventSource.relays(timedelta(seconds=10))
+    events = await client.get_events_of([f], source)
     for event in events:
         print(event.as_json())
 

--- a/bindings/nostr-sdk-ffi/bindings-python/examples/blacklist.py
+++ b/bindings/nostr-sdk-ffi/bindings-python/examples/blacklist.py
@@ -1,5 +1,5 @@
 import asyncio
-from nostr_sdk import PublicKey, Client, Filter, Kind, init_logger, LogLevel
+from nostr_sdk import PublicKey, Client, Filter, Kind, init_logger, LogLevel, EventSource
 from datetime import timedelta
 
 
@@ -20,7 +20,8 @@ async def main():
 
     # Get events
     f = Filter().authors([muted_public_key, other_public_key]).kind(Kind(0))
-    events = await client.get_events_of([f], timedelta(seconds=10))
+    source = EventSource.relays(timedelta(seconds=10))
+    events = await client.get_events_of([f], source)
     print(f"Received {events.__len__()} events")
 
 

--- a/bindings/nostr-sdk-ffi/bindings-python/examples/client.py
+++ b/bindings/nostr-sdk-ffi/bindings-python/examples/client.py
@@ -1,7 +1,6 @@
 import asyncio
 from datetime import timedelta
-from nostr_sdk import Keys, Client, NostrSigner, EventBuilder, Filter, Metadata, Nip46Signer, init_logger, LogLevel
-import time
+from nostr_sdk import Keys, Client, NostrSigner, EventBuilder, Filter, Metadata, EventSource, init_logger, LogLevel
 
 
 async def main():
@@ -48,7 +47,8 @@ async def main():
     # Get events from relays
     print("Getting events from relays...")
     f = Filter().authors([keys.public_key(), custom_keys.public_key()])
-    events = await client.get_events_of([f], timedelta(seconds=10))
+    source = EventSource.relays(timedelta(seconds=10))
+    events = await client.get_events_of([f], source)
     for event in events:
         print(event.as_json())
 

--- a/bindings/nostr-sdk-ffi/bindings-python/examples/metadata.py
+++ b/bindings/nostr-sdk-ffi/bindings-python/examples/metadata.py
@@ -1,5 +1,5 @@
 import asyncio
-from nostr_sdk import Metadata, Client, NostrSigner, Keys, Filter, PublicKey, Kind
+from nostr_sdk import Metadata, Client, NostrSigner, Keys, Filter, PublicKey, Kind, EventSource
 from datetime import timedelta
 
 
@@ -30,7 +30,8 @@ async def main():
     pk = PublicKey.from_bech32("npub1drvpzev3syqt0kjrls50050uzf25gehpz9vgdw08hvex7e0vgfeq0eseet")
     print(f"\nGetting profile metadata for {pk.to_bech32()}...")
     f = Filter().kind(Kind(0)).author(pk).limit(1)
-    events = await client.get_events_of([f], timedelta(seconds=10))
+    source = EventSource.relays(timedelta(seconds=10))
+    events = await client.get_events_of([f], source)
     for event in events:
         metadata = Metadata.from_json(event.content())
         print(f"Name: {metadata.get_name()}")

--- a/bindings/nostr-sdk-ffi/src/client/mod.rs
+++ b/bindings/nostr-sdk-ffi/src/client/mod.rs
@@ -23,7 +23,7 @@ pub mod signer;
 pub mod zapper;
 
 pub use self::builder::ClientBuilder;
-pub use self::options::Options;
+pub use self::options::{EventSource, Options};
 pub use self::signer::NostrSigner;
 use self::zapper::{ZapDetails, ZapEntity};
 use crate::error::Result;
@@ -356,7 +356,7 @@ impl Client {
     pub async fn get_events_of(
         &self,
         filters: Vec<Arc<Filter>>,
-        timeout: Option<Duration>,
+        source: &EventSource,
     ) -> Result<Vec<Arc<Event>>> {
         let filters = filters
             .into_iter()
@@ -365,7 +365,7 @@ impl Client {
 
         Ok(self
             .inner
-            .get_events_of(filters, timeout)
+            .get_events_of(filters, source.deref().clone())
             .await?
             .into_iter()
             .map(|e| Arc::new(e.into()))

--- a/bindings/nostr-sdk-ffi/src/client/mod.rs
+++ b/bindings/nostr-sdk-ffi/src/client/mod.rs
@@ -373,8 +373,6 @@ impl Client {
     }
 
     /// Get events of filters from specific relays
-    ///
-    /// Get events both from **local database** and **relays**
     pub async fn get_events_from(
         &self,
         urls: Vec<String>,

--- a/bindings/nostr-sdk-ffi/src/client/options.rs
+++ b/bindings/nostr-sdk-ffi/src/client/options.rs
@@ -215,3 +215,59 @@ impl Connection {
         builder
     }
 }
+
+#[derive(Object)]
+pub struct EventSource {
+    inner: nostr_sdk::EventSource,
+}
+
+impl Deref for EventSource {
+    type Target = nostr_sdk::EventSource;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+#[uniffi::export]
+impl EventSource {
+    /// Database only
+    #[uniffi::constructor]
+    pub fn database() -> Self {
+        Self {
+            inner: nostr_sdk::EventSource::Database,
+        }
+    }
+
+    /// Relays only
+    #[uniffi::constructor(default(timeout = None))]
+    pub fn relays(timeout: Option<Duration>) -> Self {
+        Self {
+            inner: nostr_sdk::EventSource::relays(timeout),
+        }
+    }
+
+    /// From specific relays only
+    #[uniffi::constructor(default(timeout = None))]
+    pub fn specific_relays(urls: Vec<String>, timeout: Option<Duration>) -> Self {
+        Self {
+            inner: nostr_sdk::EventSource::specific_relays(urls, timeout),
+        }
+    }
+
+    /// Both from database and relays
+    #[uniffi::constructor(default(timeout = None))]
+    pub fn both(timeout: Option<Duration>) -> Self {
+        Self {
+            inner: nostr_sdk::EventSource::both(timeout),
+        }
+    }
+
+    /// Both from database and specific relays
+    #[uniffi::constructor(default(timeout = None))]
+    pub fn both_with_specific_relays(urls: Vec<String>, timeout: Option<Duration>) -> Self {
+        Self {
+            inner: nostr_sdk::EventSource::both_with_specific_relays(urls, timeout),
+        }
+    }
+}

--- a/bindings/nostr-sdk-ffi/src/pool/mod.rs
+++ b/bindings/nostr-sdk-ffi/src/pool/mod.rs
@@ -353,8 +353,6 @@ impl RelayPool {
     }
 
     /// Get events of filters
-    ///
-    /// Get events both from **local database** and **relays**
     pub async fn get_events_of(
         &self,
         filters: Vec<Arc<Filter>>,
@@ -375,8 +373,6 @@ impl RelayPool {
     }
 
     /// Get events of filters from **specific relays**
-    ///
-    /// Get events both from **local database** and **relays**
     pub async fn get_events_from(
         &self,
         urls: Vec<String>,

--- a/bindings/nostr-sdk-ffi/src/relay/mod.rs
+++ b/bindings/nostr-sdk-ffi/src/relay/mod.rs
@@ -333,8 +333,6 @@ impl Relay {
     }
 
     /// Get events of filters
-    ///
-    /// Get events from local database and relay
     pub async fn get_events_of(
         &self,
         filters: Vec<Arc<Filter>>,

--- a/bindings/nostr-sdk-js/examples/get-events-of.js
+++ b/bindings/nostr-sdk-js/examples/get-events-of.js
@@ -1,4 +1,4 @@
-const { Keys, Client, Filter, loadWasmAsync, Timestamp, Duration } = require("../");
+const { Keys, Client, Filter, loadWasmAsync, Timestamp, Duration, EventSource } = require("../");
 
 async function main() {
     await loadWasmAsync();
@@ -14,7 +14,8 @@ async function main() {
     const filter = new Filter().author(keys.publicKey).kind(4).until(Timestamp.now()).limit(10);
     console.log('filter', filter.asJson());
 
-    let events = await client.getEventsOf([filter], Duration.fromSecs(10));
+    let source = EventSource.relays(Duration.fromSecs(10));
+    let events = await client.getEventsOf([filter], source);
     events.forEach((e) => {
         console.log(e.asJson())
     })

--- a/bindings/nostr-sdk-js/src/client/mod.rs
+++ b/bindings/nostr-sdk-js/src/client/mod.rs
@@ -22,7 +22,7 @@ pub mod signer;
 pub mod zapper;
 
 pub use self::builder::JsClientBuilder;
-use self::options::JsOptions;
+use self::options::{JsEventSource, JsOptions};
 pub use self::signer::JsNostrSigner;
 use self::zapper::{JsZapDetails, JsZapEntity};
 use crate::abortable::JsAbortHandle;
@@ -340,13 +340,12 @@ impl JsClient {
     pub async fn get_events_of(
         &self,
         filters: Vec<JsFilter>,
-        timeout: Option<JsDuration>,
+        source: &JsEventSource,
     ) -> Result<JsEventArray> {
         let filters: Vec<Filter> = filters.into_iter().map(|f| f.into()).collect();
-        let timeout: Option<Duration> = timeout.map(|d| *d);
         let events: Vec<Event> = self
             .inner
-            .get_events_of(filters, timeout)
+            .get_events_of(filters, source.deref().clone())
             .await
             .map_err(into_err)?;
         let events: JsEventArray = events

--- a/bindings/nostr-sdk-js/src/client/mod.rs
+++ b/bindings/nostr-sdk-js/src/client/mod.rs
@@ -361,8 +361,6 @@ impl JsClient {
     }
 
     /// Get events of filters from specific relays
-    ///
-    /// Get events both from **local database** and **relays**
     #[wasm_bindgen(js_name = getEventsFrom)]
     pub async fn get_events_from(
         &self,

--- a/bindings/nostr-sdk-js/src/client/options.rs
+++ b/bindings/nostr-sdk-js/src/client/options.rs
@@ -4,7 +4,7 @@
 
 use std::ops::Deref;
 
-use nostr_sdk::Options;
+use nostr_sdk::prelude::*;
 use wasm_bindgen::prelude::*;
 
 use crate::duration::JsDuration;
@@ -108,5 +108,58 @@ impl JsOptions {
     #[wasm_bindgen(js_name = relayLimits)]
     pub fn relay_limits(self, limits: &JsRelayLimits) -> Self {
         self.inner.relay_limits(limits.deref().clone()).into()
+    }
+}
+
+#[wasm_bindgen(js_name = EventSource)]
+pub struct JsEventSource {
+    inner: EventSource,
+}
+
+impl Deref for JsEventSource {
+    type Target = EventSource;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+#[wasm_bindgen(js_class = EventSource)]
+impl JsEventSource {
+    /// Database only
+    pub fn database() -> Self {
+        Self {
+            inner: nostr_sdk::EventSource::Database,
+        }
+    }
+
+    /// Relays only
+    pub fn relays(timeout: Option<JsDuration>) -> Self {
+        Self {
+            inner: nostr_sdk::EventSource::relays(timeout.map(|t| *t)),
+        }
+    }
+
+    /// From specific relays only
+    #[wasm_bindgen(js_name = specificRelays)]
+    pub fn specific_relays(urls: Vec<String>, timeout: Option<JsDuration>) -> Self {
+        Self {
+            inner: nostr_sdk::EventSource::specific_relays(urls, timeout.map(|t| *t)),
+        }
+    }
+
+    /// Both from database and relays
+    pub fn both(timeout: Option<JsDuration>) -> Self {
+        Self {
+            inner: nostr_sdk::EventSource::both(timeout.map(|t| *t)),
+        }
+    }
+
+    /// Both from database and specific relays
+    #[wasm_bindgen(js_name = bothWithSpecificRelays)]
+    pub fn both_with_specific_relays(urls: Vec<String>, timeout: Option<JsDuration>) -> Self {
+        Self {
+            inner: nostr_sdk::EventSource::both_with_specific_relays(urls, timeout.map(|t| *t)),
+        }
     }
 }

--- a/bindings/nostr-sdk-js/src/pool/mod.rs
+++ b/bindings/nostr-sdk-js/src/pool/mod.rs
@@ -387,8 +387,6 @@ impl JsRelayPool {
     }
 
     // /// Get events of filters
-    // ///
-    // /// Get events both from **local database** and **relays**
     // #[wasm_bindgen(js_name = getEventsOf)]
     // pub async fn get_events_of(
     //     &self,
@@ -410,8 +408,6 @@ impl JsRelayPool {
     // }
     //
     // /// Get events of filters from **specific relays**
-    // ///
-    // /// Get events both from **local database** and **relays**
     // #[wasm_bindgen(js_name = getEventsFrom)]
     // pub async fn get_events_from(
     //     &self,

--- a/bindings/nostr-sdk-js/src/relay/mod.rs
+++ b/bindings/nostr-sdk-js/src/relay/mod.rs
@@ -262,8 +262,6 @@ impl JsRelay {
     }
 
     /// Get events of filters
-    ///
-    /// Get events from local database and relay
     #[wasm_bindgen(js_name = getEventsOf)]
     pub async fn get_events_of(
         &self,

--- a/crates/nostr-relay-pool/src/pool/internal.rs
+++ b/crates/nostr-relay-pool/src/pool/internal.rs
@@ -14,7 +14,7 @@ use async_utility::thread::JoinHandle;
 use async_utility::{thread, time};
 use atomic_destructor::AtomicDestroyer;
 use nostr::{ClientMessage, Event, EventId, Filter, SubscriptionId, Timestamp, TryIntoUrl, Url};
-use nostr_database::{DynNostrDatabase, IntoNostrDatabase, Order};
+use nostr_database::{DynNostrDatabase, IntoNostrDatabase};
 use tokio::sync::{broadcast, mpsc, Mutex, RwLock};
 use tokio_stream::wrappers::ReceiverStream;
 
@@ -632,15 +632,8 @@ impl InternalRelayPool {
                 return Err(Error::RelayNotFound);
             }
 
-            let stored_events: Vec<Event> = self
-                .database
-                .query(filters.clone(), Order::Desc)
-                .await
-                .unwrap_or_default();
-
             // Compose events collections
-            let events: Arc<Mutex<BTreeSet<Event>>> =
-                Arc::new(Mutex::new(stored_events.into_iter().collect()));
+            let events: Arc<Mutex<BTreeSet<Event>>> = Arc::new(Mutex::new(BTreeSet::new()));
 
             // Filter relays and start query
             let mut handles = Vec::with_capacity(urls.len());

--- a/crates/nostr-relay-pool/src/pool/mod.rs
+++ b/crates/nostr-relay-pool/src/pool/mod.rs
@@ -423,8 +423,6 @@ impl RelayPool {
     }
 
     /// Get events of filters
-    ///
-    /// Get events both from **local database** and **relays**
     #[inline]
     pub async fn get_events_of(
         &self,
@@ -438,8 +436,6 @@ impl RelayPool {
     }
 
     /// Get events of filters from **specific relays**
-    ///
-    /// Get events both from **local database** and **relays**
     #[inline]
     pub async fn get_events_from<I, U>(
         &self,

--- a/crates/nostr-relay-pool/src/relay/mod.rs
+++ b/crates/nostr-relay-pool/src/relay/mod.rs
@@ -377,8 +377,6 @@ impl Relay {
     }
 
     /// Get events of filters
-    ///
-    /// Get events from local database and relay
     #[inline]
     pub async fn get_events_of(
         &self,

--- a/crates/nostr-sdk/examples/blacklist.rs
+++ b/crates/nostr-sdk/examples/blacklist.rs
@@ -27,7 +27,10 @@ async fn main() -> Result<()> {
         .authors([muted_public_key, public_key])
         .kind(Kind::Metadata);
     let events = client
-        .get_events_of(vec![filter], Some(Duration::from_secs(10)))
+        .get_events_of(
+            vec![filter],
+            EventSource::relays(Some(Duration::from_secs(10))),
+        )
         .await?;
     println!("Received {} events.", events.len());
 

--- a/crates/nostr-sdk/examples/get-events-of.rs
+++ b/crates/nostr-sdk/examples/get-events-of.rs
@@ -22,7 +22,10 @@ async fn main() -> Result<()> {
     // Get events from all connected relays
     let filter = Filter::new().author(public_key).kind(Kind::Metadata);
     let events = client
-        .get_events_of(vec![filter], Some(Duration::from_secs(10)))
+        .get_events_of(
+            vec![filter],
+            EventSource::relays(Some(Duration::from_secs(10))),
+        )
         .await?;
     println!("{events:#?}");
 

--- a/crates/nostr-sdk/examples/nip65.rs
+++ b/crates/nostr-sdk/examples/nip65.rs
@@ -19,7 +19,10 @@ async fn main() -> Result<()> {
 
     let filter = Filter::new().author(public_key).kind(Kind::RelayList);
     let events: Vec<Event> = client
-        .get_events_of(vec![filter], Some(Duration::from_secs(10)))
+        .get_events_of(
+            vec![filter],
+            EventSource::relays(Some(Duration::from_secs(10))),
+        )
         .await?;
     let event = events.first().unwrap();
     println!("Found relay list metadata:");

--- a/crates/nostr-sdk/src/client/mod.rs
+++ b/crates/nostr-sdk/src/client/mod.rs
@@ -859,8 +859,6 @@ impl Client {
     }
 
     /// Get events of filters from specific relays
-    ///
-    /// Get events both from **local database** and **relays**
     #[inline]
     pub async fn get_events_from<I, U>(
         &self,

--- a/crates/nostr-sdk/src/client/options.rs
+++ b/crates/nostr-sdk/src/client/options.rs
@@ -308,3 +308,68 @@ impl Connection {
         self
     }
 }
+
+/// Source of the events
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum EventSource {
+    /// Database only
+    Database,
+    /// Relays only
+    Relays {
+        /// Optional timeout
+        timeout: Option<Duration>,
+        /// Specific relays
+        specific_relays: Option<Vec<String>>,
+    },
+    /// Both from database and relays
+    Both {
+        /// Optional timeout for relays
+        timeout: Option<Duration>,
+        /// Specific relays
+        specific_relays: Option<Vec<String>>,
+    },
+}
+
+impl EventSource {
+    /// Relays only
+    #[inline]
+    pub fn relays(timeout: Option<Duration>) -> Self {
+        Self::Relays {
+            timeout,
+            specific_relays: None,
+        }
+    }
+
+    /// From specific relays only
+    pub fn specific_relays<I, S>(urls: I, timeout: Option<Duration>) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        Self::Relays {
+            timeout,
+            specific_relays: Some(urls.into_iter().map(|u| u.into()).collect()),
+        }
+    }
+
+    /// Both from database and relays
+    #[inline]
+    pub fn both(timeout: Option<Duration>) -> Self {
+        Self::Both {
+            timeout,
+            specific_relays: None,
+        }
+    }
+
+    /// Both from database and specific relays
+    pub fn both_with_specific_relays<I, S>(urls: I, timeout: Option<Duration>) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        Self::Both {
+            timeout,
+            specific_relays: Some(urls.into_iter().map(|u| u.into()).collect()),
+        }
+    }
+}

--- a/crates/nostr-sdk/src/client/zapper.rs
+++ b/crates/nostr-sdk/src/client/zapper.rs
@@ -8,7 +8,7 @@ use lnurl_pay::api::Lud06OrLud16;
 use lnurl_pay::{LightningAddress, LnUrl};
 use nostr::prelude::*;
 
-use super::{Client, Error};
+use super::{Client, Error, EventSource};
 
 /// Zap entity
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -100,7 +100,9 @@ impl Client {
             ZapEntity::Event(event_id) => {
                 // Get event
                 let filter: Filter = Filter::new().id(event_id);
-                let events: Vec<Event> = self.get_events_of(vec![filter], None).await?;
+                let events: Vec<Event> = self
+                    .get_events_of(vec![filter], EventSource::both(Some(self.opts.timeout)))
+                    .await?;
                 let event: &Event = events.first().ok_or(Error::EventNotFound(event_id))?;
                 let public_key: PublicKey = event.author();
                 let metadata: Metadata = self.metadata(public_key).await?;

--- a/crates/nostr-sdk/src/lib.rs
+++ b/crates/nostr-sdk/src/lib.rs
@@ -9,6 +9,7 @@
 #![warn(rustdoc::bare_urls)]
 #![allow(unknown_lints)] // TODO: remove when MSRV >= 1.72.0, required for `clippy::arc_with_non_send_sync`
 #![allow(clippy::arc_with_non_send_sync)]
+#![allow(clippy::mutable_key_type)] // TODO: remove when possible. Needed to suppress false positive for `BTreeSet<Event>`
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(feature = "all-nips", doc = include_str!("../README.md"))]
 
@@ -51,4 +52,4 @@ pub use nwc::{self, NostrWalletConnectOptions, NWC};
 pub mod client;
 pub mod prelude;
 
-pub use self::client::{Client, ClientBuilder, Options};
+pub use self::client::{Client, ClientBuilder, EventSource, Options};


### PR DESCRIPTION
* `Relay::get_events_of` and `RelayPool::get_events_of` will get events only from remote relay/s
* `Client::get_events_of` allow to choose the source of events: `database`, `relays` or `both`