### PR TITLE
nostr: add `EventBuilder::allow_self_tagging`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@
 
 ### Added
 
+* nostr: add `EventBuilder::allow_self_tagging` ([Yuki Kishimoto])
+
 ### Fixed
 
 ### Removed

--- a/bindings/nostr-sdk-ffi/src/protocol/event/builder.rs
+++ b/bindings/nostr-sdk-ffi/src/protocol/event/builder.rs
@@ -86,16 +86,35 @@ impl EventBuilder {
         builder
     }
 
+    /// Allow self-tagging
+    ///
+    /// When this mode is enabled, any `p` tags referencing the author’s public key will not be discarded.
+    pub fn allow_self_tagging(&self) -> Self {
+        let mut builder = self.clone();
+        builder.inner = builder.inner.allow_self_tagging();
+        builder
+    }
+
+    /// Build, sign and return [`Event`]
+    ///
+    /// Check [`EventBuilder::build`] to learn more.
     pub async fn sign(&self, signer: &NostrSigner) -> Result<Event> {
         let event = self.inner.clone().sign(signer.deref()).await?;
         Ok(event.into())
     }
 
+    /// Build, sign and return [`Event`] using [`Keys`] signer
+    ///
+    /// Check [`EventBuilder::build`] to learn more.
     pub fn sign_with_keys(&self, keys: &Keys) -> Result<Event> {
         let event = self.inner.clone().sign_with_keys(keys.deref())?;
         Ok(event.into())
     }
 
+    /// Build an unsigned event
+    ///
+    /// By default, this method removes any `p` tags that match the author's public key.
+    /// To allow self-tagging, call [`EventBuilder::allow_self_tagging`] first.
     pub fn build(&self, public_key: &PublicKey) -> UnsignedEvent {
         self.inner.clone().build(**public_key).into()
     }

--- a/bindings/nostr-sdk-js/src/protocol/event/builder.rs
+++ b/bindings/nostr-sdk-js/src/protocol/event/builder.rs
@@ -77,9 +77,18 @@ impl JsEventBuilder {
         self.inner.pow(difficulty).into()
     }
 
+    /// Allow self-tagging
+    ///
+    /// When this mode is enabled, any `p` tags referencing the author’s public key will not be discarded.
+    pub fn allow_self_tagging(self) -> Self {
+        self.inner.allow_self_tagging().into()
+    }
+
     /// Build, sign and return event
     ///
-    /// **This method consume the builder, so it will no longer be usable!**
+    /// Check [`EventBuilder::build`] to learn more.
+    ///
+    /// **This method consumes the builder, so it will no longer be usable!**
     #[wasm_bindgen(js_name = sign)]
     pub async fn sign(self, signer: &JsNostrSigner) -> Result<JsEvent> {
         let event = self.inner.sign(signer.deref()).await.map_err(into_err)?;
@@ -88,16 +97,21 @@ impl JsEventBuilder {
 
     /// Build, sign and return event using keys signer
     ///
-    /// **This method consume the builder, so it will no longer be usable!**
+    /// Check [`EventBuilder::build`] to learn more.
+    ///
+    /// **This method consumes the builder, so it will no longer be usable!**
     #[wasm_bindgen(js_name = signWithKeys)]
     pub fn sign_with_keys(self, keys: &JsKeys) -> Result<JsEvent> {
         let event = self.inner.sign_with_keys(keys.deref()).map_err(into_err)?;
         Ok(event.into())
     }
 
-    /// Build unsigned event
+    /// Build an unsigned event
     ///
-    /// **This method consume the builder, so it will no longer be usable!**
+    /// By default, this method removes any `p` tags that match the author's public key.
+    /// To allow self-tagging, call [`EventBuilder::allow_self_tagging`] first.
+    ///
+    /// **This method consumes the builder, so it will no longer be usable!**
     #[wasm_bindgen(js_name = build)]
     pub fn build(self, public_key: &JsPublicKey) -> JsUnsignedEvent {
         self.inner.build(**public_key).into()


### PR DESCRIPTION
Optionally allow self-tagging (`p` tag) when building events.

Closes https://github.com/rust-nostr/nostr/issues/736