### PR TITLE
book: add NIP05 & NIP19 JavaScript examples

### DIFF
--- a/book/snippets/nostr/js/index.js
+++ b/book/snippets/nostr/js/index.js
@@ -3,6 +3,8 @@ const eventJson = require("./src/event/json");
 const eventBuilder = require("./src/event/builder");
 const relayMessageJson = require("./src/messages/relay");
 const nip01 = require("./src/nip01");
+const nip05 = require("./src/nip05");
+const nip19 = require("./src/nip19");
 const nip44 = require("./src/nip44");
 const nip59 = require("./src/nip59");
 
@@ -17,6 +19,8 @@ eventBuilder.eventBuilder();
 relayMessageJson.relayMessageJson();
 
 nip01.run();
+nip05.run();
+nip19.run();
 nip44.run();
 
 nip59.run();

--- a/book/snippets/nostr/js/src/nip05.js
+++ b/book/snippets/nostr/js/src/nip05.js
@@ -1,4 +1,4 @@
-const { loadWasmSync, PublicKey, Metadata, verifyNip05, } = require("@rust-nostr/nostr");
+const { loadWasmSync, PublicKey, Metadata, verifyNip05, getNip05Profile } = require("@rust-nostr/nostr");
 
 function run() {
     // Load WASM
@@ -24,6 +24,15 @@ function run() {
         console.log(`     Unable to verify NIP-05, for ${publicKey.toBech32()}`);
     };
     // ANCHOR_END: verify-nip05
+
+    console.log();
+
+    // ANCHOR: nip05-profile
+    console.log("Get NIP-05 profile:");
+    let nip_05 = "yuki@yukikishimoto.com";
+    let profile = getNip05Profile(nip_05);
+    console.log(`     ${nip_05} Public key: ${profile.publicKey().toBech32()}`);
+    // ANCHOR_END: nip05-profile
 }
 
 module.exports.run = run;

--- a/book/snippets/nostr/js/src/nip05.js
+++ b/book/snippets/nostr/js/src/nip05.js
@@ -1,0 +1,29 @@
+const { loadWasmSync, PublicKey, Metadata, verifyNip05, } = require("@rust-nostr/nostr");
+
+function run() {
+    // Load WASM
+    loadWasmSync();
+
+    console.log();
+    // ANCHOR: set-metadata
+    // Create metadata object with name and NIP05
+    let metadata = new Metadata()
+        .name("TestName")
+        .nip05("TestName@rustNostr.com");
+    // ANCHOR_END: set-metadata
+
+    console.log();
+    // ANCHOR: verify-nip05
+    console.log("Verify NIP-05:");
+    let nip05 = "Rydal@gitlurker.info";
+    let publicKey = PublicKey.parse("npub1zwnx29tj2lnem8wvjcx7avm8l4unswlz6zatk0vxzeu62uqagcash7fhrf");
+    let proxy = null;
+    if (verifyNip05(publicKey, nip05, proxy)) {
+        console.log(`     '${nip05}' verified, for ${publicKey.toBech32()}`);
+    } else {
+        console.log(`     Unable to verify NIP-05, for ${publicKey.toBech32()}`);
+    };
+    // ANCHOR_END: verify-nip05
+}
+
+module.exports.run = run;

--- a/book/snippets/nostr/js/src/nip19.js
+++ b/book/snippets/nostr/js/src/nip19.js
@@ -1,0 +1,68 @@
+const { loadWasmSync, Keys, EventBuilder, Nip19Profile, Nip19Event, Nip19Relay} = require("@rust-nostr/nostr");
+
+function run() {
+    // Load WASM
+    loadWasmSync();
+
+    // Generate random keys
+    let keys = Keys.generate();
+
+    console.log();
+    console.log("Bare keys and ids (bech32):");
+    // ANCHOR: nip19-npub
+    console.log(` Public key: ${keys.publicKey.toBech32()}`);
+    // ANCHOR_END: nip19-npub
+
+    // ANCHOR: nip19-nsec
+    console.log(` Secret key: ${keys.secretKey.toBech32()}`);
+    // ANCHOR_END: nip19-nsec
+
+    // ANCHOR: nip19-note
+    let event = EventBuilder.textNote("Hello from Rust Nostr JS Bindings!", []).toEvent(keys);
+    console.log(` Event     : ${event.id.toBech32()}`);
+    // ANCHOR_END: nip19-note
+
+    console.log();
+    console.log("Shareable identifiers with extra metadata (bech32):");
+    // ANCHOR: nip19-nprofile-encode
+    // Create NIP-19 profile including relays data
+    let relays = ["wss://relay.damus.io"];
+    let nprofile = new Nip19Profile(keys.publicKey, relays);
+    console.log(` Profile (encoded): ${nprofile.toBech32()}`);
+    // ANCHOR_END: nip19-nprofile-encode
+
+    // ANCHOR: nip19-nprofile-decode
+    // Decode NIP-19 profile
+    let decode_nprofile = Nip19Profile.fromBech32(nprofile.toBech32());
+    console.log(` Profile (decoded): ${decode_nprofile.publicKey().toBech32()}`);
+    // ANCHOR_END: nip19-nprofile-decode
+
+    console.log();
+    // ANCHOR: nip19-nevent-encode
+    // Create NIP-19 event including author and relays data
+    let nevent = new Nip19Event(event.id, keys.publicKey, null, relays);
+    console.log(` Event (encoded): ${nevent.toBech32()}`);
+    // ANCHOR_END: nip19-nevent-encode
+
+    // ANCHOR: nip19-nevent-decode
+    // Decode NIP-19 event
+    let decode_nevent = Nip19Event.fromBech32(nevent.toBech32());
+    console.log(` Event (decoded): ${decode_nevent.eventId().toBech32()}`);
+    // ANCHOR_END: nip19-nevent-decode
+
+    console.log();
+    // ANCHOR: nip19-nrelay-encode
+    // Create NIP-19 relay
+    let relay = new Nip19Relay("wss://relay.damus.io");
+    console.log(` Relay (encoded): ${relay.toBech32()}`);
+    // ANCHOR_END: nip19-nrelay-encode
+
+    // ANCHOR: nip19-nrelay-decode
+    // Decode NIP-19 relay
+    let decode_relay = Nip19Relay.fromBech32(relay.toBech32());
+    console.log(` Relay (decoded): ${decode_relay.url()}`);
+    // ANCHOR_END: nip19-nrelay-decode
+
+}
+
+module.exports.run = run;

--- a/book/snippets/nostr/js/src/nip19.js
+++ b/book/snippets/nostr/js/src/nip19.js
@@ -1,4 +1,4 @@
-const { loadWasmSync, Keys, EventBuilder, Nip19Profile, Nip19Event, Nip19Relay} = require("@rust-nostr/nostr");
+const { loadWasmSync, Keys, EventBuilder, Nip19Profile, Nip19Event} = require("@rust-nostr/nostr");
 
 function run() {
     // Load WASM
@@ -49,19 +49,6 @@ function run() {
     let decode_nevent = Nip19Event.fromBech32(nevent.toBech32());
     console.log(` Event (decoded): ${decode_nevent.eventId().toBech32()}`);
     // ANCHOR_END: nip19-nevent-decode
-
-    console.log();
-    // ANCHOR: nip19-nrelay-encode
-    // Create NIP-19 relay
-    let relay = new Nip19Relay("wss://relay.damus.io");
-    console.log(` Relay (encoded): ${relay.toBech32()}`);
-    // ANCHOR_END: nip19-nrelay-encode
-
-    // ANCHOR: nip19-nrelay-decode
-    // Decode NIP-19 relay
-    let decode_relay = Nip19Relay.fromBech32(relay.toBech32());
-    console.log(` Relay (decoded): ${decode_relay.url()}`);
-    // ANCHOR_END: nip19-nrelay-decode
 
 }
 

--- a/book/snippets/nostr/js/src/nip19.js
+++ b/book/snippets/nostr/js/src/nip19.js
@@ -1,4 +1,4 @@
-const { loadWasmSync, Keys, EventBuilder, Nip19Profile, Nip19Event} = require("@rust-nostr/nostr");
+const { loadWasmSync, Keys, EventBuilder, Nip19Profile, Nip19Event, Coordinate } = require("@rust-nostr/nostr");
 
 function run() {
     // Load WASM
@@ -50,6 +50,19 @@ function run() {
     console.log(` Event (decoded): ${decode_nevent.eventId().toBech32()}`);
     // ANCHOR_END: nip19-nevent-decode
 
+    console.log();
+    // ANCHOR: nip19-naddr-encode
+    // Create NIP-19 coordinate
+    let coord = new Coordinate(0,keys.publicKey());
+    console.log(` Coordinate (encoded): ${coord.toBech32()}`);
+    // ANCHOR_END: nip19-naddr-encode
+
+    // ANCHOR: nip19-naddr-decode
+    // Decode NIP-19 coordinate
+    let decode_coord = Coordinate.parse(coord.toBech32());
+    console.log(` Coordinate (decoded): ${decode_coord}`);
+    // ANCHOR_END: nip19-naddr-decode
+    
 }
 
 module.exports.run = run;

--- a/book/src/nostr/06-nip05.md
+++ b/book/src/nostr/06-nip05.md
@@ -42,7 +42,19 @@ To get the NIP-05 profile data (ex. user public key and relays) the `get_nip05_p
 <div slot="title">JavaScript</div>
 <section>
 
-TODO
+Using the `Metadata` class to build the metadata object and incorporate the NIP-05 identifier with the `nip05()` method. 
+
+For more details on metadata (or general) events please refer back to the [examples](06-nip01.md) provided for NIP-01.
+
+```javascript,ignore
+{{#include ../../snippets/nostr/js/src/nip05.js:set-metadata}}
+```
+
+For verification of NIP-05 identifiers associated with a given `PublicKey` object we can the `verifyNip05()` function  as follows:
+
+```javascript,ignore
+{{#include ../../snippets/nostr/js/src/nip05.js:verify-nip05}}
+```
 
 </section>
 

--- a/book/src/nostr/06-nip05.md
+++ b/book/src/nostr/06-nip05.md
@@ -56,6 +56,12 @@ For verification of NIP-05 identifiers associated with a given `PublicKey` objec
 {{#include ../../snippets/nostr/js/src/nip05.js:verify-nip05}}
 ```
 
+To get the NIP-05 profile data (ex. user public key and relays) the `getNip05Profile()` function can be called:
+
+```javascript,ignore
+{{#include ../../snippets/nostr/js/src/nip05.js:nip05-profile}}
+```
+
 </section>
 
 <div slot="title">Kotlin</div>

--- a/book/src/nostr/06-nip19.md
+++ b/book/src/nostr/06-nip19.md
@@ -119,11 +119,11 @@ Using the `Nip19Event` class to create a shareable `nevent` that includes author
 In addition to the above objects the `Nip19Relay` class can also be used to create a shareable `nrelay`, however it should be noted that per [NIP-19 documentation](https://github.com/nostr-protocol/nips/blob/master/19.md#shareable-identifiers-with-extra-metadata) this is now depreciated. This is followed by decoding the event object.
 
 ```javascript,ignore
-{{#include ../../snippets/nostr/js/src/nip19.js:nip19-nevent-encode}}
+{{#include ../../snippets/nostr/js/src/nip19.js:nip19-nrelay-encode}}
 ```
 
 ```javascript,ignore
-{{#include ../../snippets/nostr/js/src/nip19.js:nip19-nevent-decode}}
+{{#include ../../snippets/nostr/js/src/nip19.js:nip19-nrelay-decode}}
 ```
 
 </section>

--- a/book/src/nostr/06-nip19.md
+++ b/book/src/nostr/06-nip19.md
@@ -116,6 +116,16 @@ Using the `Nip19Event` class to create a shareable `nevent` that includes author
 {{#include ../../snippets/nostr/js/src/nip19.js:nip19-nevent-decode}}
 ```
 
+Using the `Coordinate` class to generate the coordinates for a replaceable event (in this case Metadata). This is followed by decoding the object which uses the `parse` method.
+
+```javascript,ignore
+{{#include ../../snippets/nostr/js/src/nip19.js:nip19-naddr-encode}}
+```
+
+```javascript,ignore
+{{#include ../../snippets/nostr/js/src/nip19.js:nip19-naddr-decode}}
+```
+
 </section>
 
 <div slot="title">Kotlin</div>

--- a/book/src/nostr/06-nip19.md
+++ b/book/src/nostr/06-nip19.md
@@ -78,7 +78,53 @@ Using the `Coordinate` class to generate the coordinates for a replaceable event
 <div slot="title">JavaScript</div>
 <section>
 
-TODO
+For most of these examples you will see that the `toBech32()` and `fromBech32()` methods generally facilitate encoding or decoding objects per the NIP-19 standard.
+
+Public and Private (or secret) keys in `npub` and `nsec` formats.
+
+```javascript,ignore
+{{#include ../../snippets/nostr/js/src/nip19.js:nip19-npub}}
+```
+
+```javascript,ignore
+{{#include ../../snippets/nostr/js/src/nip19.js:nip19-nsec}}
+```
+
+Simple note presented in NIP-19 format.
+
+```javascript,ignore
+{{#include ../../snippets/nostr/js/src/nip19.js:nip19-note}}
+```
+
+Using the `Nip19Profile` class to create a shareable `nprofile` that includes relay data to help other applications to locate the profile data. This is followed by decoding the event object.
+
+```javascript,ignore
+{{#include ../../snippets/nostr/js/src/nip19.js:nip19-nprofile-encode}}
+```
+
+```javascript,ignore
+{{#include ../../snippets/nostr/js/src/nip19.js:nip19-nprofile-decode}}
+```
+
+Using the `Nip19Event` class to create a shareable `nevent` that includes author and relay data. This is followed by decoding the event object.
+
+```javascript,ignore
+{{#include ../../snippets/nostr/js/src/nip19.js:nip19-nevent-encode}}
+```
+
+```javascript,ignore
+{{#include ../../snippets/nostr/js/src/nip19.js:nip19-nevent-decode}}
+```
+
+In addition to the above objects the `Nip19Relay` class can also be used to create a shareable `nrelay`, however it should be noted that per [NIP-19 documentation](https://github.com/nostr-protocol/nips/blob/master/19.md#shareable-identifiers-with-extra-metadata) this is now depreciated. This is followed by decoding the event object.
+
+```javascript,ignore
+{{#include ../../snippets/nostr/js/src/nip19.js:nip19-nevent-encode}}
+```
+
+```javascript,ignore
+{{#include ../../snippets/nostr/js/src/nip19.js:nip19-nevent-decode}}
+```
 
 </section>
 

--- a/book/src/nostr/06-nip19.md
+++ b/book/src/nostr/06-nip19.md
@@ -116,16 +116,6 @@ Using the `Nip19Event` class to create a shareable `nevent` that includes author
 {{#include ../../snippets/nostr/js/src/nip19.js:nip19-nevent-decode}}
 ```
 
-In addition to the above objects the `Nip19Relay` class can also be used to create a shareable `nrelay`, however it should be noted that per [NIP-19 documentation](https://github.com/nostr-protocol/nips/blob/master/19.md#shareable-identifiers-with-extra-metadata) this is now depreciated. This is followed by decoding the event object.
-
-```javascript,ignore
-{{#include ../../snippets/nostr/js/src/nip19.js:nip19-nrelay-encode}}
-```
-
-```javascript,ignore
-{{#include ../../snippets/nostr/js/src/nip19.js:nip19-nrelay-decode}}
-```
-
 </section>
 
 <div slot="title">Kotlin</div>


### PR DESCRIPTION
### Description
- Updated index.js to include nip05.js and nip19.js
- Added js examples to snippets for nip05 and nip19
- Updated book src to embed code snippets into existing text

### Notes to the reviewers

Spotted a few missing things when making this conversion from the python to the js examples:
- No equivalent function that I could see for `get_nip05_profile()` so unable to replicate this example
- `Coordinate` class doesn't appear to have a `toBech32()` method so `naddr` didn't appear possible (maybe let me know if I missed something though)
- Missing generalised `Nip19` class to be able to decode any NIP-19 object dynamically without knowing what kind of object it is before decoding. let me know if I missed how to do this though, wasn't obvious from the js bindings.

Still having issues with my installation of the package on linux (ubuntu) machine. It does not like the "nostr_js_bg.wasm.js" file that is created on installation. The base64 decoding of this file falls over on my side.

### Checklist

* [x] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [x] I ran `just precommit` or `just check` before committing **(ran tests on another computer, please rerun!!)**
* [ ] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
