### PR TITLE
nostr: Add peer-to-peer orders kind support

### DIFF
--- a/bindings/nostr-sdk-ffi/src/protocol/event/kind.rs
+++ b/bindings/nostr-sdk-ffi/src/protocol/event/kind.rs
@@ -279,6 +279,10 @@ pub enum KindEnum {
     ReleaseArtifactSet,
     /// Relay List Metadata (NIP65)
     RelayList,
+    /// Peer-to-peer Order events
+    ///
+    /// <https://github.com/nostr-protocol/nips/blob/master/69.md>
+    PeerToPeerOrder,
     /// Client Authentication (NIP42)
     Authentication,
     /// Wallet Connect Request (NIP47)
@@ -420,6 +424,7 @@ impl From<nostr::Kind> for KindEnum {
             nostr::Kind::MlsGroupMessage => Self::MlsGroupMessage,
             nostr::Kind::Torrent => Self::Torrent,
             nostr::Kind::TorrentComment => Self::TorrentComment,
+            nostr::Kind::PeerToPeerOrder => Self::PeerToPeerOrder,
             #[allow(deprecated)]
             nostr::Kind::JobRequest(u)
             | nostr::Kind::JobResult(u)
@@ -515,6 +520,7 @@ impl From<KindEnum> for nostr::Kind {
             KindEnum::MlsGroupMessage => Self::MlsGroupMessage,
             KindEnum::Torrent => Self::Torrent,
             KindEnum::TorrentComment => Self::TorrentComment,
+            KindEnum::PeerToPeerOrder => Self::PeerToPeerOrder,
             KindEnum::Custom { kind } => Self::Custom(kind),
         }
     }

--- a/crates/nostr/src/event/kind.rs
+++ b/crates/nostr/src/event/kind.rs
@@ -182,6 +182,7 @@ kind_variants! {
     ApplicationSpecificData => 30078, "Application-specific Data", "<https://github.com/nostr-protocol/nips/blob/master/78.md>",
     Torrent => 2003, "Torrent", "<https://github.com/nostr-protocol/nips/blob/master/35.md>",
     TorrentComment => 2004, "Torrent Comment", "<https://github.com/nostr-protocol/nips/blob/master/35.md>",
+    PeerToPeerOrder => 38383, "Peer-to-peer Order events", "<https://github.com/nostr-protocol/nips/blob/master/69.md>",
 }
 
 impl PartialEq for Kind {


### PR DESCRIPTION
Include kind we use on NIP-69 p2p orders events