### PR TITLE
book: add rust snippet for NIP-17

### DIFF
--- a/book/snippets/nostr/rust/src/nip17.rs
+++ b/book/snippets/nostr/rust/src/nip17.rs
@@ -1,0 +1,52 @@
+use nostr::prelude::*;
+
+pub fn run() -> Result<()> {
+    // Sender keys
+    let alice_keys =
+        Keys::parse("5c0c523f52a5b6fad39ed2403092df8cebc36318b39383bca6c00808626fab3a")?;
+    let alice_client = Client::new(&keys);
+    alice_client.add_relay("wss://relay.damus.io").await?;
+    alice_client.connect().await;
+
+    // Receiver Keys
+    let bob_keys = Keys::parse("nsec1j4c6269y9w0q2er2xjw8sv2ehyrtfxq3jwgdlxj6qfn8z4gjsq5qfvfk99")?;
+    bob_client.add_relay("wss://relay.damus.io").await?;
+    bob_client.connect().await;
+    // Initialize subscription on Bob's side before sending the message
+    let subscription_id = init_subscription(&bob_keys, &bob_client).await?;
+
+    // Alice sends private message to Bob
+    alice_client.send_private_message(bob_keys.public_key(), "Hello Bob!".to_string(), None).await?;
+    println!("Sent private message to Bob");
+
+    // Bob receives private message
+    match bob_client.notifications().recv().await {
+        Ok(notification) => {
+            if let RelayPoolNotification::Event { event, .. } = notification {
+                let rumor = bob_client.unwrap_gift_wrap(&event).await?.rumor;
+                if rumor.kind == Kind::PrivateDirectMessage {
+                    println!("Bob received private message: {}", &rumor.content);
+                }
+            }
+        }
+        Err(err) => {
+            println!("Bob got error: {}", err.to_string());
+        }
+    }
+
+    bob_client.unsubscribe(subscription_id).await;
+
+    Ok(())
+}
+
+async fn init_subscription(
+    keys: &Keys,
+    client: &Client,
+) -> Result<SubscriptionId, Error> {
+    let message_filter = Filter::new()
+        .kind(Kind::GiftWrap)
+        .pubkey(keys.public_key())
+        .limit(0); // Limit set to 0 to get only new events! Timestamp::now() CAN'T be used for gift wrap since the timestamps are tweaked!
+    let subscription_id = client.subscribe(vec![message_filter], None).await?.val;
+    Ok(subscription_id)
+}

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -21,6 +21,7 @@
         * [NIP-05](./nostr/06-nip05.md)
         * [NIP-06](./nostr/06-nip06.md)
         * [NIP-07](./nostr/06-nip07.md)
+        * [NIP-17](./nostr/06-nip17.md)
         * [NIP-19](./nostr/06-nip19.md)
         * [NIP-21](./nostr/06-nip21.md)
         * [NIP-44](./nostr/06-nip44.md)

--- a/book/src/nostr/06-nip17.md
+++ b/book/src/nostr/06-nip17.md
@@ -1,0 +1,44 @@
+## NIP-17
+
+### Private Direct Messages
+NIP-17 defines an encrypted direct messaging scheme using NIP-44 encryption, NIP-59 seals and gift wraps. See [NIP-17](https://github.com/nostr-protocol/nips/blob/master/17.md) for a detailed description. This scheme is used to send messages between two parties avoiding metadata leaks as in [NIP-04 (Encrypted Direct Message)](https://github.com/nostr-protocol/nips/blob/master/04.md).
+
+<custom-tabs category="lang">
+
+<div slot="title">Rust</div>
+<section>
+
+```rust,ignore
+{{#include ../../snippets/nostr/rust/src/nip17.rs}}
+```
+
+</section>
+
+<div slot="title">Python</div>
+<section>
+
+TODO
+
+</section>
+
+<div slot="title">JavaScript</div>
+<section>
+
+TODO
+
+</section>
+
+<div slot="title">Kotlin</div>
+<section>
+
+TODO
+
+</section>
+
+<div slot="title">Swift</div>
+<section>
+
+TODO
+
+</section>
+</custom-tabs>


### PR DESCRIPTION
### Description

This PR adds  an Rust snippet for NIP-17 (private direct messages) to the book.

### Checklist

* [x] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [x] I ran `just precommit` or `just check` before committing
* [ ] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
