### PR TITLE
lmdb: event ingester and other improvements 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * pool: avoid spawning a task for every authentication request ([Yuki Kishimoto])
 * lmdb: bump MSRV to 1.72.0 ([Yuki Kishimoto])
 * lmdb: implement event ingester ([Yuki Kishimoto])
+* lmdb: avoid spawning thread for read methods ([Yuki Kishimoto])
 * ndb: return `None` in `NostrEventsDatabase::event_by_id` if event doesn't exist ([Yuki Kishimoto])
 * ndb: avoid event clone when calling `NostrEventsDatabase::save_event` ([Yuki Kishimoto])
 * ffi: improve `Events::merge` and `Events::to_vec` performance ([Yuki Kishimoto])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 * lmdb: bump MSRV to 1.72.0 ([Yuki Kishimoto])
 * lmdb: implement event ingester ([Yuki Kishimoto])
 * lmdb: avoid spawning thread for read methods ([Yuki Kishimoto])
+* lmdb: avoid long-lived read txn when ingesting event ([Yuki Kishimoto])
 * ndb: return `None` in `NostrEventsDatabase::event_by_id` if event doesn't exist ([Yuki Kishimoto])
 * ndb: avoid event clone when calling `NostrEventsDatabase::save_event` ([Yuki Kishimoto])
 * ffi: improve `Events::merge` and `Events::to_vec` performance ([Yuki Kishimoto])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@
 * pool: take event reference in `send_event` methods ([Yuki Kishimoto])
 * pool: use the relay ingester to perform actions ([Yuki Kishimoto])
 * pool: avoid spawning a task for every authentication request ([Yuki Kishimoto])
+* lmdb: bump MSRV to 1.72.0 ([Yuki Kishimoto])
+* lmdb: implement event ingester ([Yuki Kishimoto])
 * ndb: return `None` in `NostrEventsDatabase::event_by_id` if event doesn't exist ([Yuki Kishimoto])
 * ndb: avoid event clone when calling `NostrEventsDatabase::save_event` ([Yuki Kishimoto])
 * ffi: improve `Events::merge` and `Events::to_vec` performance ([Yuki Kishimoto])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2753,6 +2753,7 @@ dependencies = [
  "nostr-database",
  "tempfile",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/contrib/scripts/check-crates.sh
+++ b/contrib/scripts/check-crates.sh
@@ -53,8 +53,9 @@ buildargs=(
 )
 
 skip_msrv=(
+    "-p nostr-lmdb"                   # MSRV: 1.72.0
     "-p nostr-sdk --features tor"     # MSRV: 1.77.0
-    "-p nostr-sdk --all-features"     # MSRV: 1.77.0 (since uses tor)
+    "-p nostr-sdk --all-features"     # MSRV: 1.77.0 (since uses lmdb and tor)
     "-p nostr-cli"                    # MSRV: 1.74.0
 )
 

--- a/crates/nostr-lmdb/Cargo.toml
+++ b/crates/nostr-lmdb/Cargo.toml
@@ -8,7 +8,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 readme = "README.md"
-rust-version.workspace = true
+rust-version = "1.72.0"
 keywords = ["nostr", "database", "lmdb"]
 
 [dependencies]
@@ -16,6 +16,8 @@ async-utility.workspace = true
 heed = { version = "0.20", default-features = false, features = ["read-txn-no-tls"] }
 nostr = { workspace = true, features = ["std"] }
 nostr-database = { workspace = true, features = ["flatbuf"] }
+tokio = { workspace = true, features = ["sync"] }
+tracing.workspace = true
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/nostr-lmdb/src/lib.rs
+++ b/crates/nostr-lmdb/src/lib.rs
@@ -64,15 +64,13 @@ impl NostrEventsDatabase for NostrLMDB {
         Box::pin(async move {
             if self
                 .db
-                .event_is_deleted(*event_id)
-                .await
+                .event_is_deleted(event_id)
                 .map_err(DatabaseError::backend)?
             {
                 Ok(DatabaseEventStatus::Deleted)
             } else if self
                 .db
                 .has_event(event_id)
-                .await
                 .map_err(DatabaseError::backend)?
             {
                 Ok(DatabaseEventStatus::Saved)
@@ -91,7 +89,6 @@ impl NostrEventsDatabase for NostrLMDB {
             if let Some(t) = self
                 .db
                 .when_is_coordinate_deleted(coordinate)
-                .await
                 .map_err(DatabaseError::backend)?
             {
                 Ok(&t >= timestamp)
@@ -108,17 +105,16 @@ impl NostrEventsDatabase for NostrLMDB {
         Box::pin(async move {
             self.db
                 .get_event_by_id(event_id)
-                .await
                 .map_err(DatabaseError::backend)
         })
     }
 
     fn count(&self, filter: Filter) -> BoxedFuture<Result<usize, DatabaseError>> {
-        Box::pin(async move { self.db.count(filter).await.map_err(DatabaseError::backend) })
+        Box::pin(async move { self.db.count(filter).map_err(DatabaseError::backend) })
     }
 
     fn query(&self, filter: Filter) -> BoxedFuture<Result<Events, DatabaseError>> {
-        Box::pin(async move { self.db.query(filter).await.map_err(DatabaseError::backend) })
+        Box::pin(async move { self.db.query(filter).map_err(DatabaseError::backend) })
     }
 
     fn negentropy_items(
@@ -128,7 +124,6 @@ impl NostrEventsDatabase for NostrLMDB {
         Box::pin(async move {
             self.db
                 .negentropy_items(filter)
-                .await
                 .map_err(DatabaseError::backend)
         })
     }

--- a/crates/nostr-lmdb/src/store/error.rs
+++ b/crates/nostr-lmdb/src/store/error.rs
@@ -8,6 +8,7 @@ use std::{fmt, io};
 use async_utility::tokio::task::JoinError;
 use nostr::{key, secp256k1};
 use nostr_database::flatbuffers;
+use tokio::sync::oneshot;
 
 #[derive(Debug)]
 pub enum Error {
@@ -20,8 +21,9 @@ pub enum Error {
     Thread(JoinError),
     Key(key::Error),
     Secp256k1(secp256k1::Error),
-    /// Mutex poisoned
-    MutexPoisoned,
+    OneshotRecv(oneshot::error::RecvError),
+    /// MPSC send error
+    MpscSend,
     /// The event kind is wrong
     WrongEventKind,
     /// Not found
@@ -39,7 +41,8 @@ impl fmt::Display for Error {
             Self::Thread(e) => write!(f, "{e}"),
             Self::Key(e) => write!(f, "{e}"),
             Self::Secp256k1(e) => write!(f, "{e}"),
-            Self::MutexPoisoned => write!(f, "mutex poisoned"),
+            Self::OneshotRecv(e) => write!(f, "{e}"),
+            Self::MpscSend => write!(f, "mpsc channel send error"),
             Self::NotFound => write!(f, "Not found"),
             Self::WrongEventKind => write!(f, "Wrong event kind"),
         }
@@ -79,5 +82,11 @@ impl From<key::Error> for Error {
 impl From<secp256k1::Error> for Error {
     fn from(e: secp256k1::Error) -> Self {
         Self::Secp256k1(e)
+    }
+}
+
+impl From<oneshot::error::RecvError> for Error {
+    fn from(e: oneshot::error::RecvError) -> Self {
+        Self::OneshotRecv(e)
     }
 }

--- a/crates/nostr-lmdb/src/store/ingester.rs
+++ b/crates/nostr-lmdb/src/store/ingester.rs
@@ -1,0 +1,233 @@
+// Copyright (c) 2022-2023 Yuki Kishimoto
+// Copyright (c) 2023-2025 Rust Nostr Developers
+// Distributed under the MIT software license
+
+use std::sync::mpsc::{Receiver, Sender};
+use std::thread;
+
+use heed::{RoTxn, RwTxn};
+use nostr::nips::nip01::Coordinate;
+use nostr::{Event, Kind, Timestamp};
+use nostr_database::{FlatBufferBuilder, RejectedReason, SaveEventStatus};
+use tokio::sync::oneshot;
+
+use super::error::Error;
+use super::lmdb::Lmdb;
+
+pub(super) struct IngesterItem {
+    event: Event,
+    tx: Option<oneshot::Sender<Result<SaveEventStatus, Error>>>,
+}
+
+impl IngesterItem {
+    // #[inline]
+    // pub(super) fn without_feedback(event: Event) -> Self {
+    //     Self { event, tx: None }
+    // }
+
+    #[must_use]
+    pub(super) fn with_feedback(
+        event: Event,
+    ) -> (Self, oneshot::Receiver<Result<SaveEventStatus, Error>>) {
+        let (tx, rx) = oneshot::channel();
+        (
+            Self {
+                event,
+                tx: Some(tx),
+            },
+            rx,
+        )
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct Ingester {
+    db: Lmdb,
+    rx: Receiver<IngesterItem>,
+}
+
+impl Ingester {
+    /// Build and spawn a new ingester
+    pub(super) fn run(db: Lmdb) -> Sender<IngesterItem> {
+        // Create new asynchronous channel
+        let (tx, rx) = std::sync::mpsc::channel();
+
+        // Construct and spawn ingester
+        let ingester = Self { db, rx };
+        ingester.spawn_ingester();
+
+        // Return ingester sender
+        tx
+    }
+
+    fn spawn_ingester(self) {
+        thread::spawn(move || {
+            #[cfg(debug_assertions)]
+            tracing::debug!("Ingester thread started");
+
+            let mut fbb = FlatBufferBuilder::with_capacity(70_000);
+
+            // Listen for items
+            while let Ok(IngesterItem { event, tx }) = self.rx.recv() {
+                // Ingest
+                let res = self.ingest_event(event, &mut fbb);
+
+                // If sender is available send the `Result` otherwise log as error
+                match tx {
+                    // Send to receiver
+                    Some(tx) => {
+                        // SAFETY: panic only if the receiver is not listening
+                        tx.send(res).unwrap();
+                    }
+                    // Log error if `Result::Err`
+                    None => {
+                        if let Err(e) = res {
+                            tracing::error!(error = %e, "Event ingestion failed.");
+                        }
+                    }
+                }
+            }
+
+            #[cfg(debug_assertions)]
+            tracing::debug!("Ingester thread exited");
+        });
+    }
+
+    fn ingest_event(
+        &self,
+        event: Event,
+        fbb: &mut FlatBufferBuilder,
+    ) -> nostr::Result<SaveEventStatus, Error> {
+        if event.kind.is_ephemeral() {
+            return Ok(SaveEventStatus::Rejected(RejectedReason::Ephemeral));
+        }
+
+        // Acquire read transaction
+        let read_txn = self.db.read_txn()?;
+
+        // Already exists
+        if self.db.has_event(&read_txn, event.id.as_bytes())? {
+            return Ok(SaveEventStatus::Rejected(RejectedReason::Duplicate));
+        }
+
+        // Reject event if ID was deleted
+        if self.db.is_deleted(&read_txn, &event.id)? {
+            return Ok(SaveEventStatus::Rejected(RejectedReason::Deleted));
+        }
+
+        // Reject event if ADDR was deleted after it's created_at date
+        // (non-parameterized or parameterized)
+        if let Some(coordinate) = event.coordinate() {
+            if let Some(time) = self.db.when_is_coordinate_deleted(&read_txn, &coordinate)? {
+                if event.created_at <= time {
+                    return Ok(SaveEventStatus::Rejected(RejectedReason::Deleted));
+                }
+            }
+        }
+
+        // Acquire write transaction
+        let mut txn = self.db.write_txn()?;
+
+        // Remove replaceable events being replaced
+        if event.kind.is_replaceable() {
+            // Find replaceable event
+            if let Some(stored) =
+                self.db
+                    .find_replaceable_event(&read_txn, &event.pubkey, event.kind)?
+            {
+                if stored.created_at > event.created_at {
+                    txn.abort();
+                    return Ok(SaveEventStatus::Rejected(RejectedReason::Replaced));
+                }
+
+                let coordinate: Coordinate = Coordinate::new(event.kind, event.pubkey);
+                self.db
+                    .remove_replaceable(&read_txn, &mut txn, &coordinate, event.created_at)?;
+            }
+        }
+
+        // Remove parameterized replaceable events being replaced
+        if event.kind.is_addressable() {
+            if let Some(identifier) = event.tags.identifier() {
+                let coordinate: Coordinate =
+                    Coordinate::new(event.kind, event.pubkey).identifier(identifier);
+
+                // Find param replaceable event
+                if let Some(stored) = self.db.find_addressable_event(&read_txn, &coordinate)? {
+                    if stored.created_at > event.created_at {
+                        txn.abort();
+                        return Ok(SaveEventStatus::Rejected(RejectedReason::Replaced));
+                    }
+
+                    self.db.remove_addressable(
+                        &read_txn,
+                        &mut txn,
+                        &coordinate,
+                        Timestamp::max(),
+                    )?;
+                }
+            }
+        }
+
+        // Handle deletion events
+        if let Kind::EventDeletion = event.kind {
+            let invalid: bool = self.handle_deletion_event(&read_txn, &mut txn, &event)?;
+
+            if invalid {
+                txn.abort();
+                return Ok(SaveEventStatus::Rejected(RejectedReason::InvalidDelete));
+            }
+        }
+
+        // Store and index the event
+        self.db.store(&mut txn, fbb, &event)?;
+
+        // Commit
+        read_txn.commit()?;
+        txn.commit()?;
+
+        Ok(SaveEventStatus::Success)
+    }
+
+    fn handle_deletion_event(
+        &self,
+        read_txn: &RoTxn,
+        txn: &mut RwTxn,
+        event: &Event,
+    ) -> nostr::Result<bool, Error> {
+        for id in event.tags.event_ids() {
+            if let Some(target) = self.db.get_event_by_id(read_txn, id.as_bytes())? {
+                // Author must match
+                if target.pubkey != event.pubkey.as_bytes() {
+                    return Ok(true);
+                }
+
+                // Mark as deleted and remove event
+                self.db.mark_deleted(txn, id)?;
+                self.db.remove(txn, &target)?;
+            }
+        }
+
+        for coordinate in event.tags.coordinates() {
+            // Author must match
+            if coordinate.public_key != event.pubkey {
+                return Ok(true);
+            }
+
+            // Mark deleted
+            self.db
+                .mark_coordinate_deleted(txn, &coordinate.borrow(), event.created_at)?;
+
+            // Remove events (up to the created_at of the deletion event)
+            if coordinate.kind.is_replaceable() {
+                self.db
+                    .remove_replaceable(read_txn, txn, coordinate, event.created_at)?;
+            } else if coordinate.kind.is_addressable() {
+                self.db
+                    .remove_addressable(read_txn, txn, coordinate, event.created_at)?;
+            }
+        }
+
+        Ok(false)
+    }
+}


### PR DESCRIPTION
* lmdb: bump MSRV to 1.72.0
* lmdb: use event ingester
* lmdb: avoid spawning thread for read methods
* lmdb: avoid long-lived read txn when ingesting event