### PR TITLE
nostr: add client tag support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 * nostr: add `nip21::extract_from_text` function ([Yuki Kishimoto])
 * nostr: add `EventBuilder::allow_self_tagging` ([Yuki Kishimoto])
 * nostr: add `Nip19Event::from_event` ([Yuki Kishimoto])
+* nostr: add `Tag::client` constructor ([Yuki Kishimoto])
 * nostr: add `Tag::len` method ([Yuki Kishimoto])
 * nostr: add `push`, `pop`, `insert`, `remove`, `extend` and `retain` methods to `Tags` struct ([Yuki Kishimoto])
 * nostr: add `with_capacity`, `from_list`, `from_text` and `parse` constructors to `Tags` struct ([Yuki Kishimoto])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@
 * nostr: add `EncryptedSecretKey::decrypt` method ([Yuki Kishimoto])
 * nostr: add `Nip19Coordinate` struct ([Yuki Kishimoto])
 * nostr: add `Coordinate::verify` method ([Yuki Kishimoto])
+* nostr: add `TagStandard::Client` variant ([Yuki Kishimoto])
 * pool: event verification cache ([Yuki Kishimoto])
 * ffi: add Mac Catalyst support in Swift package ([Yuki Kishimoto])
 

--- a/bindings/nostr-sdk-ffi/src/protocol/event/tag/mod.rs
+++ b/bindings/nostr-sdk-ffi/src/protocol/event/tag/mod.rs
@@ -151,6 +151,16 @@ impl Tag {
         }
     }
 
+    /// Construct `["client", "<name>"]` tag
+    ///
+    /// <https://github.com/nostr-protocol/nips/blob/master/89.md>
+    #[uniffi::constructor]
+    pub fn client(name: String) -> Self {
+        Self {
+            inner: tag::Tag::client(name),
+        }
+    }
+
     /// Compose `["expiration", "<timestamp>"]` tag
     ///
     /// <https://github.com/nostr-protocol/nips/blob/master/40.md>

--- a/bindings/nostr-sdk-js/src/protocol/event/tag/mod.rs
+++ b/bindings/nostr-sdk-js/src/protocol/event/tag/mod.rs
@@ -140,6 +140,16 @@ impl JsTag {
         }
     }
 
+    /// Construct `["client", "<name>"]` tag
+    ///
+    /// <https://github.com/nostr-protocol/nips/blob/master/89.md>
+    #[inline]
+    pub fn client(name: String) -> Self {
+        Self {
+            inner: Tag::client(name),
+        }
+    }
+
     /// Compose `["expiration", "<timestamp>"]` tag
     ///
     /// <https://github.com/nostr-protocol/nips/blob/master/40.md>

--- a/crates/nostr/src/event/tag/mod.rs
+++ b/crates/nostr/src/event/tag/mod.rs
@@ -231,6 +231,19 @@ impl Tag {
         Self::from_standardized_without_cell(TagStandard::POW { nonce, difficulty })
     }
 
+    /// Construct `["client", "<name>"]` tag
+    ///
+    /// <https://github.com/nostr-protocol/nips/blob/master/89.md>
+    pub fn client<S>(name: S) -> Self
+    where
+        S: Into<String>,
+    {
+        Self::from_standardized_without_cell(TagStandard::Client {
+            name: name.into(),
+            address: None,
+        })
+    }
+
     /// Compose `["expiration", "<timestamp>"]` tag
     ///
     /// <https://github.com/nostr-protocol/nips/blob/master/40.md>


### PR DESCRIPTION
- Add `TagStandard::Client` variant
- Add `Tag::client` constructor

Closes https://github.com/rust-nostr/nostr/issues/750
