### PR TITLE
nostr: fix job kind ranges

### DIFF
--- a/crates/nostr/src/event/kind.rs
+++ b/crates/nostr/src/event/kind.rs
@@ -15,9 +15,9 @@ use serde::de::{Deserialize, Deserializer, Error, Visitor};
 use serde::ser::{Serialize, Serializer};
 
 /// NIP90 - Job request range
-pub const NIP90_JOB_REQUEST_RANGE: Range<u16> = 5_000..5_999;
+pub const NIP90_JOB_REQUEST_RANGE: Range<u16> = 5_000..6_000;
 /// NIP90 - Job result range
-pub const NIP90_JOB_RESULT_RANGE: Range<u16> = 6_000..6_999;
+pub const NIP90_JOB_RESULT_RANGE: Range<u16> = 6_000..7_000;
 /// Regular range
 pub const REGULAR_RANGE: Range<u16> = 1_000..10_000;
 /// Replaceable range


### PR DESCRIPTION
rust ranges are exclusive of the end

### Description

just a minor correction

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Checklist

* [ ] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [ ] I ran `just precommit` or `just check` before committing
* [ ] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
