### PR TITLE
nip19: Custom checksum with `usize::MAX` limit for bech32 decoding

### DIFF
--- a/crates/nostr/src/nips/nip19.rs
+++ b/crates/nostr/src/nips/nip19.rs
@@ -11,11 +11,11 @@
 use alloc::borrow::Cow;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
-use bech32::primitives::decode::{CheckedHrpstring, CheckedHrpstringError};
 use core::fmt;
 use core::ops::Deref;
 use core::str::FromStr;
 
+use bech32::primitives::decode::{CheckedHrpstring, CheckedHrpstringError};
 use bech32::{self, Bech32, Hrp};
 
 use super::nip01::Coordinate;


### PR DESCRIPTION
Related: https://github.com/rust-nostr/nostr/issues/723

### Description

This patch introduces a custom checksum with a `usize::MAX` limit instead of the
previous limit of `1023`.

Before this patch, the following code would not work. Now it works as expected:

```rust
use nostr::prelude::*;

const NPROFILE: &str = "...";

fn main() {
    let nprofile = Nip19Profile::from_bech32(NPROFILE).unwrap();
    println!("{}", nprofile.public_key);
    for (idx, relay) in nprofile.relays.iter().enumerate() {
        println!("{idx}: {relay}");
    }
}
```

Output:

```
Public Key: 813fce4c4e76f1e7b4f4697bf1030a90f1a0b783f187d329800a4dd8697f9759
0: wss://brb.io/
1: wss://brb.io/
2: wss://eden.nostr.land/
3: wss://eden.nostr.land/
4: wss://nos.lol/
5: wss://nos.lol/
6: wss://nostr-pub.wellorder.net/
7: wss://nostr-pub.wellorder.net/
8: wss://nostr.bitcoiner.social/
9: wss://nostr.fmt.wiz.biz/
10: wss://nostr.fmt.wiz.biz/
11: wss://nostr.relayer.se/
12: wss://nostr.relayer.se/
13: wss://nostr.wine/
14: wss://nostr.x0f.org/
15: wss://offchain.pub/
16: wss://offchain.pub/
17: wss://relay.current.fyi/
18: wss://relay.current.fyi/
19: wss://relay.damus.io/
20: wss://relay.damus.io/
21: wss://relay.mostr.pub/
22: wss://relay.nostr.band/
23: wss://relay.nostr.info/
24: wss://relay.nostr.info/
25: wss://relay.noswhere.com/
26: wss://relay.primal.net/
27: wss://relay.snort.social/
28: wss://relay.snort.social/
```


### Notes to the reviewers

Why not encoding? I tried, but it produce a different nprofile, so I implemented decoding only.

### Checklist

* [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [X] I ran `just precommit` or `just check` before committing
* [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)

