### PR TITLE
sdk: add ability to add relay by url without handling a Result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 * bindings(nostr): expose `as_pretty_json` for some structs ([Yuki Kishimoto])
 * ffi(nostr): expose `Kind::is_*` methods ([Yuki Kishimoto])
 * js(nostr): add `Kind` object ([Yuki Kishimoto])
+* sdk: add ability to add relay by url without handling a Result ([Janek])
 
 ### Fixed
 
@@ -464,6 +465,7 @@ added `nostrdb` storage backend, added NIP32 and completed NIP51 support and mor
 [reyamir]: https://github.com/reyamir
 [w3irdrobot]: https://github.com/w3irdrobot
 [nanikamado]: https://github.com/nanikamado
+[Janek]: https://github.com/xeruf
 
 <!-- Tags -->
 [Unreleased]: https://github.com/rust-nostr/nostr/compare/v0.34.0...HEAD

--- a/crates/nostr-relay-pool/src/pool/mod.rs
+++ b/crates/nostr-relay-pool/src/pool/mod.rs
@@ -149,17 +149,26 @@ impl RelayPool {
         self.inner.relay(url).await
     }
 
+    /// Add new relay by Url
+    ///
+    /// If there are pool subscriptions, the added relay will inherit them.
+    /// Use `subscribe_to` instead of `subscribe` to prevent a subscription from being inherited.
+    #[inline]
+    pub async fn add_relay_url(&self, url: Url, opts: RelayOptions) -> bool {
+        self.inner.add_relay(url, opts).await
+    }
+
     /// Add new relay
     ///
-    /// If are set pool subscriptions, the new added relay will inherit them. Use `subscribe_to` method instead of `subscribe`,
-    /// to avoid to set pool subscriptions.
+    /// If there are pool subscriptions, the added relay will inherit them.
+    /// Use `subscribe_to` instead of `subscribe` to prevent a subscription from being inherited.
     #[inline]
     pub async fn add_relay<U>(&self, url: U, opts: RelayOptions) -> Result<bool, Error>
     where
         U: TryIntoUrl,
         Error: From<<U as TryIntoUrl>::Err>,
     {
-        self.inner.add_relay(url, opts).await
+        Ok(self.inner.add_relay(url.try_into_url()?, opts).await)
     }
 
     /// Disconnect and remove relay
@@ -202,8 +211,7 @@ impl RelayPool {
         Error: From<<U as TryIntoUrl>::Err>,
     {
         let relay = self.relay(url).await?;
-        relay.connect(connection_timeout).await;
-        Ok(())
+        Ok(relay.connect(connection_timeout).await)
     }
 
     /// Get subscriptions


### PR DESCRIPTION
Previously the nesting of Results made it very unclear which failures need to be handled. Not propagating TryIntoUrl into the plumbing provides more clarity.

Update of https://github.com/rust-nostr/nostr/pull/538

### Checklist

* [x] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [x] I ran `just precommit` or `just check` before committing
* [x] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
