### PR TITLE
doc: Fix doc warnings

### DIFF
--- a/crates/nostr-cli/src/cli/parser.rs
+++ b/crates/nostr-cli/src/cli/parser.rs
@@ -29,7 +29,6 @@ static METACHAR_PATTERN: Lazy<Regex> = Lazy::new(|| Regex::new(r#"\\([$`"\\\n])"
 ///
 /// If the input contains mismatched quotes (a quoted string missing a matching ending quote),
 /// a `MismatchedQuotes` error is returned.
-/// ```
 pub fn split(input: &str) -> Result<Vec<String>, MismatchedQuotes> {
     let mut words = Vec::new();
     let mut field = String::new();

--- a/crates/nostr-relay-pool/src/pool/mod.rs
+++ b/crates/nostr-relay-pool/src/pool/mod.rs
@@ -209,7 +209,7 @@ impl RelayPool {
         .await
     }
 
-    /// Get relays that have a certain [RelayServiceFlag] enabled
+    /// Get relays that have a certain [`RelayServiceFlags`] enabled
     pub async fn relays_with_flag(
         &self,
         flag: RelayServiceFlags,

--- a/crates/nostr-sdk/src/client/mod.rs
+++ b/crates/nostr-sdk/src/client/mod.rs
@@ -170,7 +170,6 @@ impl Client {
     /// * unsubscribe from all subscriptions
     /// * disconnect and force remove all relays
     /// * unset the signer
-    /// * clear the [`RelayFiltering`]
     ///
     /// This method will NOT:
     /// * reset [`Options`]
@@ -781,7 +780,7 @@ impl Client {
     /// This method will be deprecated in the future!
     /// This is a temporary solution for who still want to query events both from database and relays and merge the result.
     /// The optimal solution is to execute a [`Client::sync`] to reconcile missing events, [`Client::subscribe`] to get all
-    /// new future events, [`NostrDatabase::query`] to query stored events and [`Client::handle_notifications`] to listen-for/handle new events (i.e. to know when update the UI).
+    /// new future events, [`NostrEventsDatabase::query`] to query stored events and [`Client::handle_notifications`] to listen-for/handle new events (i.e. to know when update the UI).
     /// This will allow very fast queries, low bandwidth usage (depending on how many events the client have to reconcile) and a lower load on the relays.
     ///
     /// You can obtain the same result with:

--- a/crates/nostr/src/nips/nip62.rs
+++ b/crates/nostr/src/nips/nip62.rs
@@ -4,7 +4,7 @@
 
 //! NIP-62: Request to Vanish
 //!
-//! https://github.com/nostr-protocol/nips/blob/master/62.md
+//! <https://github.com/nostr-protocol/nips/blob/master/62.md>
 
 use alloc::vec::Vec;
 


### PR DESCRIPTION
### Description

Fix warnings produce by `cargo doc --no-deps`

### Notes to the reviewers

I removed `* clear the [RelayFiltering]` from [`Client::reset`] [because it was removed] 

### Checklist

* [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [X] I ran `just precommit` or `just check` before committing
* [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)

[`Client::reset`]: https://docs.rs/nostr-sdk/latest/nostr_sdk/client/struct.Client.html#method.reset
[because it was removed]: https://github.com/rust-nostr/nostr/blob/40c20a093672b4cc6d31bb1d96be09c1843d5893/CHANGELOG.md?plain=1#L45