### PR TITLE
nostr: refine coordinate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 * nostr: add `with_capacity`, `from_list`, `from_text` and `parse` constructors to `Tags` struct ([Yuki Kishimoto])
 * nostr: add `Tags::dedup` method ([Yuki Kishimoto])
 * nostr: add `EncryptedSecretKey::decrypt` method ([Yuki Kishimoto])
+* nostr: add `Nip19Coordinate` struct ([Yuki Kishimoto])
 * pool: event verification cache ([Yuki Kishimoto])
 * ffi: add Mac Catalyst support in Swift package ([Yuki Kishimoto])
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * nostr: remove `WeakTag` ([Yuki Kishimoto])
 * nostr: change `TagStandard::Relays` variant inner value from `Vec<Url>` to `Vec<RelayUrl>` ([Yuki Kishimoto])
 * nostr: split `NostrURI` into `ToNostrUri` and `FromNostrUri` traits ([Yuki Kishimoto])
+* nostr: replaced generic parameter `S: AsRef<str>` with `&str` in `Coordinate::parse` and `Coordinate::from_kpi_format` ([Yuki Kishimoto])
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 * nostr: add `Tags::dedup` method ([Yuki Kishimoto])
 * nostr: add `EncryptedSecretKey::decrypt` method ([Yuki Kishimoto])
 * nostr: add `Nip19Coordinate` struct ([Yuki Kishimoto])
+* nostr: add `Coordinate::verify` method ([Yuki Kishimoto])
 * pool: event verification cache ([Yuki Kishimoto])
 * ffi: add Mac Catalyst support in Swift package ([Yuki Kishimoto])
 

--- a/bindings/nostr-sdk-ffi/src/protocol/nips/nip01.rs
+++ b/bindings/nostr-sdk-ffi/src/protocol/nips/nip01.rs
@@ -7,7 +7,7 @@ use std::str::FromStr;
 
 use nostr::nips::nip01;
 use nostr::serde_json::Value;
-use nostr::{JsonUtil, RelayUrl, Url};
+use nostr::{JsonUtil, Url};
 use uniffi::{Object, Record};
 
 use crate::error::Result;
@@ -48,30 +48,19 @@ impl From<Coordinate> for nip01::Coordinate {
             kind: value.inner.kind,
             public_key: value.inner.public_key,
             identifier: value.inner.identifier,
-            relays: value.inner.relays,
         }
     }
 }
 
 #[uniffi::export]
 impl Coordinate {
-    #[uniffi::constructor(default(identifier = "", relays = []))]
-    pub fn new(
-        kind: &Kind,
-        public_key: &PublicKey,
-        identifier: String,
-        relays: Vec<String>,
-    ) -> Self {
+    #[uniffi::constructor(default(identifier = ""))]
+    pub fn new(kind: &Kind, public_key: &PublicKey, identifier: String) -> Self {
         Self {
             inner: nip01::Coordinate {
                 kind: **kind,
                 public_key: **public_key,
                 identifier,
-                // TODO: propagate error
-                relays: relays
-                    .into_iter()
-                    .filter_map(|u| RelayUrl::parse(&u).ok())
-                    .collect(),
             },
         }
     }
@@ -91,10 +80,6 @@ impl Coordinate {
 
     pub fn identifier(&self) -> String {
         self.inner.identifier.clone()
-    }
-
-    pub fn relays(&self) -> Vec<String> {
-        self.inner.relays.iter().map(|u| u.to_string()).collect()
     }
 }
 

--- a/bindings/nostr-sdk-ffi/src/protocol/nips/nip01.rs
+++ b/bindings/nostr-sdk-ffi/src/protocol/nips/nip01.rs
@@ -6,8 +6,6 @@ use std::ops::Deref;
 use std::str::FromStr;
 
 use nostr::nips::nip01;
-use nostr::nips::nip19::ToBech32;
-use nostr::nips::nip21::ToNostrUri;
 use nostr::serde_json::Value;
 use nostr::{JsonUtil, RelayUrl, Url};
 use uniffi::{Object, Record};
@@ -81,14 +79,6 @@ impl Coordinate {
     #[uniffi::constructor]
     pub fn parse(coordinate: &str) -> Result<Self> {
         Ok(nip01::Coordinate::from_str(coordinate)?.into())
-    }
-
-    pub fn to_bech32(&self) -> Result<String> {
-        Ok(self.inner.to_bech32()?)
-    }
-
-    pub fn to_nostr_uri(&self) -> Result<String> {
-        Ok(self.inner.to_nostr_uri()?)
     }
 
     pub fn kind(&self) -> Kind {

--- a/bindings/nostr-sdk-ffi/src/protocol/nips/nip01.rs
+++ b/bindings/nostr-sdk-ffi/src/protocol/nips/nip01.rs
@@ -81,6 +81,15 @@ impl Coordinate {
     pub fn identifier(&self) -> String {
         self.inner.identifier.clone()
     }
+
+    /// Check if the coordinate is valid.
+    ///
+    /// Returns `false` if:
+    /// - the `Kind` is `replaceable` and the identifier is not empty
+    /// - the `Kind` is `addressable` and the identifier is empty
+    pub fn verify(&self) -> bool {
+        self.inner.verify().is_ok()
+    }
 }
 
 #[derive(Record)]

--- a/bindings/nostr-sdk-ffi/src/protocol/nips/nip19.rs
+++ b/bindings/nostr-sdk-ffi/src/protocol/nips/nip19.rs
@@ -34,7 +34,7 @@ pub enum Nip19Enum {
     /// nevent
     Event { event: Arc<Nip19Event> },
     /// naddr
-    Coord { coordinate: Arc<Coordinate> },
+    Addr { coordinate: Arc<Nip19Coordinate> },
 }
 
 impl From<nip19::Nip19> for Nip19Enum {
@@ -58,7 +58,7 @@ impl From<nip19::Nip19> for Nip19Enum {
             nip19::Nip19::Event(event) => Self::Event {
                 event: Arc::new(event.into()),
             },
-            nip19::Nip19::Coordinate(coordinate) => Self::Coord {
+            nip19::Nip19::Coordinate(coordinate) => Self::Addr {
                 coordinate: Arc::new(coordinate.into()),
             },
         }
@@ -212,6 +212,58 @@ impl Nip19Profile {
 
     pub fn public_key(&self) -> Arc<PublicKey> {
         Arc::new(self.inner.public_key.into())
+    }
+
+    pub fn relays(&self) -> Vec<String> {
+        self.inner.relays.iter().map(|u| u.to_string()).collect()
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, Object)]
+#[uniffi::export(Debug, Eq, Hash)]
+pub struct Nip19Coordinate {
+    inner: nip19::Nip19Coordinate,
+}
+
+impl From<nip19::Nip19Coordinate> for Nip19Coordinate {
+    fn from(inner: nip19::Nip19Coordinate) -> Self {
+        Self { inner }
+    }
+}
+
+#[uniffi::export]
+impl Nip19Coordinate {
+    #[uniffi::constructor(default(relays = []))]
+    pub fn new(coordinate: &Coordinate, relays: &[String]) -> Result<Self> {
+        Ok(Self {
+            inner: nip19::Nip19Coordinate::new(coordinate.deref().clone(), relays)?,
+        })
+    }
+
+    #[uniffi::constructor]
+    pub fn from_bech32(bech32: &str) -> Result<Self> {
+        Ok(Self {
+            inner: nip19::Nip19Coordinate::from_bech32(bech32)?,
+        })
+    }
+
+    #[uniffi::constructor]
+    pub fn from_nostr_uri(uri: &str) -> Result<Self> {
+        Ok(Self {
+            inner: nip19::Nip19Coordinate::from_nostr_uri(uri)?,
+        })
+    }
+
+    pub fn to_bech32(&self) -> Result<String> {
+        Ok(self.inner.to_bech32()?)
+    }
+
+    pub fn to_nostr_uri(&self) -> Result<String> {
+        Ok(self.inner.to_nostr_uri()?)
+    }
+
+    pub fn coordinate(&self) -> Coordinate {
+        self.inner.coordinate.clone().into()
     }
 
     pub fn relays(&self) -> Vec<String> {

--- a/bindings/nostr-sdk-ffi/src/protocol/nips/nip21.rs
+++ b/bindings/nostr-sdk-ffi/src/protocol/nips/nip21.rs
@@ -9,8 +9,7 @@ use uniffi::{Enum, Object};
 use crate::error::Result;
 use crate::protocol::event::EventId;
 use crate::protocol::key::PublicKey;
-use crate::protocol::nips::nip01::Coordinate;
-use crate::protocol::nips::nip19::{Nip19Event, Nip19Profile};
+use crate::protocol::nips::nip19::{Nip19Coordinate, Nip19Event, Nip19Profile};
 
 /// A representation any `NIP21` object. Useful for decoding
 /// `NIP21` strings without necessarily knowing what you're decoding
@@ -26,7 +25,7 @@ pub enum Nip21Enum {
     /// nostr::nevent
     Event { event: Arc<Nip19Event> },
     /// nostr::naddr
-    Coord { coordinate: Arc<Coordinate> },
+    Addr { coordinate: Arc<Nip19Coordinate> },
 }
 
 impl From<nip21::Nip21> for Nip21Enum {
@@ -44,7 +43,7 @@ impl From<nip21::Nip21> for Nip21Enum {
             nip21::Nip21::Event(event) => Self::Event {
                 event: Arc::new(event.into()),
             },
-            nip21::Nip21::Coordinate(coordinate) => Self::Coord {
+            nip21::Nip21::Coordinate(coordinate) => Self::Addr {
                 coordinate: Arc::new(coordinate.into()),
             },
         }

--- a/bindings/nostr-sdk-js/src/protocol/nips/nip01.rs
+++ b/bindings/nostr-sdk-js/src/protocol/nips/nip01.rs
@@ -33,23 +33,12 @@ impl From<Coordinate> for JsCoordinate {
 #[wasm_bindgen(js_class = Coordinate)]
 impl JsCoordinate {
     #[wasm_bindgen(constructor)]
-    pub fn new(
-        kind: &JsKind,
-        public_key: &JsPublicKey,
-        identifier: Option<String>,
-        relays: Option<Vec<String>>,
-    ) -> Self {
+    pub fn new(kind: &JsKind, public_key: &JsPublicKey, identifier: Option<String>) -> Self {
         Self {
             inner: Coordinate {
                 kind: **kind,
                 public_key: **public_key,
                 identifier: identifier.unwrap_or_default(),
-                // TODO: propagate error
-                relays: relays
-                    .unwrap_or_default()
-                    .into_iter()
-                    .filter_map(|u| RelayUrl::parse(&u).ok())
-                    .collect(),
             },
         }
     }
@@ -76,11 +65,6 @@ impl JsCoordinate {
     #[wasm_bindgen(getter)]
     pub fn identifier(&self) -> String {
         self.inner.identifier.clone()
-    }
-
-    #[wasm_bindgen(getter)]
-    pub fn relays(&self) -> Vec<String> {
-        self.inner.relays.iter().map(|u| u.to_string()).collect()
     }
 
     #[wasm_bindgen(js_name = toString)]

--- a/bindings/nostr-sdk-js/src/protocol/nips/nip01.rs
+++ b/bindings/nostr-sdk-js/src/protocol/nips/nip01.rs
@@ -87,16 +87,6 @@ impl JsCoordinate {
     pub fn _to_string(&self) -> String {
         self.inner.to_string()
     }
-
-    #[wasm_bindgen(js_name = toBech32)]
-    pub fn to_bech32(&self) -> Result<String> {
-        self.inner.to_bech32().map_err(into_err)
-    }
-
-    #[wasm_bindgen(js_name = toNostrUri)]
-    pub fn to_nostr_uri(&self) -> Result<String> {
-        self.inner.to_nostr_uri().map_err(into_err)
-    }
 }
 
 #[wasm_bindgen(js_name = Metadata)]

--- a/bindings/nostr-sdk-js/src/protocol/nips/nip01.rs
+++ b/bindings/nostr-sdk-js/src/protocol/nips/nip01.rs
@@ -67,6 +67,15 @@ impl JsCoordinate {
         self.inner.identifier.clone()
     }
 
+    /// Check if the coordinate is valid.
+    ///
+    /// Returns `false` if:
+    /// - the `Kind` is `replaceable` and the identifier is not empty
+    /// - the `Kind` is `addressable` and the identifier is empty
+    pub fn verify(&self) -> bool {
+        self.inner.verify().is_ok()
+    }
+
     #[wasm_bindgen(js_name = toString)]
     pub fn _to_string(&self) -> String {
         self.inner.to_string()

--- a/bindings/nostr-sdk-js/src/protocol/nips/nip19.rs
+++ b/bindings/nostr-sdk-js/src/protocol/nips/nip19.rs
@@ -7,6 +7,7 @@ use std::ops::Deref;
 use nostr_sdk::prelude::*;
 use wasm_bindgen::prelude::*;
 
+use super::nip01::JsCoordinate;
 use crate::error::{into_err, Result};
 use crate::protocol::event::{JsEvent, JsEventId, JsKind};
 use crate::protocol::key::JsPublicKey;
@@ -138,6 +139,60 @@ impl JsNip19Profile {
     #[wasm_bindgen(js_name = publicKey)]
     pub fn public_key(&self) -> JsPublicKey {
         self.inner.public_key.into()
+    }
+
+    pub fn relays(&self) -> Vec<String> {
+        self.inner.relays.iter().map(|u| u.to_string()).collect()
+    }
+}
+
+#[wasm_bindgen(js_name = Nip19Coordinate)]
+pub struct JsNip19Coordinate {
+    inner: Nip19Coordinate,
+}
+
+impl From<Nip19Coordinate> for JsNip19Coordinate {
+    fn from(inner: Nip19Coordinate) -> Self {
+        Self { inner }
+    }
+}
+
+#[wasm_bindgen(js_class = Nip19Coordinate)]
+impl JsNip19Coordinate {
+    #[wasm_bindgen(constructor)]
+    pub fn new(coordinate: &JsCoordinate, relays: Vec<String>) -> Result<JsNip19Coordinate> {
+        Ok(Self {
+            inner: Nip19Coordinate::new(coordinate.deref().clone(), relays).map_err(into_err)?,
+        })
+    }
+
+    #[wasm_bindgen(js_name = fromBech32)]
+    pub fn from_bech32(bech32: &str) -> Result<JsNip19Coordinate> {
+        Ok(Self {
+            inner: Nip19Coordinate::from_bech32(bech32).map_err(into_err)?,
+        })
+    }
+
+    #[wasm_bindgen(js_name = fromNostrUri)]
+    pub fn from_nostr_uri(uri: &str) -> Result<JsNip19Coordinate> {
+        Ok(Self {
+            inner: Nip19Coordinate::from_nostr_uri(uri).map_err(into_err)?,
+        })
+    }
+
+    #[wasm_bindgen(js_name = toBech32)]
+    pub fn to_bech32(&self) -> Result<String> {
+        self.inner.to_bech32().map_err(into_err)
+    }
+
+    #[wasm_bindgen(js_name = toNostrUri)]
+    pub fn to_nostr_uri(&self) -> Result<String> {
+        self.inner.to_nostr_uri().map_err(into_err)
+    }
+
+    #[wasm_bindgen]
+    pub fn coordinate(&self) -> JsCoordinate {
+        self.inner.coordinate.clone().into()
     }
 
     pub fn relays(&self) -> Vec<String> {

--- a/crates/nostr/src/event/tag/list.rs
+++ b/crates/nostr/src/event/tag/list.rs
@@ -153,10 +153,10 @@ impl Tags {
                     };
                     tags.push(Tag::from_standardized_without_cell(standard));
                 }
-                Nip21::Coordinate(coordinate) => {
+                Nip21::Coordinate(addr) => {
                     let standard: TagStandard = TagStandard::Coordinate {
-                        relay_url: coordinate.relays.first().cloned(),
-                        coordinate,
+                        relay_url: addr.relays.first().cloned(),
+                        coordinate: addr.coordinate,
                         uppercase: false,
                     };
                     tags.push(Tag::from_standardized_without_cell(standard));

--- a/crates/nostr/src/nips/nip01.rs
+++ b/crates/nostr/src/nips/nip01.rs
@@ -102,12 +102,7 @@ impl Coordinate {
     }
 
     /// Parse coordinate from `<kind>:<pubkey>:[<d-tag>]` format, `bech32` or [NIP21](https://github.com/nostr-protocol/nips/blob/master/21.md) uri
-    pub fn parse<S>(coordinate: S) -> Result<Self, Error>
-    where
-        S: AsRef<str>,
-    {
-        let coordinate: &str = coordinate.as_ref();
-
+    pub fn parse(coordinate: &str) -> Result<Self, Error> {
         // Try from hex
         if let Ok(coordinate) = Self::from_kpi_format(coordinate) {
             return Ok(coordinate);
@@ -127,24 +122,15 @@ impl Coordinate {
     }
 
     /// Try to parse from `<kind>:<pubkey>:[<d-tag>]` format
-    pub fn from_kpi_format<S>(coordinate: S) -> Result<Self, Error>
-    where
-        S: AsRef<str>,
-    {
-        let coordinate: &str = coordinate.as_ref();
+    pub fn from_kpi_format(coordinate: &str) -> Result<Self, Error> {
         let mut kpi = coordinate.split(':');
-        if let (Some(kind_str), Some(public_key_str), Some(identifier)) =
-            (kpi.next(), kpi.next(), kpi.next())
-        {
-            let kind: Kind = Kind::from_str(kind_str)?;
-
-            Ok(Self {
-                kind,
+        match (kpi.next(), kpi.next(), kpi.next()) {
+            (Some(kind_str), Some(public_key_str), Some(identifier)) => Ok(Self {
+                kind: Kind::from_str(kind_str)?,
                 public_key: PublicKey::from_hex(public_key_str)?,
                 identifier: identifier.to_string(),
-            })
-        } else {
-            Err(Error::InvalidCoordinate)
+            }),
+            _ => Err(Error::InvalidCoordinate),
         }
     }
 

--- a/crates/nostr/src/nips/nip01.rs
+++ b/crates/nostr/src/nips/nip01.rs
@@ -10,7 +10,6 @@ use alloc::borrow::ToOwned;
 #[cfg(not(feature = "std"))]
 use alloc::collections::BTreeMap as AllocMap;
 use alloc::string::{String, ToString};
-use alloc::vec::Vec;
 use core::fmt;
 use core::num::ParseIntError;
 use core::str::FromStr;
@@ -24,8 +23,8 @@ use serde_json::Value;
 
 use super::nip19::FromBech32;
 use super::nip21::FromNostrUri;
-use crate::types::{RelayUrl, Url};
-use crate::{event, key, Filter, JsonUtil, Kind, PublicKey, Tag, TagStandard};
+use crate::types::Url;
+use crate::{event, key, Filter, JsonUtil, Kind, PublicKey, Tag};
 
 /// Raw Event error
 #[derive(Debug, PartialEq, Eq)]
@@ -84,8 +83,6 @@ pub struct Coordinate {
     /// Needed for a parametrized replaceable event.
     /// Leave empty for a replaceable event.
     pub identifier: String,
-    /// Relays
-    pub relays: Vec<RelayUrl>,
 }
 
 impl fmt::Display for Coordinate {
@@ -102,7 +99,6 @@ impl Coordinate {
             kind,
             public_key,
             identifier: String::new(),
-            relays: Vec::new(),
         }
     }
 
@@ -145,7 +141,6 @@ impl Coordinate {
                 kind: Kind::from_str(kind_str)?,
                 public_key: PublicKey::from_hex(public_key_str)?,
                 identifier: identifier.to_owned(),
-                relays: Vec::new(),
             })
         } else {
             Err(Error::InvalidCoordinate)
@@ -181,11 +176,7 @@ impl Coordinate {
 
 impl From<Coordinate> for Tag {
     fn from(coordinate: Coordinate) -> Self {
-        Self::from_standardized(TagStandard::Coordinate {
-            relay_url: coordinate.relays.first().cloned(),
-            coordinate,
-            uppercase: false,
-        })
+        Self::coordinate(coordinate)
     }
 }
 
@@ -245,7 +236,6 @@ impl CoordinateBorrow<'_> {
             kind: *self.kind,
             public_key: *self.public_key,
             identifier: self.identifier.map(|s| s.to_string()).unwrap_or_default(),
-            relays: Vec::new(),
         }
     }
 }

--- a/crates/nostr/src/nips/nip19.rs
+++ b/crates/nostr/src/nips/nip19.rs
@@ -736,7 +736,6 @@ impl Nip19Coordinate {
             kind: kind.ok_or_else(|| Error::FieldMissing("kind".to_string()))?,
             public_key: pubkey.ok_or_else(|| Error::FieldMissing("pubkey".to_string()))?,
             identifier: identifier.ok_or_else(|| Error::FieldMissing("identifier".to_string()))?,
-            relays: Vec::new(),
         };
 
         Ok(Self { coordinate, relays })

--- a/crates/nostr/src/nips/nip19.rs
+++ b/crates/nostr/src/nips/nip19.rs
@@ -12,6 +12,7 @@ use alloc::borrow::Cow;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use core::fmt;
+use core::ops::Deref;
 use core::str::FromStr;
 
 use bech32::{self, Bech32, Hrp};
@@ -223,7 +224,7 @@ pub enum Nip19 {
     /// nevent
     Event(Nip19Event),
     /// naddr
-    Coordinate(Coordinate),
+    Coordinate(Nip19Coordinate),
 }
 
 pub trait FromBech32: Sized {
@@ -253,7 +254,7 @@ impl FromBech32 for Nip19 {
             Nip19Prefix::NProfile => Ok(Self::Profile(Nip19Profile::from_bech32_data(data)?)),
             Nip19Prefix::NEvent => Ok(Self::Event(Nip19Event::from_bech32_data(data)?)),
             Nip19Prefix::Note => Ok(Self::EventId(EventId::from_slice(data.as_slice())?)),
-            Nip19Prefix::NAddr => Ok(Self::Coordinate(Coordinate::from_bech32_data(data)?)),
+            Nip19Prefix::NAddr => Ok(Self::Coordinate(Nip19Coordinate::from_bech32_data(data)?)),
         }
     }
 }
@@ -639,7 +640,52 @@ impl FromBech32 for Nip19Profile {
     }
 }
 
-impl Coordinate {
+impl FromBech32 for Coordinate {
+    type Err = Error;
+
+    fn from_bech32(addr: &str) -> Result<Self, Self::Err> {
+        let (hrp, data) = bech32::decode(addr)?;
+
+        if hrp != HRP_COORDINATE {
+            return Err(Error::WrongPrefix);
+        }
+
+        let coordinate = Nip19Coordinate::from_bech32_data(data)?;
+
+        Ok(coordinate.coordinate)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct Nip19Coordinate {
+    pub coordinate: Coordinate,
+    pub relays: Vec<RelayUrl>,
+}
+
+impl Deref for Nip19Coordinate {
+    type Target = Coordinate;
+
+    fn deref(&self) -> &Self::Target {
+        &self.coordinate
+    }
+}
+
+impl Nip19Coordinate {
+    pub fn new<I, U>(coordinate: Coordinate, relays: I) -> Result<Self, Error>
+    where
+        I: IntoIterator<Item = U>,
+        U: TryIntoUrl,
+        Error: From<<U as TryIntoUrl>::Err>,
+    {
+        Ok(Self {
+            coordinate,
+            relays: relays
+                .into_iter()
+                .map(|u| u.try_into_url())
+                .collect::<Result<_, _>>()?,
+        })
+    }
+
     fn from_bech32_data(mut data: Vec<u8>) -> Result<Self, Error> {
         let mut identifier: Option<String> = None;
         let mut pubkey: Option<PublicKey> = None;
@@ -686,16 +732,18 @@ impl Coordinate {
             data.drain(..l + 2);
         }
 
-        Ok(Self {
+        let coordinate = Coordinate {
             kind: kind.ok_or_else(|| Error::FieldMissing("kind".to_string()))?,
             public_key: pubkey.ok_or_else(|| Error::FieldMissing("pubkey".to_string()))?,
             identifier: identifier.ok_or_else(|| Error::FieldMissing("identifier".to_string()))?,
-            relays,
-        })
+            relays: Vec::new(),
+        };
+
+        Ok(Self { coordinate, relays })
     }
 }
 
-impl FromBech32 for Coordinate {
+impl FromBech32 for Nip19Coordinate {
     type Err = Error;
 
     fn from_bech32(addr: &str) -> Result<Self, Self::Err> {
@@ -709,7 +757,7 @@ impl FromBech32 for Coordinate {
     }
 }
 
-impl ToBech32 for Coordinate {
+impl ToBech32 for Nip19Coordinate {
     type Err = Error;
 
     fn to_bech32(&self) -> Result<String, Self::Err> {
@@ -850,7 +898,7 @@ mod tests {
     #[test]
     fn from_bech32_naddr() {
         let coordinate: &str = "naddr1qqxnzd3exgersv33xymnsve3qgs8suecw4luyht9ekff89x4uacneapk8r5dyk0gmn6uwwurf6u9rusrqsqqqa282m3gxt";
-        let coordinate: Coordinate = Coordinate::from_bech32(coordinate).unwrap();
+        let coordinate = Nip19Coordinate::from_bech32(coordinate).unwrap();
 
         let expected_pubkey: PublicKey =
             PublicKey::from_hex("787338757fc25d65cd929394d5e7713cf43638e8d259e8dcf5c73b834eb851f2")

--- a/crates/nostr/src/nips/nip21.rs
+++ b/crates/nostr/src/nips/nip21.rs
@@ -13,8 +13,10 @@ use core::str::FromStr;
 
 use bech32::Fe32;
 
-use super::nip01::Coordinate;
-use super::nip19::{self, FromBech32, Nip19, Nip19Event, Nip19Prefix, Nip19Profile, ToBech32};
+use super::nip19::{
+    self, FromBech32, Nip19, Nip19Coordinate, Nip19Event, Nip19Prefix, Nip19Profile, ToBech32,
+};
+use crate::nips::nip01::Coordinate;
 use crate::{EventId, PublicKey};
 
 /// URI scheme
@@ -110,8 +112,9 @@ impl ToNostrUri for Nip19Profile {}
 impl FromNostrUri for Nip19Profile {}
 impl ToNostrUri for Nip19Event {}
 impl FromNostrUri for Nip19Event {}
-impl ToNostrUri for Coordinate {}
 impl FromNostrUri for Coordinate {}
+impl ToNostrUri for Nip19Coordinate {}
+impl FromNostrUri for Nip19Coordinate {}
 
 /// A representation any `NIP21` object. Useful for decoding
 /// `NIP21` strings without necessarily knowing what you're decoding
@@ -127,7 +130,7 @@ pub enum Nip21 {
     /// nostr::nevent
     Event(Nip19Event),
     /// nostr::naddr
-    Coordinate(Coordinate),
+    Coordinate(Nip19Coordinate),
 }
 
 impl From<Nip21> for Nip19 {


### PR DESCRIPTION
- Add `Nip19Coordinate` struct
- Remove `relays` from `Coordinate` struct
- Add `Coordinate::verify` method
- Update coordinate parsing constructors to take `&str`

Closes https://github.com/rust-nostr/nostr/issues/759