### PR TITLE
nostr(nip24): Check if the `t` tag content is a lowercase string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * nostr: change `EventBuilder::git_repository_announcement` constructor signature ([Yuki Kishimoto])
 * nostr: change `EventBuilder::git_issue` constructor signature ([Yuki Kishimoto])
 * nostr: change `EventBuilder::git_patch` constructor signature ([Yuki Kishimoto])
+* nostr: `TagStandard::parse` now returns `Err(Error::UnknownStandardizedTag)` for non-lowercase hashtags as per NIP-24 ([awiteb])
 * pool: drop `RelayFiltering` ([Yuki Kishimoto])
 * sdk: change `Client::fetch_metadata` output ([Yuki Kishimoto]) 
 
@@ -92,6 +93,7 @@
 * nostr: fix `EventBuilder::git_repository_announcement` constructor according to last NIP34 rev ([Yuki Kishimoto])
 * nostr: fix `EventBuilder::git_issue` constructor according to last NIP34 rev ([Yuki Kishimoto])
 * nostr: fix `EventBuilder::git_patch` constructor according to last NIP34 rev ([Yuki Kishimoto])
+* nostr: `Tag::hashtag` now lowercases the hashtag as per NIP-24 ([awiteb])
 
 ### Removed
 

--- a/crates/nostr/src/event/tag/mod.rs
+++ b/crates/nostr/src/event/tag/mod.rs
@@ -298,12 +298,15 @@ impl Tag {
     }
 
     /// Compose `["t", "<hashtag>"]` tag
+    ///
+    /// This will convert the hashtag to lowercase.
     #[inline]
     pub fn hashtag<T>(hashtag: T) -> Self
     where
         T: Into<String>,
     {
-        Self::from_standardized_without_cell(TagStandard::Hashtag(hashtag.into()))
+        let hashtag: String = hashtag.into();
+        Self::from_standardized_without_cell(TagStandard::Hashtag(hashtag.to_lowercase()))
     }
 
     /// Compose `["r", "<value>"]` tag
@@ -608,6 +611,15 @@ mod tests {
             Tag::custom(TagKind::Client, ["nostr-sdk"])
         );
     }
+
+    #[test]
+    fn test_hashtag() {
+        assert_eq!(
+            Tag::parse(["t", "Nostr"]).unwrap(),
+            Tag::custom(TagKind::t(), ["Nostr"])
+        );
+        assert_eq!(Tag::hashtag("Nostr"), Tag::custom(TagKind::t(), ["nostr"]));
+    }
 }
 
 #[cfg(bench)]
@@ -677,6 +689,14 @@ mod benches {
             "30023:a695f6b60119d9521934a691347d9f78e8770b56da16bb255ee286ddf9fda919:ipsum",
             "wss://relay.nostr.org",
         ];
+        bh.iter(|| {
+            black_box(Tag::parse(tag)).unwrap();
+        });
+    }
+
+    #[bench]
+    pub fn parse_t_tag(bh: &mut Bencher) {
+        let tag = ["t", "test"];
         bh.iter(|| {
             black_box(Tag::parse(tag)).unwrap();
         });

--- a/crates/nostr/src/event/tag/standard.rs
+++ b/crates/nostr/src/event/tag/standard.rs
@@ -315,6 +315,13 @@ impl TagStandard {
                 } => {
                     return parse_q_tag(tag);
                 }
+                // Parse `t` tag
+                SingleLetterTag {
+                    character: Alphabet::T,
+                    uppercase: false,
+                } => {
+                    return parse_t_tag(tag);
+                }
                 _ => (), // Covered later
             },
             TagKind::Anon => {
@@ -356,10 +363,6 @@ impl TagStandard {
             let tag_1: &str = tag[1].as_ref();
 
             return match tag_kind {
-                TagKind::SingleLetter(SingleLetterTag {
-                    character: Alphabet::T,
-                    uppercase: false,
-                }) => Ok(Self::Hashtag(tag_1.to_string())),
                 TagKind::SingleLetter(SingleLetterTag {
                     character: Alphabet::G,
                     uppercase: false,
@@ -1243,6 +1246,22 @@ where
         relay_url,
         public_key,
     })
+}
+
+fn parse_t_tag<S>(tag: &[S]) -> Result<TagStandard, Error>
+where
+    S: AsRef<str>,
+{
+    let hashtag = tag.get(1).ok_or(Error::UnknownStandardizedTag)?.as_ref();
+
+    // Not all languages have uppercase and lowercase versions of letters.
+    // If not all letters are lowercase and there is no single uppercase letter,
+    // it means the hashtag is in a language that doesn't have uppercase/lowercase letters.
+    if !hashtag.chars().all(char::is_lowercase) && hashtag.chars().any(char::is_uppercase) {
+        return Err(Error::UnknownStandardizedTag);
+    }
+
+    Ok(TagStandard::Hashtag(hashtag.to_string()))
 }
 
 fn parse_client_tag<S>(tag: &[S]) -> Result<TagStandard, Error>
@@ -2534,5 +2553,12 @@ mod tests {
                 Url::parse("https://github.com/rust-nostr").unwrap(),
             ])
         );
+
+        assert_eq!(
+            TagStandard::parse(&["t", "Nostr"]),
+            Err(Error::UnknownStandardizedTag)
+        );
+        assert!(TagStandard::parse(&["t", "nostr"]).is_ok());
+        assert!(TagStandard::parse(&["t", "سلام"]).is_ok());
     }
 }


### PR DESCRIPTION
Close #784

### Description

As NIP-24 states:

> - `t`: a hashtag. The value MUST be a lowercase string.

In this patch:
- `Tag::hashtag` always converts hashtags to lowercase.
- `TagStandard::parse` returns an error (`UnknownStandardizedTag`) if the t-tag content is not a lowercase string.

### Notes to the Reviewers

Not all languages have uppercase and lowercase versions of letters. Rust will return `false` for both `char::is_lowercase` and `char::is_uppercase` in such cases. In `parse_t_tag`, if not all letters are lowercase, it means there is at least one uppercase letter. If no uppercase letter is found, it indicates that the language of the hashtag does not have distinct uppercase and lowercase letters. Try this example.

```rust
fn main() {
    let arabic_char = 'أ';
    println!(
        "{}, {}",
        arabic_char.is_uppercase(), // false
        arabic_char.is_lowercase() // false
    );
}
```

### Checklist

* [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [X] I ran `just precommit` or `just check` before committing
* [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
