### PR TITLE
book: add (id) TypeScript examples

### DIFF
--- a/book/snippets/js/src/event/id.ts
+++ b/book/snippets/js/src/event/id.ts
@@ -1,0 +1,61 @@
+import { EventId, Keys, Timestamp, Kind, EventBuilder } from "@rust-nostr/nostr-sdk"
+
+export function eventID() {
+
+    // Generate Keys
+    const keys = Keys.generate();
+
+    console.log();
+    console.log("Event ID:");
+
+    // ANCHOR: build-event-id
+    console.log("  Build Event ID:");
+    let event_id = new EventId(keys.publicKey, Timestamp.now(), new Kind(1), [], "");
+    console.log(`     - ${event_id}`);
+    // ANCHOR_END: build-event-id
+
+    console.log();
+    // ANCHOR: format-parse-hex
+    // To Hex and then Parse
+    console.log("  Event ID (hex):");
+    let event_id_hex = event_id.toHex();
+    console.log(`     - Hex: ${event_id_hex}`);
+    console.log(`     - Parse: ${EventId.parse(event_id_hex)}`);
+   // ANCHOR_END: format-parse-hex
+
+    console.log();
+    // ANCHOR: format-parse-bech32
+    // To Bech32 and then Parse
+    console.log("  Event ID (bech32):");
+    let event_id_bech32 = event_id.toBech32();
+    console.log(`     - Bech32: ${event_id_bech32}`);
+    console.log(`     - Parse: ${EventId.parse(event_id_bech32)}`);
+    // ANCHOR_END: format-parse-bech32
+
+    console.log();
+    // ANCHOR: format-parse-nostr-uri
+    // To Nostr URI and then Parse
+    console.log("  Event ID (nostr uri):");
+    let event_id_nostr_uri = event_id.toNostrUri();
+    console.log(`     - Nostr URI: ${event_id_nostr_uri}`);
+    // UNCOMMENT_ON_RELEASE: console.log(`     - Parse: ${EventId.parse(event_id_nostr_uri)}`);
+    // ANCHOR_END: format-parse-nostr-uri
+
+    console.log();
+    // ANCHOR: format-parse-bytes
+    // As Bytes and then Parse
+    console.log("  Event ID (bytes):");
+    let event_id_bytes = event_id.asBytes();
+    console.log(`     - Bytes: ${event_id_bytes}`);
+    // UNCOMMENT_ON_RELEASE: console.log(`     - From Bytes: ${EventId.fromBytes(event_id_hex)}`);
+    // ANCHOR_END: format-parse-bytes
+
+    console.log();
+    // ANCHOR: access-verify
+    // Event ID from Event & Verfiy
+    console.log("  Event ID from Event:");
+    let event = EventBuilder.textNote("This is a note", []).signWithKeys(keys);
+    console.log(`     - Event ID: ${event.id.toBech32()}`);
+    console.log(`     - Verify the ID & Signature: ${event.verify()}`);
+    // ANCHOR_END: access-verify
+}

--- a/book/snippets/js/src/event/id.ts
+++ b/book/snippets/js/src/event/id.ts
@@ -57,5 +57,6 @@ export function eventID() {
     let event = EventBuilder.textNote("This is a note").signWithKeys(keys);
     console.log(`     - Event ID: ${event.id.toBech32()}`);
     console.log(`     - Verify the ID & Signature: ${event.verify()}`);
+    console.log(`     - Verify the ID Only: ${event.verifyId()}`);
     // ANCHOR_END: access-verify
 }

--- a/book/snippets/js/src/event/id.ts
+++ b/book/snippets/js/src/event/id.ts
@@ -54,7 +54,7 @@ export function eventID() {
     // ANCHOR: access-verify
     // Event ID from Event & Verfiy
     console.log("  Event ID from Event:");
-    let event = EventBuilder.textNote("This is a note", []).signWithKeys(keys);
+    let event = EventBuilder.textNote("This is a note").signWithKeys(keys);
     console.log(`     - Event ID: ${event.id.toBech32()}`);
     console.log(`     - Verify the ID & Signature: ${event.verify()}`);
     // ANCHOR_END: access-verify

--- a/book/src/sdk/event/id.md
+++ b/book/src/sdk/event/id.md
@@ -27,9 +27,8 @@ Upon instantiation the following content are passed to the class instance to gen
 
 Once we have an event id object we are able to format and parse this using a few simple methods. 
 To present as a hex, bech32, nostr uri or as bytes we need only call the relevant methods `to_hex()`, `to_bech32()`, `to_nostr_uri()` or `to_bytes()`. 
-Similarly, we can parse these different representations of the event ID by using the opposite 'from' methods: `from_hex()`, `from_bech32()`, `from_nostr_uri()` or `from_bytes()`.
 
-In the event that we want to generalise and simplify this process, across hex/bech32 or nostr uri formats, we can instead simply call `parse()` method and pass this the event id string matching one of these formats. 
+It is somewhat trivial to perform the reverse action given that this has been generalised across, hex/bech32 or nostr uri formats. This is achived by calling the `parse()` method and passing this the event id string matching one of these formats. The exception to this rule is for bytes where the `from_bytes()` method is to be used.
 
 For more information/examples on the formatting of Nostr objects please refer to [NIP-19](../nips/19.md) and [NIP-21](../nips/21.md).
 
@@ -54,7 +53,36 @@ For more information/examples on the formatting of Nostr objects please refer to
 <div slot="title">JavaScript</div>
 <section>
 
-TODO
+The `EventId` class can be called in order to construct event ids, although this is not necessary when building `Event` objects as it will be done automatically at that time. 
+
+Upon instantiation the following content are passed to the class instance to generate the event ID: `publicKey`, `createdAt`, `kind`, `tags` and `content`.
+
+```typescript,ignore
+{{#include ../../../snippets/js/src/event/id.ts:build-event-id}}
+```
+
+Once we have an event id object we are able to format and parse this using a few simple methods. 
+To present as a hex, bech32, nostr uri or as bytes we need only call the relevant methods `toHex()`, `toBech32()`, `toNostrUri()` or `asBytes()`. 
+
+It is somewhat trivial to perform the reverse action given that this has been generalised across, hex/bech32 or nostr uri formats. This is achived by calling the `parse()` method and passing this the event id string matching one of these formats. The exception to this rule is for bytes where the `fromBytes()` method is to be used.
+
+For more information/examples on the formatting of Nostr objects please refer to [NIP-19](../nips/19.md) and [NIP-21](../nips/21.md).
+
+```typescript,ignore
+{{#include ../../../snippets/js/src/event/id.ts:format-parse-hex}}
+```
+
+```typescript,ignore
+{{#include ../../../snippets/js/src/event/id.ts:format-parse-bech32}}
+```
+
+```typescript,ignore
+{{#include ../../../snippets/js/src/event/id.ts:format-parse-nostr-uri}}
+```
+
+```typescript,ignore
+{{#include ../../../snippets/js/src/event/id.ts:format-parse-bytes}}
+```
 
 </section>
 
@@ -105,7 +133,11 @@ In addition to directly creating/manipulating event ID objects we can also easil
 <div slot="title">JavaScript</div>
 <section>
 
-TODO
+In addition to directly creating/manipulating event ID objects we can also easily access these directly from events, by calling the `id()` method on and instance of the `Event` class, or, verify that the event id (and signature) for an event is valid, by using the `verify()` method.  
+
+```typescript,ignore
+{{#include ../../../snippets/js/src/event/id.ts:access-verify}}
+```
 
 </section>
 

--- a/book/src/sdk/event/id.md
+++ b/book/src/sdk/event/id.md
@@ -133,7 +133,7 @@ In addition to directly creating/manipulating event ID objects we can also easil
 <div slot="title">JavaScript</div>
 <section>
 
-In addition to directly creating/manipulating event ID objects we can also easily access these directly from events, by calling the `id()` method on and instance of the `Event` class, or, verify that the event id (and signature) for an event is valid, by using the `verify()` method.  
+In addition to directly creating/manipulating event ID objects we can also easily access these directly from events, by calling the `id()` method on and instance of the `Event` class, or, verify that the event id (and signature) for an event is valid, by using `verify()` method for both Signature & ID or the `verifyId()` method for the ID alone.  
 
 ```typescript,ignore
 {{#include ../../../snippets/js/src/event/id.ts:access-verify}}


### PR DESCRIPTION
### Description
- Added ts example to existing id.md
- Modified text for python examples to better reflect code snippets (exclusive use of parse() method)
- Added id.ts  example code

### Notes to the reviewers
- There are two commented stings in the code examples for parse of nostr uri and bytes, the relevant methods `parse()` and `fromBytes()` (respectively) were unavailable at the time of writing these examples.
- Happy New Year :tada: , keep up the awesome work! 

### Checklist

* [x] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [x] I ran `just precommit` or `just check` before committing
* [ ] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
