### PR TITLE
nostr: fix NIP34 event construction according to last rev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * nostr: split `NostrURI` into `ToNostrUri` and `FromNostrUri` traits ([Yuki Kishimoto])
 * nostr: replaced generic parameter `S: AsRef<str>` with `&str` in `Coordinate::parse` and `Coordinate::from_kpi_format` ([Yuki Kishimoto])
 * nostr: change `EventId::new` signature ([Yuki Kishimoto])
+* nostr: change `EventBuilder::git_repository_announcement` constructor signature ([Yuki Kishimoto])
 * nostr: change `EventBuilder::git_issue` constructor signature ([Yuki Kishimoto])
 
 ### Changed
@@ -76,6 +77,7 @@
 
 ### Fixed
 
+* nostr: fix `EventBuilder::git_repository_announcement` constructor according to last NIP34 rev ([Yuki Kishimoto])
 * nostr: fix `EventBuilder::git_issue` constructor according to last NIP34 rev ([Yuki Kishimoto])
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * nostr: split `NostrURI` into `ToNostrUri` and `FromNostrUri` traits ([Yuki Kishimoto])
 * nostr: replaced generic parameter `S: AsRef<str>` with `&str` in `Coordinate::parse` and `Coordinate::from_kpi_format` ([Yuki Kishimoto])
 * nostr: change `EventId::new` signature ([Yuki Kishimoto])
+* nostr: change `EventBuilder::git_issue` constructor signature ([Yuki Kishimoto])
 
 ### Changed
 
@@ -74,6 +75,8 @@
 * ffi: add Mac Catalyst support in Swift package ([Yuki Kishimoto])
 
 ### Fixed
+
+* nostr: fix `EventBuilder::git_issue` constructor according to last NIP34 rev ([Yuki Kishimoto])
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * nostr: change `EventId::new` signature ([Yuki Kishimoto])
 * nostr: change `EventBuilder::git_repository_announcement` constructor signature ([Yuki Kishimoto])
 * nostr: change `EventBuilder::git_issue` constructor signature ([Yuki Kishimoto])
+* nostr: change `EventBuilder::git_patch` constructor signature ([Yuki Kishimoto])
 
 ### Changed
 
@@ -79,6 +80,7 @@
 
 * nostr: fix `EventBuilder::git_repository_announcement` constructor according to last NIP34 rev ([Yuki Kishimoto])
 * nostr: fix `EventBuilder::git_issue` constructor according to last NIP34 rev ([Yuki Kishimoto])
+* nostr: fix `EventBuilder::git_patch` constructor according to last NIP34 rev ([Yuki Kishimoto])
 
 ### Removed
 

--- a/bindings/nostr-sdk-ffi/src/protocol/event/builder.rs
+++ b/bindings/nostr-sdk-ffi/src/protocol/event/builder.rs
@@ -858,7 +858,7 @@ impl EventBuilder {
     #[uniffi::constructor]
     pub fn git_patch(patch: GitPatch) -> Result<Self> {
         Ok(Self {
-            inner: nostr::EventBuilder::git_patch(patch.try_into()?),
+            inner: nostr::EventBuilder::git_patch(patch.try_into()?)?,
         })
     }
 }

--- a/bindings/nostr-sdk-ffi/src/protocol/event/builder.rs
+++ b/bindings/nostr-sdk-ffi/src/protocol/event/builder.rs
@@ -836,10 +836,10 @@ impl EventBuilder {
     ///
     /// <https://github.com/nostr-protocol/nips/blob/master/34.md>
     #[uniffi::constructor]
-    pub fn git_repository_announcement(data: GitRepositoryAnnouncement) -> Self {
-        Self {
-            inner: nostr::EventBuilder::git_repository_announcement(data.into()),
-        }
+    pub fn git_repository_announcement(data: GitRepositoryAnnouncement) -> Result<Self> {
+        Ok(Self {
+            inner: nostr::EventBuilder::git_repository_announcement(data.into())?,
+        })
     }
 
     /// Git Issue

--- a/bindings/nostr-sdk-ffi/src/protocol/event/builder.rs
+++ b/bindings/nostr-sdk-ffi/src/protocol/event/builder.rs
@@ -846,10 +846,10 @@ impl EventBuilder {
     ///
     /// <https://github.com/nostr-protocol/nips/blob/master/34.md>
     #[uniffi::constructor]
-    pub fn git_issue(issue: GitIssue) -> Self {
-        Self {
-            inner: nostr::EventBuilder::git_issue(issue.into()),
-        }
+    pub fn git_issue(issue: GitIssue) -> Result<Self> {
+        Ok(Self {
+            inner: nostr::EventBuilder::git_issue(issue.into())?,
+        })
     }
 
     /// Git Patch

--- a/bindings/nostr-sdk-ffi/src/protocol/event/tag/standard.rs
+++ b/bindings/nostr-sdk-ffi/src/protocol/event/tag/standard.rs
@@ -336,7 +336,9 @@ impl From<tag::TagStandard> for TagStandard {
                 hash: hash.to_string(),
             },
             tag::TagStandard::GitEarliestUniqueCommitId(commit) => {
-                Self::GitEarliestUniqueCommitId { commit }
+                Self::GitEarliestUniqueCommitId {
+                    commit: commit.to_string(),
+                }
             }
             tag::TagStandard::GitMaintainers(public_keys) => Self::GitMaintainers {
                 public_keys: public_keys
@@ -571,9 +573,9 @@ impl TryFrom<TagStandard> for tag::TagStandard {
                 Ok(Self::GitClone(parsed_urls))
             }
             TagStandard::GitCommit { hash } => Ok(Self::GitCommit(Sha1Hash::from_str(&hash)?)),
-            TagStandard::GitEarliestUniqueCommitId { commit } => {
-                Ok(Self::GitEarliestUniqueCommitId(commit))
-            }
+            TagStandard::GitEarliestUniqueCommitId { commit } => Ok(
+                Self::GitEarliestUniqueCommitId(Sha1Hash::from_str(&commit)?),
+            ),
             TagStandard::GitMaintainers { public_keys } => Ok(Self::GitMaintainers(
                 public_keys.into_iter().map(|p| **p).collect(),
             )),

--- a/bindings/nostr-sdk-ffi/src/protocol/nips/nip34.rs
+++ b/bindings/nostr-sdk-ffi/src/protocol/nips/nip34.rs
@@ -76,12 +76,10 @@ impl From<GitRepositoryAnnouncement> for nip34::GitRepositoryAnnouncement {
 /// Git Issue
 #[derive(Record)]
 pub struct GitIssue {
-    /// The issue content (markdown)
-    pub content: String,
     /// The repository address
     pub repository: Arc<Coordinate>,
-    /// Public keys (owners or other users)
-    pub public_keys: Vec<Arc<PublicKey>>,
+    /// The issue content (markdown)
+    pub content: String,
     /// Subject
     pub subject: Option<String>,
     /// Labels
@@ -91,9 +89,8 @@ pub struct GitIssue {
 impl From<GitIssue> for nip34::GitIssue {
     fn from(value: GitIssue) -> Self {
         Self {
-            content: value.content,
             repository: value.repository.as_ref().deref().clone(),
-            public_keys: value.public_keys.into_iter().map(|p| **p).collect(),
+            content: value.content,
             subject: value.subject,
             labels: value.labels,
         }

--- a/bindings/nostr-sdk-ffi/src/protocol/nips/nip34.rs
+++ b/bindings/nostr-sdk-ffi/src/protocol/nips/nip34.rs
@@ -12,7 +12,6 @@ use nostr::{RelayUrl, Url};
 use uniffi::{Enum, Record};
 
 use crate::error::NostrSdkError;
-use crate::protocol::event::EventId;
 use crate::protocol::key::PublicKey;
 use crate::protocol::nips::nip01::Coordinate;
 use crate::protocol::types::Timestamp;
@@ -186,16 +185,14 @@ impl TryFrom<GitPatchContent> for nip34::GitPatchContent {
 /// Git Patch
 #[derive(Record)]
 pub struct GitPatch {
-    /// Repository ID
-    pub repo_id: String,
+    /// Repository
+    pub repository: Arc<Coordinate>,
     /// Patch
     pub content: GitPatchContent,
-    /// Maintainers
-    pub maintainers: Vec<Arc<PublicKey>>,
     /// Earliest unique commit ID of repo
     pub euc: String,
-    /// Root proposal ID
-    pub root_proposal_id: Option<Arc<EventId>>,
+    /// Labels
+    pub labels: Vec<String>,
 }
 
 impl TryFrom<GitPatch> for nip34::GitPatch {
@@ -203,11 +200,10 @@ impl TryFrom<GitPatch> for nip34::GitPatch {
 
     fn try_from(value: GitPatch) -> Result<Self, Self::Error> {
         Ok(Self {
-            repo_id: value.repo_id,
+            repository: value.repository.as_ref().deref().clone(),
             content: value.content.try_into()?,
-            maintainers: value.maintainers.into_iter().map(|p| **p).collect(),
-            euc: value.euc,
-            root_proposal_id: value.root_proposal_id.map(|e| **e),
+            euc: Sha1Hash::from_str(&value.euc)?,
+            labels: value.labels,
         })
     }
 }

--- a/bindings/nostr-sdk-ffi/src/protocol/nips/nip34.rs
+++ b/bindings/nostr-sdk-ffi/src/protocol/nips/nip34.rs
@@ -67,7 +67,7 @@ impl From<GitRepositoryAnnouncement> for nip34::GitRepositoryAnnouncement {
                 .into_iter()
                 .filter_map(|u| RelayUrl::parse(&u).ok())
                 .collect(),
-            euc: value.euc,
+            euc: value.euc.and_then(|euc| Sha1Hash::from_str(&euc).ok()),
             maintainers: value.maintainers.into_iter().map(|p| **p).collect(),
         }
     }

--- a/bindings/nostr-sdk-js/src/protocol/event/builder.rs
+++ b/bindings/nostr-sdk-js/src/protocol/event/builder.rs
@@ -861,10 +861,12 @@ impl JsEventBuilder {
     ///
     /// <https://github.com/nostr-protocol/nips/blob/master/34.md>
     #[wasm_bindgen(js_name = gitRepositoryAnnouncement)]
-    pub fn git_repository_announcement(data: JsGitRepositoryAnnouncement) -> Self {
-        Self {
-            inner: EventBuilder::git_repository_announcement(data.into()),
-        }
+    pub fn git_repository_announcement(
+        data: JsGitRepositoryAnnouncement,
+    ) -> Result<JsEventBuilder> {
+        Ok(Self {
+            inner: EventBuilder::git_repository_announcement(data.into()).map_err(into_err)?,
+        })
     }
 
     /// Git Issue

--- a/bindings/nostr-sdk-js/src/protocol/event/builder.rs
+++ b/bindings/nostr-sdk-js/src/protocol/event/builder.rs
@@ -871,9 +871,9 @@ impl JsEventBuilder {
     ///
     /// <https://github.com/nostr-protocol/nips/blob/master/34.md>
     #[wasm_bindgen(js_name = gitIssue)]
-    pub fn git_issue(issue: JsGitIssue) -> Self {
-        Self {
-            inner: EventBuilder::git_issue(issue.into()),
-        }
+    pub fn git_issue(issue: JsGitIssue) -> Result<JsEventBuilder> {
+        Ok(Self {
+            inner: EventBuilder::git_issue(issue.into()).map_err(into_err)?,
+        })
     }
 }

--- a/bindings/nostr-sdk-js/src/protocol/nips/nip34.rs
+++ b/bindings/nostr-sdk-js/src/protocol/nips/nip34.rs
@@ -77,15 +77,12 @@ impl From<JsGitRepositoryAnnouncement> for GitRepositoryAnnouncement {
 /// Git Issue
 #[wasm_bindgen(js_name = GitIssue)]
 pub struct JsGitIssue {
-    /// The issue content (markdown)
-    #[wasm_bindgen(getter_with_clone)]
-    pub content: String,
     /// The repository address
     #[wasm_bindgen(getter_with_clone)]
     pub repository: JsCoordinate,
-    /// Public keys (owners or other users)
+    /// The issue content (markdown)
     #[wasm_bindgen(getter_with_clone)]
-    pub public_keys: Vec<JsPublicKey>,
+    pub content: String,
     /// Subject
     #[wasm_bindgen(getter_with_clone)]
     pub subject: Option<String>,
@@ -97,9 +94,8 @@ pub struct JsGitIssue {
 impl From<JsGitIssue> for GitIssue {
     fn from(value: JsGitIssue) -> Self {
         Self {
-            content: value.content,
             repository: value.repository.deref().clone(),
-            public_keys: value.public_keys.into_iter().map(|p| *p).collect(),
+            content: value.content,
             subject: value.subject,
             labels: value.labels,
         }

--- a/bindings/nostr-sdk-js/src/protocol/nips/nip34.rs
+++ b/bindings/nostr-sdk-js/src/protocol/nips/nip34.rs
@@ -3,7 +3,9 @@
 // Distributed under the MIT software license
 
 use core::ops::Deref;
+use core::str::FromStr;
 
+use nostr::hashes::sha1::Hash as Sha1Hash;
 use nostr_sdk::prelude::*;
 use wasm_bindgen::prelude::*;
 
@@ -68,7 +70,7 @@ impl From<JsGitRepositoryAnnouncement> for GitRepositoryAnnouncement {
                 .into_iter()
                 .filter_map(|u| RelayUrl::parse(&u).ok())
                 .collect(),
-            euc: value.euc,
+            euc: value.euc.and_then(|euc| Sha1Hash::from_str(&euc).ok()),
             maintainers: value.maintainers.into_iter().map(|p| *p).collect(),
         }
     }

--- a/crates/nostr/src/event/builder.rs
+++ b/crates/nostr/src/event/builder.rs
@@ -1705,7 +1705,9 @@ impl EventBuilder {
     ///
     /// <https://github.com/nostr-protocol/nips/blob/master/34.md>
     #[inline]
-    pub fn git_repository_announcement(announcement: GitRepositoryAnnouncement) -> Self {
+    pub fn git_repository_announcement(
+        announcement: GitRepositoryAnnouncement,
+    ) -> Result<Self, Error> {
         announcement.to_event_builder()
     }
 

--- a/crates/nostr/src/event/builder.rs
+++ b/crates/nostr/src/event/builder.rs
@@ -1723,7 +1723,7 @@ impl EventBuilder {
     ///
     /// <https://github.com/nostr-protocol/nips/blob/master/34.md>
     #[inline]
-    pub fn git_patch(patch: GitPatch) -> Self {
+    pub fn git_patch(patch: GitPatch) -> Result<Self, Error> {
         patch.to_event_builder()
     }
 

--- a/crates/nostr/src/event/builder.rs
+++ b/crates/nostr/src/event/builder.rs
@@ -42,6 +42,8 @@ impl fmt::Display for WrongKindError {
 pub enum Error {
     /// Unsigned event error
     Event(super::Error),
+    /// NIP01 error
+    NIP01(nip01::Error),
     /// OpenTimestamps error
     #[cfg(feature = "nip03")]
     NIP03(String),
@@ -72,6 +74,7 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Event(e) => write!(f, "{e}"),
+            Self::NIP01(e) => write!(f, "{e}"),
             #[cfg(feature = "nip03")]
             Self::NIP03(e) => write!(f, "{e}"),
             #[cfg(feature = "nip04")]
@@ -97,6 +100,12 @@ impl From<SignerError> for Error {
 impl From<super::Error> for Error {
     fn from(e: super::Error) -> Self {
         Self::Event(e)
+    }
+}
+
+impl From<nip01::Error> for Error {
+    fn from(e: nip01::Error) -> Self {
+        Self::NIP01(e)
     }
 }
 
@@ -1704,7 +1713,7 @@ impl EventBuilder {
     ///
     /// <https://github.com/nostr-protocol/nips/blob/master/34.md>
     #[inline]
-    pub fn git_issue(issue: GitIssue) -> Self {
+    pub fn git_issue(issue: GitIssue) -> Result<Self, Error> {
         issue.to_event_builder()
     }
 

--- a/crates/nostr/src/event/tag/standard.rs
+++ b/crates/nostr/src/event/tag/standard.rs
@@ -72,7 +72,7 @@ pub enum TagStandard {
     /// Git earliest unique commit ID
     ///
     /// <https://github.com/nostr-protocol/nips/blob/master/34.md>
-    GitEarliestUniqueCommitId(String),
+    GitEarliestUniqueCommitId(Sha1Hash),
     /// Git repo maintainers
     ///
     /// <https://github.com/nostr-protocol/nips/blob/master/34.md>
@@ -722,8 +722,8 @@ impl From<TagStandard> for Vec<String> {
             TagStandard::GitCommit(hash) => {
                 vec![tag_kind, hash.to_string()]
             }
-            TagStandard::GitEarliestUniqueCommitId(id) => {
-                vec![tag_kind, id, EUC.to_string()]
+            TagStandard::GitEarliestUniqueCommitId(commit) => {
+                vec![tag_kind, commit.to_string(), EUC.to_string()]
             }
             TagStandard::GitMaintainers(public_keys) => {
                 let mut tag: Vec<String> = Vec::with_capacity(1 + public_keys.len());
@@ -1178,7 +1178,9 @@ where
                 metadata: Some(RelayMetadata::from_str(tag_2)?),
             })
         } else if tag_2 == EUC {
-            Ok(TagStandard::GitEarliestUniqueCommitId(tag_1.to_string()))
+            // ["r", "<commit-id>", "euc"]
+            let commit: Sha1Hash = Sha1Hash::from_str(tag_1)?;
+            Ok(TagStandard::GitEarliestUniqueCommitId(commit))
         } else {
             Err(Error::UnknownStandardizedTag)
         };
@@ -1875,9 +1877,9 @@ mod tests {
 
         assert_eq!(
             vec!["r", "5e664e5a7845cd1373c79f580ca4fe29ab5b34d2", "euc"],
-            TagStandard::GitEarliestUniqueCommitId(String::from(
-                "5e664e5a7845cd1373c79f580ca4fe29ab5b34d2"
-            ))
+            TagStandard::GitEarliestUniqueCommitId(
+                Sha1Hash::from_str("5e664e5a7845cd1373c79f580ca4fe29ab5b34d2").unwrap()
+            )
             .to_vec()
         );
 
@@ -2459,9 +2461,9 @@ mod tests {
 
         assert_eq!(
             TagStandard::parse(&["r", "5e664e5a7845cd1373c79f580ca4fe29ab5b34d2", "euc"]).unwrap(),
-            TagStandard::GitEarliestUniqueCommitId(String::from(
-                "5e664e5a7845cd1373c79f580ca4fe29ab5b34d2"
-            ))
+            TagStandard::GitEarliestUniqueCommitId(
+                Sha1Hash::from_str("5e664e5a7845cd1373c79f580ca4fe29ab5b34d2").unwrap()
+            )
         );
 
         assert_eq!(


### PR DESCRIPTION
Fix NIP34 event construction according to <https://github.com/nostr-protocol/nips/blob/ea36ec9ed7596e49bf7f217b05954c1fecacad88/34.md> revision.

Closes https://github.com/rust-nostr/nostr/issues/758
