### PR TITLE
pool: improve auto-closing subscriptions and add new exit policy 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 * lmdb: avoid long-lived read txn when ingesting event ([Yuki Kishimoto])
 * ndb: return `None` in `NostrEventsDatabase::event_by_id` if event doesn't exist ([Yuki Kishimoto])
 * ndb: avoid event clone when calling `NostrEventsDatabase::save_event` ([Yuki Kishimoto])
+* pool: better handling of auto-closing subscription activity when fetching events ([Yuki Kishimoto])
 * sdk: auto-update the gossip data when sending an event ([Yuki Kishimoto])
 * sdk: avoid full clone of relays when only urls are needed ([Yuki Kishimoto])
 * nwc: allow usage of multiple relays ([Yuki Kishimoto])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@
 * nostr: impl `FromIterator<Tag>` for `Tags` ([Yuki Kishimoto])
 * nostr: add `EventDeletionRequest` struct ([Yuki Kishimoto])
 * nostr: add `notifications` field to NIP47 `GetInfoResponse` ([Yuki Kishimoto])
+* database: add `Events::force_insert` ([Yuki Kishimoto])
 * pool: event verification cache ([Yuki Kishimoto])
 * pool: add `AdmitPolicy` trait ([Yuki Kishimoto])
 * ffi: add Mac Catalyst support in Swift package ([Yuki Kishimoto])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@
 * database: add `Events::force_insert` ([Yuki Kishimoto])
 * pool: event verification cache ([Yuki Kishimoto])
 * pool: add `AdmitPolicy` trait ([Yuki Kishimoto])
+* pool: add `ReqExitPolicy::WaitForEvents` variant ([Yuki Kishimoto])
 * ffi: add Mac Catalyst support in Swift package ([Yuki Kishimoto])
 * js: add `KindStandard` enum ([Yuki Kishimoto])
 

--- a/bindings/nostr-sdk-ffi/src/relay/options.rs
+++ b/bindings/nostr-sdk-ffi/src/relay/options.rs
@@ -175,6 +175,8 @@ impl RelayOptions {
 pub enum ReqExitPolicy {
     /// Exit on EOSE
     ExitOnEOSE,
+    /// Wait to receive N events and then exit.
+    WaitForEvents { num: u16 },
     /// After EOSE is received, keep listening for N more events that match the filter.
     WaitForEventsAfterEOSE { num: u16 },
     /// After EOSE is received, keep listening for matching events for `Duration` more time.
@@ -185,6 +187,7 @@ impl From<ReqExitPolicy> for prelude::ReqExitPolicy {
     fn from(value: ReqExitPolicy) -> Self {
         match value {
             ReqExitPolicy::ExitOnEOSE => Self::ExitOnEOSE,
+            ReqExitPolicy::WaitForEvents { num } => Self::WaitForEvents(num),
             ReqExitPolicy::WaitForEventsAfterEOSE { num } => Self::WaitForEventsAfterEOSE(num),
             ReqExitPolicy::WaitDurationAfterEOSE { duration } => {
                 Self::WaitDurationAfterEOSE(duration)

--- a/bindings/nostr-sdk-js/src/relay/options.rs
+++ b/bindings/nostr-sdk-js/src/relay/options.rs
@@ -108,6 +108,14 @@ impl JsReqExitPolicy {
         }
     }
 
+    /// Wait to receive N events and then exit.
+    #[wasm_bindgen(js_name = waitForEvents)]
+    pub fn wait_for_events(num: u16) -> Self {
+        Self {
+            inner: ReqExitPolicy::WaitForEvents(num),
+        }
+    }
+
     /// After EOSE is received, keep listening for N more events that match the filter
     #[wasm_bindgen(js_name = waitForEventsAfterEOSE)]
     pub fn wait_for_events_after_eose(num: u16) -> Self {

--- a/crates/nostr-database/src/collections/events.rs
+++ b/crates/nostr-database/src/collections/events.rs
@@ -70,9 +70,20 @@ impl Events {
     /// Insert [`Event`]
     ///
     /// If the set did not previously contain an equal value, `true` is returned.
+    /// If the collection is full, the older events will be discarded.
+    /// Use [`Events::force_insert`] to always make sure the event is inserted.
     #[inline]
     pub fn insert(&mut self, event: Event) -> bool {
         self.set.insert(event).inserted
+    }
+
+    /// Force insert [`Event`]
+    ///
+    /// Use [`Events::insert`] to respect the max collection capacity (if any).
+    /// If the collection capacity is full, this method will increase it.
+    #[inline]
+    pub fn force_insert(&mut self, event: Event) -> bool {
+        self.set.force_insert(event).inserted
     }
 
     /// Insert events

--- a/crates/nostr-database/src/collections/tree.rs
+++ b/crates/nostr-database/src/collections/tree.rs
@@ -237,6 +237,28 @@ where
         }
     }
 
+    /// Force insert the value
+    ///
+    /// If the capacity is full, automatically increases the capacity.
+    pub fn force_insert(&mut self, value: T) -> InsertResult<T> {
+        let inserted: bool = self.set.insert(value);
+
+        // If successfully inserted, check if the capacity must be increased
+        if inserted {
+            if let Capacity::Bounded { max, .. } = self.capacity {
+                if self.set.len() >= max {
+                    self.capacity = Capacity::bounded(max + 1);
+                }
+            }
+        }
+
+        // Insert value
+        InsertResult {
+            inserted,
+            pop: None,
+        }
+    }
+
     /// Extend with values
     pub fn extend<I>(&mut self, values: I)
     where

--- a/crates/nostr-relay-pool/src/pool/mod.rs
+++ b/crates/nostr-relay-pool/src/pool/mod.rs
@@ -996,7 +996,8 @@ impl RelayPool {
             .stream_events_from(urls, filter, timeout, policy)
             .await?;
         while let Some(event) = stream.next().await {
-            events.insert(event);
+            // To find out more about why the `force_insert` was used, search for EVENTS_FORCE_INSERT ine the code.
+            events.force_insert(event);
         }
 
         Ok(events)

--- a/crates/nostr-relay-pool/src/relay/options.rs
+++ b/crates/nostr-relay-pool/src/relay/options.rs
@@ -175,6 +175,8 @@ pub enum ReqExitPolicy {
     /// Exit on EOSE.
     #[default]
     ExitOnEOSE,
+    /// Wait to receive N events and then exit.
+    WaitForEvents(u16),
     /// After EOSE is received, keep listening for N more events that match the filter.
     WaitForEventsAfterEOSE(u16),
     /// After EOSE is received, keep listening for matching events for [`Duration`] more time.

--- a/crates/nostr-sdk/src/client/mod.rs
+++ b/crates/nostr-sdk/src/client/mod.rs
@@ -1505,7 +1505,8 @@ impl Client {
             self.gossip_stream_events(filter, timeout, policy).await?;
 
         while let Some(event) = stream.next().await {
-            events.insert(event);
+            // To find out more about why the `force_insert` was used, search for EVENTS_FORCE_INSERT ine the code.
+            events.force_insert(event);
         }
 
         Ok(events)


### PR DESCRIPTION
- Use `Events::force_insert` when fetching events from relays
- Better handling of auto-closing subscription activity when fetching events
- Add `ReqExitPolicy::WaitForEvents` variant