### PR TITLE
sdk: fetch policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@
 * lmdb: add LMDB storage backend ([Yuki Kishimoto])
 * relay-builder: add `MockRelay` ([Yuki Kishimoto])
 * pool: add `RelayPool::disconnect_relay` method ([Yuki Kishimoto])
+* sdk: add fetch policies ([Yuki Kishimoto])
 * bindings(nostr): expose `as_pretty_json` for some structs ([Yuki Kishimoto])
 * bindings(sdk): expose `Client::fetch_metadata` ([Yuki Kishimoto])
 * bindings(sdk): expose `Client::pool` method ([Yuki Kishimoto])

--- a/bindings/nostr-sdk-ffi/src/client/options.rs
+++ b/bindings/nostr-sdk-ffi/src/client/options.rs
@@ -285,4 +285,12 @@ impl EventSource {
             inner: nostr_sdk::EventSource::both_with_specific_relays(urls, timeout),
         }
     }
+
+    /// Use database as main source and fallback to relays if the result is empty.
+    #[uniffi::constructor(default(timeout = None))]
+    pub fn database_with_fallback(timeout: Option<Duration>) -> Self {
+        Self {
+            inner: nostr_sdk::EventSource::database_with_fallback(timeout),
+        }
+    }
 }

--- a/bindings/nostr-sdk-js/src/client/options.rs
+++ b/bindings/nostr-sdk-js/src/client/options.rs
@@ -129,14 +129,14 @@ impl JsEventSource {
     /// Database only
     pub fn database() -> Self {
         Self {
-            inner: nostr_sdk::EventSource::Database,
+            inner: EventSource::Database,
         }
     }
 
     /// Relays only
     pub fn relays(timeout: Option<JsDuration>) -> Self {
         Self {
-            inner: nostr_sdk::EventSource::relays(timeout.map(|t| *t)),
+            inner: EventSource::relays(timeout.map(|t| *t)),
         }
     }
 
@@ -144,14 +144,14 @@ impl JsEventSource {
     #[wasm_bindgen(js_name = specificRelays)]
     pub fn specific_relays(urls: Vec<String>, timeout: Option<JsDuration>) -> Self {
         Self {
-            inner: nostr_sdk::EventSource::specific_relays(urls, timeout.map(|t| *t)),
+            inner: EventSource::specific_relays(urls, timeout.map(|t| *t)),
         }
     }
 
     /// Both from database and relays
     pub fn both(timeout: Option<JsDuration>) -> Self {
         Self {
-            inner: nostr_sdk::EventSource::both(timeout.map(|t| *t)),
+            inner: EventSource::both(timeout.map(|t| *t)),
         }
     }
 
@@ -159,7 +159,15 @@ impl JsEventSource {
     #[wasm_bindgen(js_name = bothWithSpecificRelays)]
     pub fn both_with_specific_relays(urls: Vec<String>, timeout: Option<JsDuration>) -> Self {
         Self {
-            inner: nostr_sdk::EventSource::both_with_specific_relays(urls, timeout.map(|t| *t)),
+            inner: EventSource::both_with_specific_relays(urls, timeout.map(|t| *t)),
+        }
+    }
+
+    /// Use database as main source and fallback to relays if the result is empty.
+    #[wasm_bindgen(js_name = databaseWithFallback)]
+    pub fn database_with_fallback(timeout: Option<JsDuration>) -> Self {
+        Self {
+            inner: EventSource::database_with_fallback(timeout.map(|t| *t)),
         }
     }
 }

--- a/crates/nostr-sdk/examples/blacklist.rs
+++ b/crates/nostr-sdk/examples/blacklist.rs
@@ -2,8 +2,6 @@
 // Copyright (c) 2023-2024 Rust Nostr Developers
 // Distributed under the MIT software license
 
-use std::time::Duration;
-
 use nostr_sdk::prelude::*;
 
 #[tokio::main]
@@ -26,12 +24,7 @@ async fn main() -> Result<()> {
     let filter = Filter::new()
         .authors([muted_public_key, public_key])
         .kind(Kind::Metadata);
-    let events = client
-        .get_events_of(
-            vec![filter],
-            EventSource::relays(Some(Duration::from_secs(10))),
-        )
-        .await?;
+    let events = client.get_events_of(vec![filter], None).await?;
     println!("Received {} events.", events.len());
 
     Ok(())

--- a/crates/nostr-sdk/examples/get-events-of.rs
+++ b/crates/nostr-sdk/examples/get-events-of.rs
@@ -21,12 +21,7 @@ async fn main() -> Result<()> {
 
     // Get events from all connected relays
     let filter = Filter::new().author(public_key).kind(Kind::Metadata);
-    let events = client
-        .get_events_of(
-            vec![filter],
-            EventSource::relays(Some(Duration::from_secs(10))),
-        )
-        .await?;
+    let events = client.get_events_of(vec![filter], None).await?;
     println!("{events:#?}");
 
     // Get events from specific relays

--- a/crates/nostr-sdk/examples/nip65.rs
+++ b/crates/nostr-sdk/examples/nip65.rs
@@ -18,12 +18,7 @@ async fn main() -> Result<()> {
     client.connect().await;
 
     let filter = Filter::new().author(public_key).kind(Kind::RelayList);
-    let events: Vec<Event> = client
-        .get_events_of(
-            vec![filter],
-            EventSource::relays(Some(Duration::from_secs(10))),
-        )
-        .await?;
+    let events: Vec<Event> = client.get_events_of(vec![filter], None).await?;
     let event = events.first().unwrap();
     println!("Found relay list metadata:");
     for (url, metadata) in nip65::extract_relay_list(event) {

--- a/crates/nostr-sdk/examples/stream-events-of.rs
+++ b/crates/nostr-sdk/examples/stream-events-of.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<()> {
     // Stream events from all connected relays
     let filter = Filter::new().kind(Kind::TextNote).limit(100);
     let mut rx = client
-        .stream_events_of(vec![filter], Some(Duration::from_secs(15)))
+        .stream_events_of(vec![filter], Duration::from_secs(15))
         .await?;
 
     while let Some(event) = rx.next().await {

--- a/crates/nostr-sdk/src/client/zapper.rs
+++ b/crates/nostr-sdk/src/client/zapper.rs
@@ -8,7 +8,7 @@ use lnurl_pay::api::Lud06OrLud16;
 use lnurl_pay::{LightningAddress, LnUrl};
 use nostr::prelude::*;
 
-use super::{Client, Error, EventSource};
+use super::{Client, Error};
 
 /// Zap entity
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -100,9 +100,7 @@ impl Client {
             ZapEntity::Event(event_id) => {
                 // Get event
                 let filter: Filter = Filter::new().id(event_id);
-                let events: Vec<Event> = self
-                    .get_events_of(vec![filter], EventSource::both(Some(self.opts.timeout)))
-                    .await?;
+                let events: Vec<Event> = self.get_events_of(vec![filter], None).await?;
                 let event: &Event = events.first().ok_or(Error::EventNotFound(event_id))?;
                 let public_key: PublicKey = event.pubkey;
                 let metadata: Metadata = self.fetch_metadata(public_key, None).await?;

--- a/crates/nostr-sdk/src/lib.rs
+++ b/crates/nostr-sdk/src/lib.rs
@@ -54,4 +54,4 @@ pub use nwc::{self, NostrWalletConnectOptions, NWC};
 pub mod client;
 pub mod prelude;
 
-pub use self::client::{Client, ClientBuilder, EventSource, Options};
+pub use self::client::{Client, ClientBuilder, Options};

--- a/crates/nostr-sdk/src/prelude.rs
+++ b/crates/nostr-sdk/src/prelude.rs
@@ -16,6 +16,8 @@ pub use nostr_signer::prelude::*;
 #[cfg(feature = "nip57")]
 pub use nostr_zapper::prelude::*;
 
+pub use crate::client::builder::*;
+pub use crate::client::options::*;
 // Internal modules
 pub use crate::client::*;
 pub use crate::*;


### PR DESCRIPTION
Allow to use database as main source of events and fallback to relays if result is empty.

@xeruf 
