### PR TITLE
nostr: update `Event` fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * nostr: deprecate `Event::from_value` ([Yuki Kishimoto])
 * nostr: deprecate `Tag::as_vec` ([Yuki Kishimoto])
 * nostr: re-write `RawRelayMessage` parsing ([Yuki Kishimoto])
+* nostr: update `Event` fields ([Yuki Kishimoto])
 * signer: update NIP-04 and NIP-44 methods signature ([Yuki Kishimoto])
 * webln: bump `webln` to `v0.3` ([Yuki Kishimoto])
 * sdk: bump `lnurl-pay` to `v0.6` ([Yuki Kishimoto])

--- a/bindings/nostr-ffi/src/event/mod.rs
+++ b/bindings/nostr-ffi/src/event/mod.rs
@@ -48,23 +48,23 @@ impl Deref for Event {
 impl Event {
     #[inline]
     pub fn id(&self) -> EventId {
-        self.inner.id().into()
+        self.inner.id.into()
     }
 
     /// Get event author (`pubkey` field)
     #[inline]
     pub fn author(&self) -> PublicKey {
-        self.inner.author().into()
+        self.inner.pubkey.into()
     }
 
     #[inline]
     pub fn created_at(&self) -> Timestamp {
-        self.inner.created_at().into()
+        self.inner.created_at.into()
     }
 
     #[inline]
     pub fn kind(&self) -> Kind {
-        self.inner.kind().into()
+        self.inner.kind.into()
     }
 
     pub fn tags(&self) -> Vec<Arc<Tag>> {
@@ -94,12 +94,12 @@ impl Event {
 
     #[inline]
     pub fn content(&self) -> String {
-        self.inner.content().to_string()
+        self.inner.content.to_string()
     }
 
     #[inline]
     pub fn signature(&self) -> String {
-        self.inner.signature().to_string()
+        self.inner.sig.to_string()
     }
 
     /// Verify both `EventId` and `Signature`

--- a/bindings/nostr-js/src/event/mod.rs
+++ b/bindings/nostr-js/src/event/mod.rs
@@ -57,23 +57,23 @@ impl From<JsEvent> for Event {
 impl JsEvent {
     #[wasm_bindgen(getter)]
     pub fn id(&self) -> JsEventId {
-        self.inner.id().into()
+        self.inner.id.into()
     }
 
     /// Get event author (`pubkey` field)
     #[wasm_bindgen(getter)]
     pub fn author(&self) -> JsPublicKey {
-        self.inner.author().into()
+        self.inner.pubkey.into()
     }
 
     #[wasm_bindgen(js_name = createdAt, getter)]
     pub fn created_at(&self) -> JsTimestamp {
-        self.inner.created_at().into()
+        self.inner.created_at.into()
     }
 
     #[wasm_bindgen(getter)]
     pub fn kind(&self) -> u16 {
-        self.inner.kind().as_u16()
+        self.inner.kind.as_u16()
     }
 
     #[wasm_bindgen(getter)]
@@ -101,12 +101,12 @@ impl JsEvent {
 
     #[wasm_bindgen(getter)]
     pub fn content(&self) -> String {
-        self.inner.content().to_string()
+        self.inner.content.to_string()
     }
 
     #[wasm_bindgen(getter)]
     pub fn signature(&self) -> String {
-        self.inner.signature().to_string()
+        self.inner.sig.to_string()
     }
 
     /// Verify both `EventId` and `Signature`

--- a/crates/nostr-database/examples/helper.rs
+++ b/crates/nostr-database/examples/helper.rs
@@ -34,7 +34,7 @@ async fn main() {
 
         let event = EventBuilder::text_note(
             format!("Reply to event #{i}"),
-            [Tag::event(event.id()), Tag::public_key(event.author())],
+            [Tag::event(event.id), Tag::public_key(event.pubkey)],
         )
         .to_event(&keys_b)
         .unwrap();

--- a/crates/nostr-database/examples/memory.rs
+++ b/crates/nostr-database/examples/memory.rs
@@ -40,7 +40,7 @@ async fn main() {
 
         let event = EventBuilder::text_note(
             format!("Reply to event #{i}"),
-            [Tag::event(event.id()), Tag::public_key(event.author())],
+            [Tag::event(event.id), Tag::public_key(event.pubkey)],
         )
         .to_event(&keys_b)
         .unwrap();

--- a/crates/nostr-database/src/flatbuffers/mod.rs
+++ b/crates/nostr-database/src/flatbuffers/mod.rs
@@ -81,10 +81,10 @@ impl FlatBufferEncode for Event {
         let args = event_fbs::EventArgs {
             id: Some(&id),
             pubkey: Some(&pubkey),
-            created_at: self.created_at().as_u64(),
-            kind: self.kind().as_u64(),
+            created_at: self.created_at.as_u64(),
+            kind: self.kind.as_u64(),
             tags: Some(fbb.create_vector(&tags)),
-            content: Some(fbb.create_string(self.content())),
+            content: Some(fbb.create_string(&self.content)),
             sig: Some(&sig),
         };
 

--- a/crates/nostr-database/src/helper.rs
+++ b/crates/nostr-database/src/helper.rs
@@ -202,7 +202,7 @@ impl InternalDatabaseHelper {
         let now: Timestamp = Timestamp::now();
         events
             .into_iter()
-            .filter(|e| !e.is_ephemeral())
+            .filter(|e| !e.kind.is_ephemeral())
             .map(|event| self.internal_index_event(&event, &now))
             .flat_map(|res| res.to_discard)
             .collect()
@@ -217,7 +217,7 @@ impl InternalDatabaseHelper {
         let now: Timestamp = Timestamp::now();
         events
             .into_iter()
-            .filter(|e| !e.is_expired() && !e.is_ephemeral())
+            .filter(|e| !e.is_expired() && !e.kind.is_ephemeral())
             .filter(move |event| self.internal_index_event(event, &now).to_store)
     }
 
@@ -240,9 +240,9 @@ impl InternalDatabaseHelper {
         let mut to_discard: HashSet<EventId> = HashSet::new();
 
         // Compose others fields
-        let author: PublicKey = event.author();
-        let created_at: Timestamp = event.created_at();
-        let kind: Kind = event.kind();
+        let author: PublicKey = event.pubkey;
+        let created_at: Timestamp = event.created_at;
+        let kind: Kind = event.kind;
 
         let mut should_insert: bool = true;
 
@@ -430,7 +430,7 @@ impl InternalDatabaseHelper {
     #[tracing::instrument(skip_all, level = "trace")]
     pub fn index_event(&mut self, event: &Event) -> DatabaseEventResult {
         // Check if it's expired or ephemeral (in `internal_index_event` is checked only the raw event expiration)
-        if event.is_expired() || event.is_ephemeral() {
+        if event.is_expired() || event.kind.is_ephemeral() {
             return DatabaseEventResult::default();
         }
         let now = Timestamp::now();
@@ -741,7 +741,7 @@ impl DatabaseHelper {
     #[tracing::instrument(skip_all, level = "trace")]
     pub async fn index_event(&self, event: &Event) -> DatabaseEventResult {
         // Check if it's expired or ephemeral
-        if event.is_expired() || event.is_ephemeral() {
+        if event.is_expired() || event.kind.is_ephemeral() {
             return DatabaseEventResult::default();
         }
 

--- a/crates/nostr-database/src/lib.rs
+++ b/crates/nostr-database/src/lib.rs
@@ -188,7 +188,7 @@ pub trait NostrDatabaseExt: NostrDatabase {
             .limit(1);
         let events: Vec<Event> = self.query(vec![filter], Order::Desc).await?;
         match events.first() {
-            Some(event) => match Metadata::from_json(event.content()) {
+            Some(event) => match Metadata::from_json(&event.content) {
                 Ok(metadata) => Ok(Profile::new(public_key, metadata)),
                 Err(e) => {
                     tracing::error!("Impossible to deserialize profile metadata: {e}");
@@ -236,8 +236,8 @@ pub trait NostrDatabaseExt: NostrDatabase {
                     .into_iter()
                     .map(|e| {
                         let metadata: Metadata =
-                            Metadata::from_json(e.content()).unwrap_or_default();
-                        Profile::new(e.author(), metadata)
+                            Metadata::from_json(&e.content).unwrap_or_default();
+                        Profile::new(e.pubkey, metadata)
                     })
                     .collect();
 

--- a/crates/nostr-database/src/memory.rs
+++ b/crates/nostr-database/src/memory.rs
@@ -118,7 +118,7 @@ impl NostrDatabase for MemoryDatabase {
         } else {
             // Mark it as seen
             let mut seen_event_ids = self.seen_event_ids.lock().await;
-            self._event_id_seen(&mut seen_event_ids, event.id(), None);
+            self._event_id_seen(&mut seen_event_ids, event.id, None);
 
             Ok(false)
         }

--- a/crates/nostr-indexeddb/src/lib.rs
+++ b/crates/nostr-indexeddb/src/lib.rs
@@ -282,7 +282,7 @@ impl_nostr_database!({
                 .db
                 .transaction_on_one_with_mode(EVENTS_CF, IdbTransactionMode::Readwrite)?;
             let store = tx.object_store(EVENTS_CF)?;
-            let key = JsValue::from(event.id().to_hex());
+            let key = JsValue::from(event.id.to_hex());
 
             // Acquire FlatBuffers Builder
             let mut fbb = self.fbb.lock().await;

--- a/crates/nostr-relay-pool/src/relay/internal.rs
+++ b/crates/nostr-relay-pool/src/relay/internal.rs
@@ -1133,7 +1133,7 @@ impl InternalRelay {
 
     #[inline]
     pub async fn send_event(&self, event: Event, opts: RelaySendOptions) -> Result<EventId, Error> {
-        let id: EventId = event.id();
+        let id: EventId = event.id;
         self.batch_event(vec![event], opts).await?;
         Ok(id)
     }
@@ -1153,7 +1153,7 @@ impl InternalRelay {
         let mut missing: HashSet<EventId> = HashSet::with_capacity(events_len);
 
         for event in events.into_iter() {
-            missing.insert(event.id());
+            missing.insert(event.id);
             msgs.push(ClientMessage::event(event));
         }
 
@@ -1227,13 +1227,13 @@ impl InternalRelay {
         if event.kind != Kind::Authentication {
             return Err(Error::UnexpectedKind {
                 expected: Kind::Authentication,
-                found: event.kind(),
+                found: event.kind,
             });
         }
 
         let mut notifications = self.internal_notification_sender.subscribe();
 
-        let id: EventId = event.id();
+        let id: EventId = event.id;
 
         // Send message
         let msg: ClientMessage = ClientMessage::auth(event);

--- a/crates/nostr-rocksdb/src/lib.rs
+++ b/crates/nostr-rocksdb/src/lib.rs
@@ -186,7 +186,7 @@ impl NostrDatabase for RocksDatabase {
                 let events_cf = self.cf_handle(EVENTS_CF)?;
 
                 // Serialize key and value
-                let id = event.id();
+                let id = event.id;
                 let key: &[u8] = id.as_bytes();
                 let value: &[u8] = event.encode(&mut fbb);
 

--- a/crates/nostr-sdk/examples/bot.rs
+++ b/crates/nostr-sdk/examples/bot.rs
@@ -47,7 +47,7 @@ async fn main() -> Result<()> {
     client
         .handle_notifications(|notification| async {
             if let RelayPoolNotification::Event { event, .. } = notification {
-                if event.kind() == Kind::GiftWrap {
+                if event.kind == Kind::GiftWrap {
                     match client.unwrap_gift_wrap(&event).await {
                         Ok(UnwrappedGift { rumor, sender }) => {
                             if rumor.kind == Kind::PrivateDirectMessage {

--- a/crates/nostr-sdk/examples/client-with-opts.rs
+++ b/crates/nostr-sdk/examples/client-with-opts.rs
@@ -48,7 +48,7 @@ async fn main() -> Result<()> {
     client
         .handle_notifications(|notification| async {
             if let RelayPoolNotification::Event { event, .. } = notification {
-                if event.kind() == Kind::GiftWrap {
+                if event.kind == Kind::GiftWrap {
                     let UnwrappedGift { rumor, .. } = client.unwrap_gift_wrap(&event).await?;
                     println!("Rumor: {}", rumor.as_json());
                 } else {

--- a/crates/nostr-sdk/examples/subscriptions.rs
+++ b/crates/nostr-sdk/examples/subscriptions.rs
@@ -65,15 +65,15 @@ async fn main() -> Result<()> {
                 }
 
                 // Check kind
-                if event.kind() == Kind::EncryptedDirectMessage {
+                if event.kind == Kind::EncryptedDirectMessage {
                     if let Ok(msg) =
-                        nip04::decrypt(keys.secret_key()?, &event.pubkey, event.content())
+                        nip04::decrypt(keys.secret_key()?, &event.pubkey, &event.content)
                     {
                         println!("DM: {msg}");
                     } else {
                         tracing::error!("Impossible to decrypt direct message");
                     }
-                } else if event.kind() == Kind::TextNote {
+                } else if event.kind == Kind::TextNote {
                     println!("TextNote: {:?}", event);
                 } else {
                     println!("{:?}", event);

--- a/crates/nostr-sdk/examples/tor.rs
+++ b/crates/nostr-sdk/examples/tor.rs
@@ -38,7 +38,7 @@ async fn main() -> Result<()> {
     client
         .handle_notifications(|notification| async {
             if let RelayPoolNotification::Event { event, .. } = notification {
-                if event.kind() == Kind::GiftWrap {
+                if event.kind == Kind::GiftWrap {
                     let UnwrappedGift { rumor, .. } = client.unwrap_gift_wrap(&event).await?;
                     println!("Rumor: {}", rumor.as_json());
                 } else {

--- a/crates/nostr-sdk/src/client/mod.rs
+++ b/crates/nostr-sdk/src/client/mod.rs
@@ -1113,7 +1113,7 @@ impl Client {
             .get_events_of(vec![filter], EventSource::both(None))
             .await?; // TODO: add timeout?
         match events.first() {
-            Some(event) => Ok(Metadata::from_json(event.content())?),
+            Some(event) => Ok(Metadata::from_json(&event.content)?),
             None => Err(Error::MetadataNotFound),
         }
     }
@@ -1239,7 +1239,7 @@ impl Client {
 
         // Get first event (result of `get_events_of` is sorted DESC by timestamp)
         if let Some(event) = events.into_iter().next() {
-            for tag in event.into_iter_tags() {
+            for tag in event.tags.into_iter() {
                 if let Some(TagStandard::PublicKey {
                     public_key,
                     relay_url,
@@ -1298,8 +1298,8 @@ impl Client {
                 .get_events_of(filters, EventSource::both(timeout))
                 .await?;
             for event in events.into_iter() {
-                let metadata = Metadata::from_json(event.content())?;
-                if let Some(m) = contacts.get_mut(&event.author()) {
+                let metadata = Metadata::from_json(&event.content)?;
+                if let Some(m) = contacts.get_mut(&event.pubkey) {
                     *m = metadata
                 };
             }

--- a/crates/nostr-sdk/src/client/zapper.rs
+++ b/crates/nostr-sdk/src/client/zapper.rs
@@ -104,7 +104,7 @@ impl Client {
                     .get_events_of(vec![filter], EventSource::both(Some(self.opts.timeout)))
                     .await?;
                 let event: &Event = events.first().ok_or(Error::EventNotFound(event_id))?;
-                let public_key: PublicKey = event.author();
+                let public_key: PublicKey = event.pubkey;
                 let metadata: Metadata = self.metadata(public_key).await?;
                 (public_key, metadata)
             }

--- a/crates/nostr-signer/src/lib.rs
+++ b/crates/nostr-signer/src/lib.rs
@@ -252,16 +252,16 @@ impl NostrSigner {
 
         // Decrypt and verify seal
         let seal: String = self
-            .nip44_decrypt(&gift_wrap.pubkey, gift_wrap.content())
+            .nip44_decrypt(&gift_wrap.pubkey, &gift_wrap.content)
             .await?;
         let seal: Event = Event::from_json(seal)?;
         seal.verify()?;
 
         // Decrypt rumor
-        let rumor: String = self.nip44_decrypt(&seal.pubkey, seal.content()).await?;
+        let rumor: String = self.nip44_decrypt(&seal.pubkey, &seal.content).await?;
 
         Ok(UnwrappedGift {
-            sender: seal.author(),
+            sender: seal.pubkey,
             rumor: UnsignedEvent::from_json(rumor)?,
         })
     }

--- a/crates/nostr-signer/src/nip46/client.rs
+++ b/crates/nostr-signer/src/nip46/client.rs
@@ -128,8 +128,8 @@ impl Nip46Signer {
         time::timeout(Some(self.timeout), async {
             while let Ok(notification) = notifications.recv().await {
                 if let RelayPoolNotification::Event { event, .. } = notification {
-                    if event.kind() == Kind::NostrConnect {
-                        let msg = nip04::decrypt(secret_key, &event.pubkey, event.content())?;
+                    if event.kind == Kind::NostrConnect {
+                        let msg = nip04::decrypt(secret_key, &event.pubkey, &event.content)?;
                         let msg = Message::from_json(msg)?;
 
                         tracing::debug!("Received NIP46 message: '{msg}'");
@@ -279,9 +279,9 @@ async fn get_signer_public_key(
     time::timeout(Some(timeout), async {
         while let Ok(notification) = notifications.recv().await {
             if let RelayPoolNotification::Event { event, .. } = notification {
-                if event.kind() == Kind::NostrConnect {
+                if event.kind == Kind::NostrConnect {
                     // Decrypt content
-                    let msg: String = nip04::decrypt(secret_key, &event.pubkey, event.content())?;
+                    let msg: String = nip04::decrypt(secret_key, &event.pubkey, event.content)?;
 
                     tracing::debug!("Received Nostr Connect message: '{msg}'");
 
@@ -300,7 +300,7 @@ async fn get_signer_public_key(
                             result: Some(ResponseResult::Connect),
                             error: None,
                             ..
-                        } => return Ok(event.author()),
+                        } => return Ok(event.pubkey),
                         _ => {}
                     }
                 }

--- a/crates/nostr-signer/src/nip46/signer.rs
+++ b/crates/nostr-signer/src/nip46/signer.rs
@@ -128,9 +128,9 @@ impl NostrConnectRemoteSigner {
         self.pool
             .handle_notifications(|notification| async {
                 if let RelayPoolNotification::Event { event, .. } = notification {
-                    if event.kind() == Kind::NostrConnect {
+                    if event.kind == Kind::NostrConnect {
                         if let Ok(msg) =
-                            nip04::decrypt(self.keys.secret_key()?, &event.pubkey, event.content())
+                            nip04::decrypt(self.keys.secret_key()?, &event.pubkey, event.content)
                         {
                             tracing::debug!("New Nostr Connect message received: {msg}");
 
@@ -247,7 +247,7 @@ impl NostrConnectRemoteSigner {
 
                                 // Compose and publish event
                                 let event =
-                                    EventBuilder::nostr_connect(&self.keys, event.author(), msg)?
+                                    EventBuilder::nostr_connect(&self.keys, event.pubkey, msg)?
                                         .to_event(&self.keys)?;
                                 self.pool.send_event(event, RelaySendOptions::new()).await?;
                             }

--- a/crates/nostr-sqlite/src/lib.rs
+++ b/crates/nostr-sqlite/src/lib.rs
@@ -155,7 +155,7 @@ impl NostrDatabase for SQLiteDatabase {
             let mut fbb = self.fbb.write().await;
 
             // Encode
-            let event_id: EventId = event.id();
+            let event_id: EventId = event.id;
             let value: Vec<u8> = event.encode(&mut fbb).to_vec();
 
             // Save event
@@ -186,7 +186,7 @@ impl NostrDatabase for SQLiteDatabase {
         let events: Vec<(EventId, Vec<u8>)> = events
             .into_iter()
             .map(move |e| {
-                let event_id: EventId = e.id();
+                let event_id: EventId = e.id;
                 let value: Vec<u8> = e.encode(&mut fbb).to_vec();
                 (event_id, value)
             })

--- a/crates/nostr/src/event/id.rs
+++ b/crates/nostr/src/event/id.rs
@@ -260,7 +260,6 @@ mod tests {
 #[cfg(bench)]
 mod benches {
     use super::*;
-    use crate::prelude::hex::{decode, encode};
     use crate::test::{black_box, Bencher};
 
     const ID: &str = "2be17aa3031bdcb006f0fce80c146dea9c1c0268b0af2398bb673365c6444d45";

--- a/crates/nostr/src/event/tag/mod.rs
+++ b/crates/nostr/src/event/tag/mod.rs
@@ -481,7 +481,7 @@ mod tests {
         // Got this fresh off the wire
         let event: &str = r#"{"id":"2be17aa3031bdcb006f0fce80c146dea9c1c0268b0af2398bb673365c6444d45","pubkey":"f86c44a2de95d9149b51c6a29afeabba264c18e2fa7c49de93424a0c56947785","created_at":1640839235,"kind":4,"tags":[["p","13adc511de7e1cfcf1c6b7f6365fb5a03442d7bcacf565ea57fa7770912c023d"]],"content":"uRuvYr585B80L6rSJiHocw==?iv=oh6LVqdsYYol3JfFnXTbPA==","sig":"a5d9290ef9659083c490b303eb7ee41356d8778ff19f2f91776c8dc4443388a64ffcf336e61af4c25c05ac3ae952d1ced889ed655b67790891222aaa15b99fdd"}"#;
         let event = Event::from_json(event).unwrap();
-        let tag = event.tags().first().unwrap();
+        let tag = event.tags.first().unwrap();
 
         assert_eq!(
             tag,

--- a/crates/nostr/src/event/unsigned.rs
+++ b/crates/nostr/src/event/unsigned.rs
@@ -245,8 +245,8 @@ impl From<Event> for UnsignedEvent {
             pubkey: event.pubkey,
             created_at: event.created_at,
             kind: event.kind,
-            tags: event.tags.clone(),
-            content: event.content.clone(),
+            tags: event.tags,
+            content: event.content,
         }
     }
 }

--- a/crates/nostr/src/nips/nip26.rs
+++ b/crates/nostr/src/nips/nip26.rs
@@ -541,8 +541,8 @@ impl EventProperties {
     /// Create from an Event
     pub fn from_event(event: &Event) -> Self {
         Self {
-            kind: event.kind().as_u16(),
-            created_time: event.created_at().as_u64(),
+            kind: event.kind.as_u16(),
+            created_time: event.created_at.as_u64(),
         }
     }
 }

--- a/crates/nostr/src/nips/nip47.rs
+++ b/crates/nostr/src/nips/nip47.rs
@@ -699,7 +699,7 @@ impl Response {
     /// Deserialize from [Event]
     #[inline]
     pub fn from_event(uri: &NostrWalletConnectURI, event: &Event) -> Result<Self, Error> {
-        let decrypt_res: String = nip04::decrypt(&uri.secret, &event.pubkey, event.content())?;
+        let decrypt_res: String = nip04::decrypt(&uri.secret, &event.pubkey, &event.content)?;
         Self::from_json(decrypt_res)
     }
 

--- a/crates/nostr/src/nips/nip57.rs
+++ b/crates/nostr/src/nips/nip57.rs
@@ -381,7 +381,7 @@ pub fn decrypt_sent_private_zap_message(
 ) -> Result<Event, Error> {
     // Re-create our ephemeral encryption key
     let secret_key: SecretKey =
-        create_encryption_key(secret_key, public_key, private_zap_event.created_at())?;
+        create_encryption_key(secret_key, public_key, private_zap_event.created_at)?;
     let key: [u8; 32] = util::generate_shared_key(&secret_key, public_key);
 
     // decrypt like normal
@@ -449,12 +449,12 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(msg, private_zap_msg.content());
+        assert_eq!(msg, &private_zap_msg.content);
 
         let private_zap_msg =
             decrypt_received_private_zap_message(bob_keys.secret_key().unwrap(), &private_zap)
                 .unwrap();
 
-        assert_eq!(msg, private_zap_msg.content())
+        assert_eq!(msg, &private_zap_msg.content)
     }
 }

--- a/crates/nostr/src/nips/nip58.rs
+++ b/crates/nostr/src/nips/nip58.rs
@@ -49,7 +49,7 @@ impl fmt::Display for Error {
 pub(crate) fn filter_for_kind(events: Vec<Event>, kind_needed: &Kind) -> Vec<Event> {
     events
         .into_iter()
-        .filter(|e| e.kind() == *kind_needed)
+        .filter(|e| &e.kind == kind_needed)
         .collect()
 }
 

--- a/crates/nostr/src/nips/nip59.rs
+++ b/crates/nostr/src/nips/nip59.rs
@@ -114,15 +114,15 @@ impl UnwrappedGift {
         let secret_key: &SecretKey = receiver_keys.secret_key()?;
 
         // Decrypt and verify seal
-        let seal: String = nip44::decrypt(secret_key, &gift_wrap.pubkey, gift_wrap.content())?;
+        let seal: String = nip44::decrypt(secret_key, &gift_wrap.pubkey, &gift_wrap.content)?;
         let seal: Event = Event::from_json(seal)?;
         seal.verify_with_ctx(secp)?;
 
         // Decrypt rumor
-        let rumor: String = nip44::decrypt(secret_key, &seal.pubkey, seal.content())?;
+        let rumor: String = nip44::decrypt(secret_key, &seal.pubkey, &seal.content)?;
 
         Ok(UnwrappedGift {
-            sender: seal.author(),
+            sender: seal.pubkey,
             rumor: UnsignedEvent::from_json(rumor)?,
         })
     }

--- a/crates/nwc/src/lib.rs
+++ b/crates/nwc/src/lib.rs
@@ -115,7 +115,7 @@ impl NWC {
         time::timeout(Some(self.opts.timeout), async {
             while let Ok(notification) = notifications.recv().await {
                 if let RelayNotification::Event { event, .. } = notification {
-                    if event.kind() == Kind::WalletConnectResponse
+                    if event.kind == Kind::WalletConnectResponse
                         && event.event_ids().next().copied() == Some(event_id)
                     {
                         return Ok(Response::from_event(&self.uri, &event)?);


### PR DESCRIPTION
These changes enable direct access to event fields, removing the need of  `Deref` and allowing to move ownership of inner fields. Deprecate all getters and methods like `Event::into_iter_tags`.