### PR TITLE
sdk: Use `vec!` instead of `Vec::push`

### DIFF
--- a/crates/nostr-sdk/src/gossip/graph.rs
+++ b/crates/nostr-sdk/src/gossip/graph.rs
@@ -483,9 +483,10 @@ mod tests {
     async fn setup_graph() -> GossipGraph {
         let graph = GossipGraph::new();
 
-        let mut events = Vec::new();
-        events.push(build_relay_list_event(SECRET_KEY_A, KEY_A_RELAYS.to_vec()));
-        events.push(build_relay_list_event(SECRET_KEY_B, KEY_B_RELAYS.to_vec()));
+        let events = vec![
+            build_relay_list_event(SECRET_KEY_A, KEY_A_RELAYS.to_vec()),
+            build_relay_list_event(SECRET_KEY_B, KEY_B_RELAYS.to_vec()),
+        ];
 
         graph.update(events).await;
 


### PR DESCRIPTION
### Description

Fix clippy lint

### Checklist

* [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [X] I ran `just precommit` or `just check` before committing
* [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
