### PR TITLE
Add NIP-44 decryption support to NostrConnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 
 ### Changed
 
+* nostr-connect: add NIP44 decryption support ([erskingardner])
 * Bump `async-utility` to 0.3, `async-wsocket` to 0.11 and `atomic-destructor` to 0.3 ([Yuki Kishimoto])
 * nostr: remove self-tagging when building events ([Yuki Kishimoto])
 * nostr: don't set root tags when the root is null ([Yuki Kishimoto])

--- a/crates/nostr-connect/src/error.rs
+++ b/crates/nostr-connect/src/error.rs
@@ -7,7 +7,7 @@
 use std::convert::Infallible;
 
 use nostr::event::builder;
-use nostr::nips::{nip04, nip46};
+use nostr::nips::{nip04, nip44, nip46};
 use nostr::PublicKey;
 use thiserror::Error;
 use tokio::sync::SetError;
@@ -21,6 +21,9 @@ pub enum Error {
     /// NIP04 error
     #[error(transparent)]
     NIP04(#[from] nip04::Error),
+    /// NIP44 error
+    #[error(transparent)]
+    NIP44(#[from] nip44::Error),
     /// NIP46 error
     #[error(transparent)]
     NIP46(#[from] nip46::Error),


### PR DESCRIPTION
This updates the NostrConnect message handling to use either NIP-04 or NIP-44 decryption by checking for `?iv=` in the event content.
