### PR TITLE
book: add nip01 javascript examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ many-events.json
 many-events.json.zst
 .idea/
 .vscode/
+env/

--- a/book/snippets/nostr/js/index.js
+++ b/book/snippets/nostr/js/index.js
@@ -2,6 +2,7 @@ const keys = require("./src/keys");
 const eventJson = require("./src/event/json");
 const eventBuilder = require("./src/event/builder");
 const relayMessageJson = require("./src/messages/relay");
+const nip01 = require("./src/nip01");
 const nip44 = require("./src/nip44");
 const nip59 = require("./src/nip59");
 
@@ -15,6 +16,7 @@ eventBuilder.eventBuilder();
 
 relayMessageJson.relayMessageJson();
 
+nip01.run();
 nip44.run();
 
 nip59.run();

--- a/book/snippets/nostr/js/src/nip01.js
+++ b/book/snippets/nostr/js/src/nip01.js
@@ -1,0 +1,56 @@
+const { loadWasmSync, Keys, Metadata, EventBuilder } = require("@rust-nostr/nostr");
+
+function run() {
+    // Load WASM
+    loadWasmSync();
+
+    // Generate random keys
+    let keys = Keys.generate();
+
+    console.log();
+    // ANCHOR: create-event
+    // Create metadata object with desired content
+    let metadataContent = new Metadata()
+        .name("TestName")
+        .displayName("JsTestur")
+        .about("This is a Test Account for Rust Nostr JS Bindings")
+        .website("https://rust-nostr.org/")
+        .picture("https://avatars.githubusercontent.com/u/123304603?s=200&v=4")
+        .banner("https://nostr-resources.com/assets/images/cover.png")
+        .nip05("TestName@rustNostr.com");
+
+    // Build metadata event and assign content
+    let builder = EventBuilder.metadata(metadataContent);
+
+    // Signed event and print details
+    console.log("Creating Metadata Event:");
+    let event = builder.toEvent(keys);
+    
+    console.log(" Event Details:");
+    console.log(`     Author    : ${event.author.toBech32()}`);
+    console.log(`     Kind      : ${event.kind.valueOf()}`);
+    console.log(`     Content   : ${event.content.toString()}`);
+    console.log(`     Datetime  : ${event.createdAt.toHumanDatetime()}`);
+    console.log(`     Signature : ${event.signature.toString()}`);
+    console.log(`     Verify    : ${event.verify()}`);
+    console.log(`     JSON      : ${event.asJson()}`);
+    // ANCHOR_END: create-event
+
+    console.log();
+    // ANCHOR: create-metadata
+    // Deserialize Metadata from event
+    console.log("Deserializing Metadata Event:");
+    let metadata = Metadata.fromJson(event.content);
+
+    console.log(" Metadata Details:");
+    console.log(`     Name      : ${metadata.getName()}`);
+    console.log(`     Display   : ${metadata.getDisplayName()}`);
+    console.log(`     About     : ${metadata.getAbout()}`);
+    console.log(`     Website   : ${metadata.getWebsite()}`);
+    console.log(`     Picture   : ${metadata.getPicture()}`);
+    console.log(`     Banner    : ${metadata.getBanner()}`);
+    console.log(`     NIP05     : ${metadata.getNip05()}`);
+    // ANCHOR_END: create-metadata
+}
+
+module.exports.run = run;

--- a/book/src/nostr/06-nip01.md
+++ b/book/src/nostr/06-nip01.md
@@ -45,7 +45,17 @@ Use the `Metadata` class to deserialize the content of an exsiting metadata even
 <div slot="title">JavaScript</div>
 <section>
 
-TODO
+Using the `Metadata` class to build the metadata object and the `EventBuilder` class to create a Metadata event.
+
+```javascript,ignore
+{{#include ../../snippets/nostr/js/src/nip01.js:create-event}}
+```
+
+Use the `Metadata` class to deserialize the content of an exsiting metadata event. 
+
+```javascript,ignore
+{{#include ../../snippets/nostr/js/src/nip01.js:create-metadata}}
+```
 
 </section>
 


### PR DESCRIPTION
### Description

- Updated 06-nip01.md to include js code blocks
- Added js examples equivalent to python code

### Notes to the reviewers

Actually had a lot of trouble trying to get this to execute. Specifically is wasn't seeming to like the WebAssembly bit of the pkg code (line 10980) `CompileError: WebAssembly.Module(): invalid local type @+74`. 

That said I actually wrote the code and tested it on another machine beforehand and it executed as expected so figured it was worth submitting anyway.

Ran the same test again just now on in another location and fresh install and looks like I got the same issue. The other machine I was writing on earlier was likely running an older version (have ruled that out though now). Looks like it could be some issue with my setup on the Linux machine, will dig into that. Anyway, submit the code and let me know if you get any issues on your side.

### Checklist

* [x] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [ ] I ran `just precommit` or `just check` before committing
* [ ] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
