### PR TITLE
sdk: improvements to gossip logic

### DIFF
--- a/crates/nostr-sdk/src/client/error.rs
+++ b/crates/nostr-sdk/src/client/error.rs
@@ -36,8 +36,8 @@ pub enum Error {
     ImpossibleToZap(String),
     /// Broken down filters for gossip are empty
     GossipFiltersEmpty,
-    /// DMs relays not found
-    DMsRelaysNotFound,
+    /// Private message (NIP17) relays not found
+    PrivateMsgRelaysNotFound,
     /// Metadata not found
     MetadataNotFound,
 }
@@ -65,7 +65,7 @@ impl fmt::Display for Error {
             Self::GossipFiltersEmpty => {
                 write!(f, "gossip broken down filters are empty")
             }
-            Self::DMsRelaysNotFound => write!(f, "DMs relays not found"),
+            Self::PrivateMsgRelaysNotFound => write!(f, "Private message relays not found. The user is not ready to receive private messages."),
             Self::MetadataNotFound => write!(f, "metadata not found"),
         }
     }

--- a/crates/nostr-sdk/src/client/mod.rs
+++ b/crates/nostr-sdk/src/client/mod.rs
@@ -1099,6 +1099,11 @@ impl Client {
     ///
     /// This method requires a [`NostrSigner`].
     ///
+    /// # Errors
+    ///
+    /// Returns [`Error::PrivateMsgRelaysNotFound`] if the receiver hasn't set the NIP17 list,
+    /// meaning that is not ready to receive private messages.
+    ///
     /// <https://github.com/nostr-protocol/nips/blob/master/17.md>
     #[inline]
     #[cfg(feature = "nip59")]
@@ -1356,8 +1361,12 @@ impl Client {
                 .get_nip17_inbox_relays(event.tags.public_keys())
                 .await;
 
+            // Clients SHOULD publish kind 14 events to the 10050-listed relays.
+            // If that is not found, that indicates the user is not ready to receive messages under this NIP and clients shouldn't try.
+            //
+            // <https://github.com/nostr-protocol/nips/blob/6e7a618e7f873bb91e743caacc3b09edab7796a0/17.md>
             if relays.is_empty() {
-                return Err(Error::DMsRelaysNotFound);
+                return Err(Error::PrivateMsgRelaysNotFound);
             }
 
             // Add outbox and inbox relays

--- a/crates/nostr-sdk/src/client/mod.rs
+++ b/crates/nostr-sdk/src/client/mod.rs
@@ -1407,8 +1407,11 @@ impl Client {
             // Extend OUTBOX relays with WRITE ones
             outbox.extend(write_relays);
 
-            // Union of OUTBOX (and WRITE) with INBOX relays
-            outbox.union(&inbox).cloned().collect()
+            // Extend outbox relays with inbox ones
+            outbox.extend(inbox);
+
+            // Return all relays
+            outbox
         };
 
         // Send event


### PR DESCRIPTION
* Improve send private msg error
* Refactor checking and updating of outdated gossip public keys
* Avoid cloning of inbox relay urls when sending gossip event
* Don't try to get the relay lists of the gift-wrap's author, since the used keypair is randomized