### PR TITLE
chore(contrib): Do not check the deps doc

### DIFF
--- a/contrib/scripts/check-docs.sh
+++ b/contrib/scripts/check-docs.sh
@@ -13,6 +13,6 @@ buildargs=(
 
 for arg in "${buildargs[@]}"; do
     echo  "Checking '$arg' docs"
-    cargo doc $arg --all-features
+    cargo doc --no-deps $arg --all-features
     echo
 done


### PR DESCRIPTION
### Description

I don't think there is any reason to check deps docs, it's only waste of time,
so I add `--no-deps` to the `cargo doc` command, to check only our crates


### Checklist

* [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [X] I ran `just precommit` or `just check` before committing
* [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
