### PR TITLE
NIP38: User Statuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 
 ### Added
 
+* nostr: add NIP-38 support ([reyamir])
 * nostr: add NIP-62 support ([awiteb])
 * nostr: add `nip21::extract_from_text` function ([Yuki Kishimoto])
 * nostr: add `EventBuilder::allow_self_tagging` ([Yuki Kishimoto])

--- a/bindings/nostr-sdk-ffi/src/protocol/event/kind.rs
+++ b/bindings/nostr-sdk-ffi/src/protocol/event/kind.rs
@@ -326,6 +326,10 @@ pub enum KindStandard {
     SetProduct,
     /// Job Feedback (NIP90)
     JobFeedback,
+    /// User Status
+    ///
+    /// <https://github.com/nostr-protocol/nips/blob/master/38.md>
+    UserStatus,
 }
 
 fn convert(k: nostr::Kind) -> Option<KindStandard> {
@@ -410,7 +414,8 @@ fn convert(k: nostr::Kind) -> Option<KindStandard> {
         nostr::Kind::Torrent => Some(KindStandard::Torrent),
         nostr::Kind::TorrentComment => Some(KindStandard::TorrentComment),
         nostr::Kind::PeerToPeerOrder => Some(KindStandard::PeerToPeerOrder),
-        nostr_sdk::Kind::RequestToVanish => Some(KindStandard::RequestToVanish),
+        nostr::Kind::RequestToVanish => Some(KindStandard::RequestToVanish),
+        nostr::Kind::UserStatus => Some(KindStandard::UserStatus),
         nostr::Kind::Custom(..) => None,
     }
 }
@@ -493,6 +498,7 @@ impl From<KindStandard> for nostr::Kind {
             KindStandard::TorrentComment => Self::TorrentComment,
             KindStandard::PeerToPeerOrder => Self::PeerToPeerOrder,
             KindStandard::RequestToVanish => Self::RequestToVanish,
+            KindStandard::UserStatus => Self::UserStatus,
         }
     }
 }

--- a/crates/nostr-sdk/examples/status.rs
+++ b/crates/nostr-sdk/examples/status.rs
@@ -1,0 +1,37 @@
+// Copyright (c) 2022-2023 Yuki Kishimoto
+// Copyright (c) 2023-2025 Rust Nostr Developers
+// Distributed under the MIT software license
+
+use std::time::Duration;
+
+use nostr_sdk::prelude::*;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+
+    let keys = Keys::parse("nsec1ufnus6pju578ste3v90xd5m2decpuzpql2295m3sknqcjzyys9ls0qlc85")?;
+    let client = Client::new(keys);
+
+    client.add_relay("wss://relay.damus.io").await?;
+    client.add_relay("wss://nostr.wine").await?;
+    client.add_relay("wss://relay.rip").await?;
+
+    client.connect().await;
+
+    // Send a General statuses event to relays
+    let general = LiveStatus::new(StatusType::General);
+    let builder = EventBuilder::live_status(general, "Building rust-nostr");
+    client.send_event_builder(builder).await?;
+
+    // Send a Music statuses event to relays
+    let music = LiveStatus {
+        status_type: StatusType::Music,
+        expiration: Some(Timestamp::now() + Duration::from_secs(60 * 60 * 24)),
+        reference: Some("spotify:search:Intergalatic%20-%20Beastie%20Boys".into()),
+    };
+    let builder = EventBuilder::live_status(music, "Intergalatic - Beastie Boys");
+    client.send_event_builder(builder).await?;
+
+    Ok(())
+}

--- a/crates/nostr/README.md
+++ b/crates/nostr/README.md
@@ -136,7 +136,7 @@ The following crate feature flags are available:
 |     ✅     | [34 - `git` stuff](https://github.com/nostr-protocol/nips/blob/master/34.md)                                    |
 |     ✅     | [35 - Torrents](https://github.com/nostr-protocol/nips/blob/master/35.md)                                       |
 |     ✅     | [36 - Sensitive Content](https://github.com/nostr-protocol/nips/blob/master/36.md)                              |
-|     ❌     | [38 - User Statuses](https://github.com/nostr-protocol/nips/blob/master/38.md)                                  |
+|     ✅     | [38 - User Statuses](https://github.com/nostr-protocol/nips/blob/master/38.md)                                  |
 |     ✅     | [39 - External Identities in Profiles](https://github.com/nostr-protocol/nips/blob/master/39.md)                |
 |     ✅     | [40 - Expiration Timestamp](https://github.com/nostr-protocol/nips/blob/master/40.md)                           |
 |     ✅     | [42 - Authentication of clients to relays](https://github.com/nostr-protocol/nips/blob/master/42.md)            |
@@ -151,7 +151,7 @@ The following crate feature flags are available:
 |     ❌     | [52 - Calendar Events](https://github.com/nostr-protocol/nips/blob/master/52.md)                                |
 |     ✅     | [53 - Live Activities](https://github.com/nostr-protocol/nips/blob/master/53.md)                                |
 |     ❌     | [54 - Wiki](https://github.com/nostr-protocol/nips/blob/master/54.md)                                           |
-|     -      | [55 - Android Signer Application](https://github.com/nostr-protocol/nips/blob/master/55.md)                     |
+|     -     | [55 - Android Signer Application](https://github.com/nostr-protocol/nips/blob/master/55.md)                     |
 |     ✅     | [56 - Reporting](https://github.com/nostr-protocol/nips/blob/master/56.md)                                      |
 |     ✅     | [57 - Lightning Zaps](https://github.com/nostr-protocol/nips/blob/master/57.md)                                 |
 |     ✅     | [58 - Badges](https://github.com/nostr-protocol/nips/blob/master/58.md)                                         |

--- a/crates/nostr/src/event/builder.rs
+++ b/crates/nostr/src/event/builder.rs
@@ -1730,6 +1730,18 @@ impl EventBuilder {
         ])
     }
 
+    /// User Statuses
+    ///
+    /// <https://github.com/nostr-protocol/nips/blob/master/38.md>
+    #[inline]
+    pub fn live_status<S>(status: LiveStatus, content: S) -> Self
+    where
+        S: Into<String>,
+    {
+        let tags: Vec<Tag> = status.into();
+        Self::new(Kind::UserStatus, content).tags(tags)
+    }
+
     /// Git Repository Announcement
     ///
     /// <https://github.com/nostr-protocol/nips/blob/master/34.md>

--- a/crates/nostr/src/event/kind.rs
+++ b/crates/nostr/src/event/kind.rs
@@ -151,6 +151,7 @@ kind_variants! {
     TorrentComment => 2004, "Torrent Comment", "<https://github.com/nostr-protocol/nips/blob/master/35.md>",
     PeerToPeerOrder => 38383, "Peer-to-peer Order events", "<https://github.com/nostr-protocol/nips/blob/master/69.md>",
     RequestToVanish => 62, "Request to Vanish", "<https://github.com/nostr-protocol/nips/blob/master/62.md>",
+    UserStatus => 30315, "User Status", "<https://github.com/nostr-protocol/nips/blob/master/38.md>",
 }
 
 impl PartialEq for Kind {

--- a/crates/nostr/src/nips/mod.rs
+++ b/crates/nostr/src/nips/mod.rs
@@ -28,6 +28,7 @@ pub mod nip22;
 pub mod nip26;
 pub mod nip34;
 pub mod nip35;
+pub mod nip38;
 pub mod nip39;
 #[cfg(feature = "nip44")]
 pub mod nip44;

--- a/crates/nostr/src/nips/nip38.rs
+++ b/crates/nostr/src/nips/nip38.rs
@@ -1,0 +1,83 @@
+// Copyright (c) 2022-2023 Yuki Kishimoto
+// Copyright (c) 2023-2025 Rust Nostr Developers
+// Distributed under the MIT software license
+
+//! NIP38: User Statuses
+//!
+//! <https://github.com/nostr-protocol/nips/blob/master/38.md>
+
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use core::fmt;
+
+use crate::{Tag, Timestamp};
+
+/// NIP38 types
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum StatusType {
+    /// General status: "Working", "Hiking", etc.
+    #[default]
+    General,
+    /// Music what you are currently listening to
+    Music,
+    /// Custom status: "Playing", "Reading", etc.
+    Custom(String),
+}
+
+impl fmt::Display for StatusType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::General => write!(f, "general"),
+            Self::Music => write!(f, "music"),
+            Self::Custom(s) => write!(f, "{s}"),
+        }
+    }
+}
+
+/// User status
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct LiveStatus {
+    /// Status type, includes: General, Music or Custom
+    pub status_type: StatusType,
+    /// Expiration time of the status (Optional)
+    pub expiration: Option<Timestamp>,
+    /// Reference to the external resource (Optional)
+    pub reference: Option<String>,
+}
+
+impl LiveStatus {
+    /// Create a new user status
+    #[inline]
+    pub fn new(status_type: StatusType) -> Self {
+        Self {
+            status_type,
+            expiration: None,
+            reference: None,
+        }
+    }
+}
+
+impl From<LiveStatus> for Vec<Tag> {
+    fn from(
+        LiveStatus {
+            status_type,
+            expiration,
+            reference,
+        }: LiveStatus,
+    ) -> Self {
+        let mut tags =
+            Vec::with_capacity(1 + expiration.is_some() as usize + reference.is_some() as usize);
+
+        tags.push(Tag::identifier(status_type.to_string()));
+
+        if let Some(expire_at) = expiration {
+            tags.push(Tag::expiration(expire_at));
+        }
+
+        if let Some(content) = reference {
+            tags.push(Tag::reference(content));
+        }
+
+        tags
+    }
+}

--- a/crates/nostr/src/prelude.rs
+++ b/crates/nostr/src/prelude.rs
@@ -49,6 +49,7 @@ pub use crate::nips::nip21::{self, *};
 pub use crate::nips::nip26::{self, *};
 pub use crate::nips::nip34::{self, *};
 pub use crate::nips::nip35::{self, *};
+pub use crate::nips::nip38::{self, *};
 pub use crate::nips::nip39::{self, *};
 #[cfg(feature = "nip44")]
 pub use crate::nips::nip44::{self, *};


### PR DESCRIPTION
### Description

Add support for create NIP38 event with `EventBuilder`. Close: https://github.com/rust-nostr/nostr/issues/666

**Usage:**
```rust
// Send a General statuses event to relays
let general = LiveStatus {
    status_type: StatusType::General,
    expiration: None,
    reference: None,
};
let builder = EventBuilder::live_statuses(general, "Building rust-nostr", vec![]);
client.send_event_builder(builder).await?;

// Send a Music statuses event to relays
let music = LiveStatus {
    status_type: StatusType::Music,
    expiration: Some(Timestamp::now()),
    reference: Some("spotify:search:Intergalatic%20-%20Beastie%20Boys".into()),
};
let builder = EventBuilder::live_statuses(music, "Intergalatic - Beastie Boys", vec![]);
client.send_event_builder(builder).await?;
```

### Notes to the reviewers

None

### Checklist

* [x] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [x] I ran `just precommit` or `just check` before committing
* [x] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
