### PR TITLE
pool: add WebSocket transport abstraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,9 +111,11 @@
 * pool: add `RelayPool::try_connect` ([Yuki Kishimoto])
 * pool: add `RelayPool::try_connect_relay` ([Yuki Kishimoto])
 * pool: add `RelayPool::wait_for_connection` ([Yuki Kishimoto])
+* pool: add WebSocket transport abstraction ([Yuki Kishimoto])
 * sdk: add `Client::try_connect` ([Yuki Kishimoto])
 * sdk: add `Client::try_connect_relay` ([Yuki Kishimoto])
 * sdk: add `Client::wait_for_connection` ([Yuki Kishimoto])
+* sdk: add `ClientBuilder::websocket_transport` ([Yuki Kishimoto])
 * relay-builder: custom http server ([v0l])
 * cli: allow setting a port in `serve` command ([Yuki Kishimoto])
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,7 +337,7 @@ dependencies = [
 [[package]]
 name = "async-wsocket"
 version = "0.12.0"
-source = "git+https://github.com/yukibtc/async-wsocket?rev=da5da94574f73da1b4d638fd9736298a67139c59#da5da94574f73da1b4d638fd9736298a67139c59"
+source = "git+https://github.com/yukibtc/async-wsocket?rev=5fba7927576064ac0698a4ee3df0d26e5cf726dd#5fba7927576064ac0698a4ee3df0d26e5cf726dd"
 dependencies = [
  "arti-client",
  "async-utility",
@@ -4665,9 +4665,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.24.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+checksum = "be4bf6fecd69fcdede0ec680aaf474cdab988f9de6bc73d3758f0160e3b7025a"
 dependencies = [
  "futures-util",
  "log",
@@ -5820,9 +5820,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.24.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+checksum = "413083a99c579593656008130e29255e54dcaae495be556cc26888f211648c24"
 dependencies = [
  "byteorder",
  "bytes",
@@ -5834,7 +5834,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "sha1",
- "thiserror 1.0.64",
+ "thiserror 2.0.8",
  "utf-8",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2826,6 +2826,7 @@ name = "nostr-sdk-ffi"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "async-wsocket",
  "nostr",
  "nostr-connect",
  "nostr-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ rust-version = "1.70.0"
 [workspace.dependencies]
 async-utility = "0.3"
 #async-wsocket = "0.12"
-async-wsocket = { git = "https://github.com/yukibtc/async-wsocket", rev = "da5da94574f73da1b4d638fd9736298a67139c59" }
+async-wsocket = { git = "https://github.com/yukibtc/async-wsocket", rev = "5fba7927576064ac0698a4ee3df0d26e5cf726dd" }
 atomic-destructor = { version = "0.3", default-features = false }
 js-sys = "0.3"
 negentropy = { version = "0.4", default-features = false }

--- a/bindings/nostr-sdk-ffi/Cargo.toml
+++ b/bindings/nostr-sdk-ffi/Cargo.toml
@@ -22,6 +22,7 @@ uniffi-cli = ["uniffi/cli"] # required for the `uniffi-bindgen` binary
 
 [dependencies]
 async-trait = "0.1"
+async-wsocket.workspace = true
 nostr = { workspace = true, features = ["std", "all-nips"] }
 nostr-connect.workspace = true
 nostr-sdk  = { workspace = true, default-features = false, features = ["all-nips"] }

--- a/bindings/nostr-sdk-ffi/android/lib/build.gradle.kts
+++ b/bindings/nostr-sdk-ffi/android/lib/build.gradle.kts
@@ -39,7 +39,7 @@ android {
 }
 
 dependencies {
-    implementation("net.java.dev.jna:jna:5.15.0@aar")
+    api("net.java.dev.jna:jna:5.15.0@aar")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
     implementation("androidx.appcompat:appcompat:1.6.1")
 }

--- a/bindings/nostr-sdk-ffi/python/examples/custom-websocket-client.py
+++ b/bindings/nostr-sdk-ffi/python/examples/custom-websocket-client.py
@@ -1,0 +1,111 @@
+import asyncio
+
+from datetime import timedelta
+
+from aiohttp import ClientSession, ClientWebSocketResponse, WSMsgType
+from nostr_sdk import *
+
+
+class MyAdapter(WebSocketAdapter):
+    def __init__(self, session: ClientSession, ws: ClientWebSocketResponse):
+        self.session = session
+        self.websocket = ws
+
+    async def send(self, msg: WebSocketMessage):
+        try:
+            if msg.is_text():
+                await self.websocket.send_str(msg[0])
+            elif msg.is_binary():
+                await self.websocket.send_bytes(msg[0])
+        except Exception as e:
+            # Handle clean closure gracefully
+            print(f"Attempted to send on a closed WebSocket: {e}")
+            raise e
+
+    async def recv(self) -> WebSocketMessage | None:
+        try:
+            # Receive message
+            raw_msg = await self.websocket.receive()
+
+            if raw_msg.type == WSMsgType.TEXT:
+                return WebSocketMessage.TEXT(raw_msg.data)
+            elif raw_msg.type == WSMsgType.BINARY:
+                return WebSocketMessage.BINARY(raw_msg.data)
+            elif raw_msg.type == WSMsgType.PING:
+                return WebSocketMessage.PING(raw_msg.data)
+            elif raw_msg.type == WSMsgType.PONG:
+                return WebSocketMessage.PONG(raw_msg.data)
+            else:
+                raise "unknown message type"
+        except Exception as e:
+            raise e
+
+    async def close_connection(self):
+        await self.websocket.close()
+        await self.session.close()
+
+class MyWebSocketClient(CustomWebSocketTransport):
+    def support_ping(self) -> bool:
+        return False
+
+    async def connect(self, url: "str", mode: "ConnectionMode", timeout) -> WebSocketAdapterWrapper:
+        try:
+            session = ClientSession()
+            ws = await session.ws_connect(url)
+
+            adaptor = MyAdapter(session, ws)
+            wrapper = WebSocketAdapterWrapper(adaptor)
+
+            return wrapper
+        except Exception as e:
+            raise e
+
+
+async def main():
+    uniffi_set_event_loop(asyncio.get_running_loop())
+
+    # Init logger
+    init_logger(LogLevel.TRACE)
+
+    # Initialize client without signer
+    # client = Client()
+
+    # Or, initialize with Keys signer
+    keys = Keys.parse("nsec1ufnus6pju578ste3v90xd5m2decpuzpql2295m3sknqcjzyys9ls0qlc85")
+    signer = NostrSigner.keys(keys)
+
+    # Or, initialize with NIP46 signer
+    # app_keys = Keys.parse("..")
+    # uri = NostrConnectUri.parse("bunker://.. or nostrconnect://..")
+    # connect = NostrConnect(uri, app_keys, timedelta(seconds=60), None)
+    # signer = NostrSigner.nostr_connect(connect)
+
+    client = ClientBuilder().signer(signer).websocket_transport(MyWebSocketClient()).build()
+    #client = ClientBuilder().signer(signer).build()
+
+    # Add relays and connect
+    await client.add_relay("ws://127.0.0.1:7777")
+    await client.connect()
+
+    # Send an event using the Nostr Signer
+    builder = EventBuilder.text_note("Test from rust-nostr Python bindings!")
+    output = await client.send_event_builder(builder)
+
+    print("Event sent:")
+    print(f" hex:    {output.id.to_hex()}")
+    print(f" bech32: {output.id.to_bech32()}")
+    print(f" Successfully sent to:    {output.success}")
+    print(f" Failed to send to: {output.failed}")
+
+    await asyncio.sleep(2.0)
+
+    # Get events from relays
+    print("Getting events from relays...")
+    f = Filter().authors([keys.public_key()])
+    events = await client.fetch_events([f], timedelta(seconds=10))
+    for event in events.to_vec():
+        print(event.as_pretty_json())
+
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/bindings/nostr-sdk-ffi/src/client/builder.rs
+++ b/bindings/nostr-sdk-ffi/src/client/builder.rs
@@ -3,12 +3,14 @@
 // Distributed under the MIT software license
 
 use std::ops::Deref;
+use std::sync::Arc;
 
 use uniffi::Object;
 
 use super::{Client, Options};
 use crate::database::NostrDatabase;
 use crate::protocol::signer::NostrSigner;
+use crate::transport::websocket::{CustomWebSocketTransport, FFI2RustWebSocketTransport};
 
 #[derive(Clone, Default, Object)]
 pub struct ClientBuilder {
@@ -38,6 +40,14 @@ impl ClientBuilder {
     pub fn database(&self, database: &NostrDatabase) -> Self {
         let mut builder = self.clone();
         builder.inner = builder.inner.database(database.deref().clone());
+        builder
+    }
+
+    /// Set a custom WebSocket transport
+    pub fn websocket_transport(&self, transport: Arc<dyn CustomWebSocketTransport>) -> Self {
+        let mut builder = self.clone();
+        let intermediate = FFI2RustWebSocketTransport { inner: transport };
+        builder.inner = builder.inner.websocket_transport(intermediate);
         builder
     }
 

--- a/bindings/nostr-sdk-ffi/src/error.rs
+++ b/bindings/nostr-sdk-ffi/src/error.rs
@@ -30,3 +30,29 @@ where
         Self::Generic(e.to_string())
     }
 }
+
+#[derive(Debug)]
+pub(crate) struct MiddleError(String);
+
+impl std::error::Error for MiddleError {}
+
+impl fmt::Display for MiddleError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl MiddleError {
+    pub fn new<S>(msg: S) -> Self
+    where
+        S: Into<String>,
+    {
+        Self(msg.into())
+    }
+}
+
+impl From<NostrSdkError> for MiddleError {
+    fn from(e: NostrSdkError) -> Self {
+        Self(e.to_string())
+    }
+}

--- a/bindings/nostr-sdk-ffi/src/lib.rs
+++ b/bindings/nostr-sdk-ffi/src/lib.rs
@@ -14,6 +14,7 @@ pub mod notifications;
 pub mod nwc;
 pub mod protocol;
 pub mod relay;
+pub mod transport;
 mod util;
 
 /// Get git hash version of `rust-nostr` libraries

--- a/bindings/nostr-sdk-ffi/src/protocol/signer/custom.rs
+++ b/bindings/nostr-sdk-ffi/src/protocol/signer/custom.rs
@@ -51,7 +51,6 @@ impl fmt::Debug for IntermediateCustomNostrSigner {
 }
 
 mod inner {
-    use std::fmt;
     use std::ops::Deref;
     use std::sync::Arc;
 
@@ -59,17 +58,7 @@ mod inner {
     use nostr::prelude::*;
 
     use super::IntermediateCustomNostrSigner;
-
-    #[derive(Debug)]
-    struct Error(String);
-
-    impl std::error::Error for Error {}
-
-    impl fmt::Display for Error {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            write!(f, "{}", self.0)
-        }
-    }
+    use crate::error::MiddleError;
 
     #[async_trait]
     impl NostrSigner for IntermediateCustomNostrSigner {
@@ -83,11 +72,11 @@ mod inner {
                     .inner
                     .get_public_key()
                     .await
-                    .map_err(|e| SignerError::backend(Error(e.to_string())))?
+                    .map_err(|e| SignerError::backend(MiddleError::from(e)))?
                     .ok_or_else(|| {
-                        SignerError::backend(Error(String::from(
+                        SignerError::backend(MiddleError::new(
                             "Received None instead of public key",
-                        )))
+                        ))
                     })?;
                 Ok(**public_key)
             })
@@ -100,9 +89,9 @@ mod inner {
                     .inner
                     .sign_event(unsigned)
                     .await
-                    .map_err(|e| SignerError::backend(Error(e.to_string())))?
+                    .map_err(|e| SignerError::backend(MiddleError::from(e)))?
                     .ok_or_else(|| {
-                        SignerError::backend(Error(String::from("Received None instead of event")))
+                        SignerError::backend(MiddleError::new("Received None instead of event"))
                     })?;
                 Ok(event.as_ref().deref().clone())
             })
@@ -118,7 +107,7 @@ mod inner {
                 self.inner
                     .nip04_encrypt(public_key, content.to_string())
                     .await
-                    .map_err(|e| SignerError::backend(Error(e.to_string())))
+                    .map_err(|e| SignerError::backend(MiddleError::from(e)))
             })
         }
 
@@ -132,7 +121,7 @@ mod inner {
                 self.inner
                     .nip04_decrypt(public_key, content.to_string())
                     .await
-                    .map_err(|e| SignerError::backend(Error(e.to_string())))
+                    .map_err(|e| SignerError::backend(MiddleError::from(e)))
             })
         }
 
@@ -146,7 +135,7 @@ mod inner {
                 self.inner
                     .nip44_encrypt(public_key, content.to_string())
                     .await
-                    .map_err(|e| SignerError::backend(Error(e.to_string())))
+                    .map_err(|e| SignerError::backend(MiddleError::from(e)))
             })
         }
 
@@ -160,7 +149,7 @@ mod inner {
                 self.inner
                     .nip44_decrypt(public_key, content.to_string())
                     .await
-                    .map_err(|e| SignerError::backend(Error(e.to_string())))
+                    .map_err(|e| SignerError::backend(MiddleError::from(e)))
             })
         }
     }

--- a/bindings/nostr-sdk-ffi/src/transport/mod.rs
+++ b/bindings/nostr-sdk-ffi/src/transport/mod.rs
@@ -1,0 +1,5 @@
+// Copyright (c) 2022-2023 Yuki Kishimoto
+// Copyright (c) 2023-2024 Rust Nostr Developers
+// Distributed under the MIT software license
+
+pub mod websocket;

--- a/bindings/nostr-sdk-ffi/src/transport/websocket.rs
+++ b/bindings/nostr-sdk-ffi/src/transport/websocket.rs
@@ -1,0 +1,386 @@
+// Copyright (c) 2022-2023 Yuki Kishimoto
+// Copyright (c) 2023-2024 Rust Nostr Developers
+// Distributed under the MIT software license
+
+use std::fmt;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_wsocket::message::{CloseFrame, Message};
+use nostr_sdk::pool::transport::websocket::{Sink, Stream};
+use uniffi::{Enum, Object, Record};
+
+use crate::error::Result;
+use crate::relay::ConnectionMode;
+
+#[derive(Debug, Record)]
+pub struct WebSocketCloseFrame {
+    pub code: u16,
+    pub reason: String,
+}
+
+impl From<WebSocketCloseFrame> for CloseFrame {
+    fn from(frame: WebSocketCloseFrame) -> Self {
+        Self {
+            code: frame.code,
+            reason: frame.reason,
+        }
+    }
+}
+
+impl From<CloseFrame> for WebSocketCloseFrame {
+    fn from(frame: CloseFrame) -> Self {
+        Self {
+            code: frame.code,
+            reason: frame.reason,
+        }
+    }
+}
+
+#[derive(Debug, Enum)]
+pub enum WebSocketMessage {
+    Text(String),
+    Binary(Vec<u8>),
+    Ping(Vec<u8>),
+    Pong(Vec<u8>),
+    Close(Option<WebSocketCloseFrame>),
+}
+
+impl From<WebSocketMessage> for Message {
+    fn from(msg: WebSocketMessage) -> Self {
+        match msg {
+            WebSocketMessage::Text(text) => Message::Text(text),
+            WebSocketMessage::Binary(binary) => Message::Binary(binary),
+            WebSocketMessage::Ping(payload) => Message::Ping(payload),
+            WebSocketMessage::Pong(payload) => Message::Pong(payload),
+            WebSocketMessage::Close(frame) => Message::Close(frame.map(|f| f.into())),
+        }
+    }
+}
+
+impl From<Message> for WebSocketMessage {
+    fn from(msg: Message) -> Self {
+        match msg {
+            Message::Text(val) => Self::Text(val),
+            Message::Binary(val) => Self::Binary(val),
+            Message::Ping(val) => Self::Ping(val),
+            Message::Pong(val) => Self::Pong(val),
+            Message::Close(frame) => Self::Close(frame.map(|f| f.into())),
+        }
+    }
+}
+
+#[uniffi::export(with_foreign)]
+#[async_trait::async_trait]
+pub trait WebSocketAdapter: Send + Sync {
+    /// Send a WebSocket message
+    async fn send(&self, msg: WebSocketMessage) -> Result<()>;
+
+    /// Receive a message
+    ///
+    /// This method MUST await for a message.
+    ///
+    /// Return `None` to mark the stream as terminated.
+    async fn recv(&self) -> Result<Option<WebSocketMessage>>;
+
+    /// Close the WebSocket connection
+    // Note: `close` method name can't be used in Kotlin
+    async fn close_connection(&self) -> Result<()>;
+}
+
+#[derive(Object)]
+pub struct WebSocketAdapterWrapper {
+    inner: Arc<dyn WebSocketAdapter>,
+}
+
+#[uniffi::export]
+impl WebSocketAdapterWrapper {
+    #[uniffi::constructor]
+    pub fn new(adapter: Arc<dyn WebSocketAdapter>) -> Self {
+        Self { inner: adapter }
+    }
+}
+
+#[uniffi::export(with_foreign)]
+#[async_trait::async_trait]
+pub trait CustomWebSocketTransport: Send + Sync {
+    /// If returns `true`, the WebSocket implementation must handle and forward the PING/PONG messages.
+    /// The ping is used by the SDK,
+    /// for example, to calculate the average latency or to make sure the relay is still connected.
+    fn support_ping(&self) -> bool;
+
+    /// Connect to a relay
+    async fn connect(
+        &self,
+        url: String,
+        mode: ConnectionMode,
+        timeout: Duration,
+    ) -> Result<Option<Arc<WebSocketAdapterWrapper>>>;
+}
+
+pub(crate) struct FFI2RustWebSocketTransport {
+    pub(crate) inner: Arc<dyn CustomWebSocketTransport>,
+}
+
+impl fmt::Debug for FFI2RustWebSocketTransport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FFI2RustWebSocketTransport").finish()
+    }
+}
+
+mod inner {
+    use std::collections::VecDeque;
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+
+    use async_wsocket::futures_util::{Sink as SinkTrait, Stream as StreamTrait, StreamExt};
+    use async_wsocket::ConnectionMode;
+    use nostr::util::BoxedFuture;
+    use nostr::Url;
+    use nostr_sdk::pool::transport::error::TransportError;
+    use nostr_sdk::pool::transport::websocket::WebSocketTransport;
+
+    use super::*;
+    use crate::error::MiddleError;
+
+    // TODO: use ReusableBoxFuture by tokio-util to avoid reallocation?
+    type SinkFuture = Pin<Box<dyn Future<Output = Result<(), TransportError>> + Send>>;
+    type StreamFuture =
+        Pin<Box<dyn Future<Output = Result<Option<WebSocketMessage>, TransportError>> + Send>>;
+
+    struct FFI2RustWebSocketAdapter {
+        // The adapter
+        adapter: Arc<dyn WebSocketAdapter>,
+        // The messages buffer
+        buffer: VecDeque<WebSocketMessage>,
+        // Future to flush all messages
+        send_all_future: Option<SinkFuture>,
+        // Future to close websocket
+        close_future: Option<SinkFuture>,
+        // Future to recv messages
+        recv_future: Option<StreamFuture>,
+    }
+
+    impl FFI2RustWebSocketAdapter {
+        fn new(adapter: Arc<dyn WebSocketAdapter>) -> Self {
+            Self {
+                adapter,
+                buffer: VecDeque::new(),
+                send_all_future: None,
+                close_future: None,
+                recv_future: None,
+            }
+        }
+    }
+
+    impl SinkTrait<Message> for FFI2RustWebSocketAdapter {
+        type Error = TransportError;
+
+        fn poll_ready(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            if self.buffer.is_empty() && self.send_all_future.is_none() {
+                Poll::Ready(Ok(()))
+            } else {
+                // The buffer must be flushed or the future not completed yet.
+                Poll::Pending
+            }
+        }
+
+        fn start_send(mut self: Pin<&mut Self>, item: Message) -> Result<(), Self::Error> {
+            tracing::trace!("buffering message: {item:?}");
+            self.as_mut().buffer.push_back(item.into());
+            Ok(())
+        }
+
+        fn poll_flush(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            let mut this = self.as_mut();
+
+            // If there's an active future for sending all messages, poll it
+            if let Some(send_future) = this.send_all_future.as_mut() {
+                return match send_future.as_mut().poll(cx) {
+                    // Sending complete, clear the future
+                    Poll::Ready(result) => {
+                        tracing::trace!("flushing completed");
+                        this.send_all_future = None;
+                        Poll::Ready(result)
+                    }
+                    Poll::Pending => {
+                        tracing::trace!("flushing pending");
+                        Poll::Pending
+                    }
+                };
+            }
+
+            // No active future exists and nothing to flush
+            if this.buffer.is_empty() {
+                tracing::trace!("flushing completed");
+
+                // Nothing to flush, return Ready
+                return Poll::Ready(Ok(()));
+            }
+
+            // Take buffer
+            let messages: VecDeque<WebSocketMessage> = std::mem::take(&mut this.buffer);
+            let adapter = this.adapter.clone();
+
+            tracing::trace!("flushing buffered messages: {:?}", messages);
+
+            // Create a future to send all messages
+            let future = async move {
+                for msg in messages.into_iter() {
+                    adapter
+                        .send(msg)
+                        .await
+                        .map_err(MiddleError::from)
+                        .map_err(TransportError::backend)?;
+                }
+                Ok(())
+            };
+
+            // Store this future in the state
+            this.send_all_future = Some(Box::pin(future));
+
+            // Start polling the future
+            this.poll_flush(cx)
+        }
+
+        fn poll_close(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            // If there's an active future for closing, poll it
+            if let Some(close_future) = self.as_mut().close_future.as_mut() {
+                return match close_future.as_mut().poll(cx) {
+                    // Close complete, clear the future
+                    Poll::Ready(result) => {
+                        tracing::trace!("poll close completed");
+                        self.as_mut().close_future = None;
+                        Poll::Ready(result)
+                    }
+                    Poll::Pending => {
+                        tracing::trace!("poll close pending");
+                        Poll::Pending
+                    }
+                };
+            }
+
+            // Ensure all buffered messages are flushed before closing
+            if self.as_mut().poll_flush(cx).is_pending() {
+                return Poll::Pending;
+            }
+
+            let mut this = self.as_mut();
+            let adapter = this.adapter.clone();
+
+            tracing::trace!("starting poll close");
+
+            // Create a future
+            let future = async move {
+                adapter
+                    .close_connection()
+                    .await
+                    .map_err(MiddleError::from)
+                    .map_err(TransportError::backend)
+            };
+
+            // Store this future in the state
+            this.close_future = Some(Box::pin(future));
+
+            // Start polling the future
+            this.poll_close(cx)
+        }
+    }
+
+    impl StreamTrait for FFI2RustWebSocketAdapter {
+        type Item = Result<Message, TransportError>;
+
+        fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            let mut this = self.as_mut();
+
+            // If there's an active future for closing, poll it
+            if let Some(recv_future) = this.recv_future.as_mut() {
+                return match recv_future.as_mut().poll(cx) {
+                    // Close complete, clear the future
+                    Poll::Ready(result) => {
+                        tracing::trace!("poll next completed");
+                        this.recv_future = None;
+
+                        // Convert output
+                        let output: Option<Self::Item> = match result {
+                            Ok(Some(msg)) => Some(Ok(msg.into())),
+                            Ok(None) => None,
+                            Err(e) => Some(Err(e)),
+                        };
+
+                        // Poll
+                        Poll::Ready(output)
+                    }
+                    Poll::Pending => {
+                        tracing::trace!("poll next pending");
+                        Poll::Pending
+                    }
+                };
+            }
+
+            let adapter = this.adapter.clone();
+
+            tracing::trace!("starting poll next");
+
+            // Create a future
+            let future = async move {
+                adapter
+                    .recv()
+                    .await
+                    .map_err(MiddleError::from)
+                    .map_err(TransportError::backend)
+            };
+
+            // Store this future in the state
+            this.recv_future = Some(Box::pin(future));
+
+            // Start polling the future
+            this.poll_next(cx)
+        }
+    }
+
+    impl WebSocketTransport for FFI2RustWebSocketTransport {
+        fn support_ping(&self) -> bool {
+            self.inner.support_ping()
+        }
+
+        fn connect<'a>(
+            &'a self,
+            url: &'a Url,
+            mode: &'a ConnectionMode,
+            timeout: Duration,
+        ) -> BoxedFuture<'a, Result<(Sink, Stream), TransportError>> {
+            Box::pin(async move {
+                let intermediate = self
+                    .inner
+                    .connect(url.to_string(), mode.clone().into(), timeout)
+                    .await
+                    .map_err(|e| TransportError::backend(MiddleError::from(e)))?
+                    .ok_or_else(|| {
+                        TransportError::backend(MiddleError::new("WebSocket adapter not found"))
+                    })?;
+
+                // Construct socket
+                let socket = FFI2RustWebSocketAdapter::new(intermediate.inner.clone());
+
+                // Split it
+                let (tx, rx) = socket.split();
+
+                let sink: Sink = Box::new(tx) as Sink;
+                let stream: Stream = Box::new(rx) as Stream;
+
+                Ok((sink, stream))
+            })
+        }
+    }
+}

--- a/crates/nostr-relay-builder/src/local/inner.rs
+++ b/crates/nostr-relay-builder/src/local/inner.rs
@@ -240,7 +240,7 @@ impl InnerLocalRelay {
                             match msg {
                                 Message::Text(json) => {
                                     tracing::trace!("Received {json}");
-                                    self.handle_client_msg(&mut session, &mut tx, ClientMessage::from_json(json)?, &addr)
+                                    self.handle_client_msg(&mut session, &mut tx, ClientMessage::from_json(json.as_bytes())?, &addr)
                                         .await?;
                                 }
                                 Message::Binary(..) => {
@@ -752,7 +752,7 @@ impl InnerLocalRelay {
     where
         S: AsyncRead + AsyncWrite + Unpin,
     {
-        tx.send(Message::Text(msg.as_json())).await?;
+        tx.send(Message::Text(msg.as_json().into())).await?;
         Ok(())
     }
 
@@ -762,7 +762,8 @@ impl InnerLocalRelay {
         I: IntoIterator<Item = RelayMessage>,
         S: AsyncRead + AsyncWrite + Unpin,
     {
-        let mut stream = stream::iter(msgs.into_iter()).map(|msg| Ok(Message::Text(msg.as_json())));
+        let mut stream =
+            stream::iter(msgs.into_iter()).map(|msg| Ok(Message::Text(msg.as_json().into())));
         tx.send_all(&mut stream).await?;
         Ok(())
     }

--- a/crates/nostr-relay-pool/src/lib.rs
+++ b/crates/nostr-relay-pool/src/lib.rs
@@ -20,6 +20,7 @@ pub mod relay;
 #[doc(hidden)]
 mod shared;
 mod stream;
+pub mod transport;
 
 pub use self::pool::options::RelayPoolOptions;
 pub use self::pool::{Output, RelayPool, RelayPoolNotification};

--- a/crates/nostr-relay-pool/src/lib.rs
+++ b/crates/nostr-relay-pool/src/lib.rs
@@ -19,7 +19,7 @@ pub mod prelude;
 pub mod relay;
 #[doc(hidden)]
 mod shared;
-mod stream;
+pub mod stream;
 pub mod transport;
 
 pub use self::pool::options::RelayPoolOptions;

--- a/crates/nostr-relay-pool/src/relay/error.rs
+++ b/crates/nostr-relay-pool/src/relay/error.rs
@@ -5,7 +5,6 @@
 use std::fmt;
 use std::time::Duration;
 
-use async_wsocket::Error as WsError;
 use nostr::event;
 use nostr::event::builder;
 use nostr::message::MessageHandleError;
@@ -13,13 +12,14 @@ use nostr_database::DatabaseError;
 use tokio::sync::{broadcast, SetError};
 
 use crate::shared::SharedStateError;
+use crate::transport::error::TransportError;
 use crate::RelayPoolNotification;
 
 /// Relay error
 #[derive(Debug)]
 pub enum Error {
-    /// WebSocket error
-    WebSocket(WsError),
+    /// Transport error
+    Transport(TransportError),
     /// Shared state error
     SharedState(SharedStateError),
     /// MessageHandle error
@@ -126,7 +126,7 @@ impl std::error::Error for Error {}
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::WebSocket(e) => write!(f, "{e}"),
+            Self::Transport(e) => write!(f, "{e}"),
             Self::SharedState(e) => write!(f, "{e}"),
             Self::MessageHandle(e) => write!(f, "{e}"),
             Self::Event(e) => write!(f, "{e}"),
@@ -184,9 +184,9 @@ impl fmt::Display for Error {
     }
 }
 
-impl From<WsError> for Error {
-    fn from(e: WsError) -> Self {
-        Self::WebSocket(e)
+impl From<TransportError> for Error {
+    fn from(e: TransportError) -> Self {
+        Self::Transport(e)
     }
 }
 

--- a/crates/nostr-relay-pool/src/relay/mod.rs
+++ b/crates/nostr-relay-pool/src/relay/mod.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 use async_utility::time;
 use async_wsocket::futures_util::Future;
-use async_wsocket::{ConnectionMode, Sink, Stream};
+use async_wsocket::ConnectionMode;
 use atomic_destructor::AtomicDestructor;
 use nostr_database::prelude::*;
 use tokio::sync::broadcast;
@@ -40,6 +40,7 @@ pub use self::options::{
 pub use self::stats::RelayConnectionStats;
 pub use self::status::RelayStatus;
 use crate::shared::SharedState;
+use crate::transport::websocket::{Sink, Stream};
 
 /// Subscription auto-closed reason
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -916,7 +917,7 @@ mod tests {
         assert_eq!(relay.status(), RelayStatus::Initialized);
 
         let res = relay.try_connect(Duration::from_secs(2)).await;
-        assert!(matches!(res.unwrap_err(), Error::WebSocket(..)));
+        assert!(matches!(res.unwrap_err(), Error::Transport(..)));
 
         assert_eq!(relay.status(), RelayStatus::Terminated);
 

--- a/crates/nostr-relay-pool/src/stream.rs
+++ b/crates/nostr-relay-pool/src/stream.rs
@@ -2,6 +2,8 @@
 // Copyright (c) 2023-2024 Rust Nostr Developers
 // Distributed under the MIT software license
 
+//! Streams
+
 use std::pin::Pin;
 use std::task::{Context, Poll};
 

--- a/crates/nostr-relay-pool/src/transport/error.rs
+++ b/crates/nostr-relay-pool/src/transport/error.rs
@@ -1,0 +1,37 @@
+// Copyright (c) 2022-2023 Yuki Kishimoto
+// Copyright (c) 2023-2024 Rust Nostr Developers
+// Distributed under the MIT software license
+
+//! Transport Error
+
+use core::fmt;
+
+/// Transport Error
+#[derive(Debug)]
+pub enum TransportError {
+    /// An error happened in the underlying backend.
+    Backend(Box<dyn std::error::Error + Send + Sync>),
+}
+
+impl std::error::Error for TransportError {}
+
+impl fmt::Display for TransportError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Backend(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl TransportError {
+    /// Create a new backend error
+    ///
+    /// Shorthand for `Error::Backend(Box::new(error))`.
+    #[inline]
+    pub fn backend<E>(error: E) -> Self
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        Self::Backend(Box::new(error))
+    }
+}

--- a/crates/nostr-relay-pool/src/transport/mod.rs
+++ b/crates/nostr-relay-pool/src/transport/mod.rs
@@ -1,0 +1,8 @@
+// Copyright (c) 2022-2023 Yuki Kishimoto
+// Copyright (c) 2023-2024 Rust Nostr Developers
+// Distributed under the MIT software license
+
+//! Nostr transports
+
+pub mod error;
+pub mod websocket;

--- a/crates/nostr-relay-pool/src/transport/websocket.rs
+++ b/crates/nostr-relay-pool/src/transport/websocket.rs
@@ -1,0 +1,103 @@
+// Copyright (c) 2022-2023 Yuki Kishimoto
+// Copyright (c) 2023-2024 Rust Nostr Developers
+// Distributed under the MIT software license
+
+//! WebSocket transport
+
+use std::fmt;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_wsocket::futures_util::{self, SinkExt, StreamExt, TryStreamExt};
+use async_wsocket::{ConnectionMode, Message, WebSocket};
+use nostr::util::BoxedFuture;
+use nostr::Url;
+
+use super::error::TransportError;
+
+/// WebSocket transport sink
+#[cfg(not(target_arch = "wasm32"))]
+pub type Sink = Box<dyn futures_util::Sink<Message, Error = TransportError> + Send + Unpin>;
+/// WebSocket transport stream
+#[cfg(not(target_arch = "wasm32"))]
+pub type Stream =
+    Box<dyn futures_util::Stream<Item = Result<Message, TransportError>> + Send + Unpin>;
+/// WebSocket transport sink
+#[cfg(target_arch = "wasm32")]
+pub type Sink = Box<dyn futures_util::Sink<Message, Error = TransportError> + Unpin>;
+/// WebSocket transport stream
+#[cfg(target_arch = "wasm32")]
+pub type Stream = Box<dyn futures_util::Stream<Item = Result<Message, TransportError>> + Unpin>;
+
+#[doc(hidden)]
+pub trait IntoWebSocketTransport {
+    fn into_transport(self) -> Arc<dyn WebSocketTransport>;
+}
+
+impl IntoWebSocketTransport for Arc<dyn WebSocketTransport> {
+    fn into_transport(self) -> Arc<dyn WebSocketTransport> {
+        self
+    }
+}
+
+impl<T> IntoWebSocketTransport for T
+where
+    T: WebSocketTransport + Sized + 'static,
+{
+    fn into_transport(self) -> Arc<dyn WebSocketTransport> {
+        Arc::new(self)
+    }
+}
+
+impl<T> IntoWebSocketTransport for Arc<T>
+where
+    T: WebSocketTransport + 'static,
+{
+    fn into_transport(self) -> Arc<dyn WebSocketTransport> {
+        self
+    }
+}
+
+/// WebSocket transport
+pub trait WebSocketTransport: fmt::Debug + Send + Sync {
+    /// Support ping/pong
+    fn support_ping(&self) -> bool;
+
+    /// Connect
+    fn connect<'a>(
+        &'a self,
+        url: &'a Url,
+        mode: &'a ConnectionMode,
+        timeout: Duration,
+    ) -> BoxedFuture<'a, Result<(Sink, Stream), TransportError>>;
+}
+
+/// Default websocket transport
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DefaultWebsocketTransport;
+
+impl WebSocketTransport for DefaultWebsocketTransport {
+    fn support_ping(&self) -> bool {
+        true
+    }
+
+    fn connect<'a>(
+        &'a self,
+        url: &'a Url,
+        mode: &'a ConnectionMode,
+        timeout: Duration,
+    ) -> BoxedFuture<'a, Result<(Sink, Stream), TransportError>> {
+        Box::pin(async move {
+            // Connect
+            let socket: WebSocket = async_wsocket::connect(url, mode, timeout)
+                .await
+                .map_err(TransportError::backend)?;
+
+            // Split sink and stream
+            let (tx, rx) = socket.split();
+            let sink: Sink = Box::new(tx.sink_map_err(TransportError::backend)) as Sink;
+            let stream: Stream = Box::new(rx.map_err(TransportError::backend)) as Stream;
+            Ok((sink, stream))
+        })
+    }
+}

--- a/crates/nostr-sdk/src/client/builder.rs
+++ b/crates/nostr-sdk/src/client/builder.rs
@@ -9,6 +9,9 @@ use std::sync::Arc;
 use nostr::signer::{IntoNostrSigner, NostrSigner};
 use nostr_database::memory::MemoryDatabase;
 use nostr_database::{IntoNostrDatabase, NostrDatabase};
+use nostr_relay_pool::transport::websocket::{
+    DefaultWebsocketTransport, IntoWebSocketTransport, WebSocketTransport,
+};
 
 use crate::{Client, Options};
 
@@ -17,6 +20,8 @@ use crate::{Client, Options};
 pub struct ClientBuilder {
     /// Nostr Signer
     pub signer: Option<Arc<dyn NostrSigner>>,
+    /// WebSocket transport
+    pub websocket_transport: Arc<dyn WebSocketTransport>,
     /// Database
     pub database: Arc<dyn NostrDatabase>,
     /// Client options
@@ -27,6 +32,7 @@ impl Default for ClientBuilder {
     fn default() -> Self {
         Self {
             signer: None,
+            websocket_transport: Arc::new(DefaultWebsocketTransport),
             database: Arc::new(MemoryDatabase::default()),
             opts: Options::default(),
         }
@@ -56,6 +62,18 @@ impl ClientBuilder {
         T: IntoNostrSigner,
     {
         self.signer = Some(signer.into_nostr_signer());
+        self
+    }
+
+    /// Set custom WebSocket transport
+    ///
+    /// By default [`DefaultWebsocketTransport`] is used.
+    #[inline]
+    pub fn websocket_transport<T>(mut self, transport: T) -> Self
+    where
+        T: IntoWebSocketTransport,
+    {
+        self.websocket_transport = transport.into_transport();
         self
     }
 

--- a/crates/nostr-sdk/src/client/mod.rs
+++ b/crates/nostr-sdk/src/client/mod.rs
@@ -83,6 +83,7 @@ impl Client {
         // Construct shared state
         let state = SharedState::new(
             builder.database,
+            builder.websocket_transport,
             builder.signer,
             builder.opts.filtering_mode,
             builder.opts.nip42_auto_authentication,


### PR DESCRIPTION
Allow using custom websocket clients. Add `ClientBuilder::websocket_transport`.

Closes https://github.com/rust-nostr/nostr/issues/721 
Ref https://github.com/rust-nostr/nostr/issues/650#issuecomment-2578901221 
Ref https://github.com/rust-nostr/nostr/issues/650#issuecomment-2595771489
