### PR TITLE
book: add NIP21 JavaScript examples

### DIFF
--- a/book/snippets/nostr/js/index.js
+++ b/book/snippets/nostr/js/index.js
@@ -5,6 +5,7 @@ const relayMessages = require("./src/messages/relay");
 const nip01 = require("./src/nip01");
 const nip05 = require("./src/nip05");
 const nip19 = require("./src/nip19");
+const nip21 = require("./src/nip21");
 const nip44 = require("./src/nip44");
 const nip59 = require("./src/nip59");
 const nip65 = require("./src/nip65");
@@ -23,6 +24,7 @@ async function main() {
     nip01.run();
     await nip05.run();
     nip19.run();
+    nip21.run();
     nip44.run();
 
     nip59.run();

--- a/book/snippets/nostr/js/src/nip21.js
+++ b/book/snippets/nostr/js/src/nip21.js
@@ -63,4 +63,4 @@ function run(){
 
 }
 
-run();
+module.exports.run = run;

--- a/book/snippets/nostr/js/src/nip21.js
+++ b/book/snippets/nostr/js/src/nip21.js
@@ -1,0 +1,66 @@
+const { loadWasmSync, Keys, EventBuilder, Nip19Profile, Nip19Event, Coordinate} = require("@rust-nostr/nostr");
+
+function run(){
+    // Load WASM
+    loadWasmSync();
+
+    console.log();
+    console.log("Nostr URIs:");
+
+    // ANCHOR: npub
+    let keys = Keys.generate();
+    // bech32 npub
+    let pk_bech32 = keys.publicKey.toBech32();
+    console.log(` Public key (bech32): ${pk_bech32}`);
+    // ANCHOR_END: npub
+
+    console.log();
+    // ANCHOR: note
+    let event = EventBuilder.textNote("Hello from Rust Nostr JS Bindings!", []).toEvent(keys);
+
+    // bech32 note
+    let note_bech32 = event.id.toBech32()
+    console.log(` Event (bech32): ${note_bech32}`);
+    // ANCHOR_END: note
+
+    console.log();
+    // ANCHOR: nprofile
+    let relays = ["wss://relay.damus.io"];
+    let nprofile = new Nip19Profile(keys.publicKey, relays);
+
+    // URI nprofile
+    let nprofile_uri = nprofile.toNostrUri();
+    console.log(` Profile (URI):    ${nprofile_uri}`);
+
+    // bech32 nprofile
+    let nprofile_bech32 = Nip19Profile.fromNostrUri(nprofile_uri).toBech32();
+    console.log(` Profile (bech32): ${nprofile_bech32}`);
+    // ANCHOR_END: nprofile
+    
+    console.log();
+    // ANCHOR: nevent
+    let nevent = new Nip19Event(event.id, keys.publicKey, null, relays);
+
+    // URI nevent
+    let nevent_uri = nevent.toNostrUri();
+    console.log(` Event (URI):    ${nevent_uri}`);
+
+    // bech32 nevent
+    let nevent_bech32 = Nip19Event.fromNostrUri(nevent_uri).toBech32();
+    console.log(` Event (bech32): ${nevent_bech32}`);
+    // ANCHOR_END: nevent
+
+    console.log();
+    // ANCHOR: naddr
+    // URI naddr
+    let coord_uri = new Coordinate(event.kind, keys.publicKey).toNostrUri();
+    console.log(` Coordinate (URI):    ${coord_uri}`);
+
+    // bech32 naddr
+    let coord_bech32 = new Coordinate(event.kind, keys.publicKey).toBech32();
+    console.log(` Coordinate (bech32): ${coord_bech32}`);
+    // ANCHOR_END: naddr
+
+}
+
+run();

--- a/book/src/nostr/06-nip21.md
+++ b/book/src/nostr/06-nip21.md
@@ -60,7 +60,40 @@ Coordinate identifier:
 <div slot="title">JavaScript</div>
 <section>
 
-TODO
+Generally speaking the simplest way for handling NIP-21 objects is by the `toNostrUri()` and `fromNostrUri()` methods for encoding or decoding data, respectively. 
+
+Note that the `fromNostrUri()` method is only currently available for the `NIP19Profile` and `NIP19Event` classes.
+
+
+Public key:
+
+```javascript,ignore
+{{#include ../../snippets/nostr/js/src/nip21.js:npub}}
+```
+
+Note:
+
+```javascript,ignore
+{{#include ../../snippets/nostr/js/src/nip21.js:note}}
+```
+
+Profile identifier:
+
+```javascript,ignore
+{{#include ../../snippets/nostr/js/src/nip21.js:nprofile}}
+```
+
+Event identifier:
+
+```javascript,ignore
+{{#include ../../snippets/nostr/js/src/nip21.js:nevent}}
+```
+
+Coordinate identifier:
+
+```javascript,ignore
+{{#include ../../snippets/nostr/js/src/nip21.js:naddr}}
+```
 
 </section>
 


### PR DESCRIPTION
### Description

- Updated index.js
- Added nip21.js
- Updated nip21.md

### Notes to the reviewers

Wasn’t able to adde the full URI examples for `note` and `npub`, figured it was related to the JS bindings not having `toNostrUri()` method exposed currently. If you’re able to add this let me know and I’ll update the examples.

Similarly, consider adding `fromNostrUri()` to the the `Coordinate` class and I’ll tweak the current Bech32 example so that it show how to decode the URI.

Finally, I noticed the `NIP21` with `parse()` method wasn’t available for the js bindings, as with python. Was this intentional or is it a limitation of the js binding themselves?

### Checklist

* [x] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [x] I ran `just precommit` or `just check` before committing
* [ ] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
