### PR TITLE
nostr: update `GetInfoResponse` fields types

### DIFF
--- a/bindings/nostr-sdk-ffi/src/protocol/nips/nip47.rs
+++ b/bindings/nostr-sdk-ffi/src/protocol/nips/nip47.rs
@@ -721,17 +721,17 @@ impl From<GetBalanceResponse> for nip47::GetBalanceResponse {
 #[derive(Record)]
 pub struct GetInfoResponse {
     /// The alias of the lightning node
-    pub alias: String,
+    pub alias: Option<String>,
     /// The color of the current node in hex code format
-    pub color: String,
+    pub color: Option<String>,
     /// Lightning Node's public key
-    pub pubkey: String,
+    pub pubkey: Option<String>,
     /// Active network
-    pub network: String,
+    pub network: Option<String>,
     /// Current block height
-    pub block_height: u32,
+    pub block_height: Option<u32>,
     /// Most Recent Block Hash
-    pub block_hash: String,
+    pub block_hash: Option<String>,
     /// Available methods for this connection
     pub methods: Vec<String>,
     /// List of supported notifications for this connection (optional)
@@ -743,7 +743,7 @@ impl From<nip47::GetInfoResponse> for GetInfoResponse {
         Self {
             alias: value.alias,
             color: value.color,
-            pubkey: value.pubkey,
+            pubkey: value.pubkey.map(|p| p.to_string()),
             network: value.network,
             block_height: value.block_height,
             block_hash: value.block_hash,
@@ -758,7 +758,7 @@ impl From<GetInfoResponse> for nip47::GetInfoResponse {
         Self {
             alias: value.alias,
             color: value.color,
-            pubkey: value.pubkey,
+            pubkey: value.pubkey.and_then(|p| p.parse().ok()),
             network: value.network,
             block_height: value.block_height,
             block_hash: value.block_hash,

--- a/bindings/nostr-sdk-js/src/protocol/nips/nip47.rs
+++ b/bindings/nostr-sdk-js/src/protocol/nips/nip47.rs
@@ -539,21 +539,21 @@ impl From<JsGetBalanceResponse> for GetBalanceResponse {
 pub struct JsGetInfoResponse {
     /// The alias of the lightning node
     #[wasm_bindgen(getter_with_clone)]
-    pub alias: String,
+    pub alias: Option<String>,
     /// The color of the current node in hex code format
     #[wasm_bindgen(getter_with_clone)]
-    pub color: String,
+    pub color: Option<String>,
     /// Lightning Node's public key
     #[wasm_bindgen(getter_with_clone)]
-    pub pubkey: String,
+    pub pubkey: Option<String>,
     /// Active network
     #[wasm_bindgen(getter_with_clone)]
-    pub network: String,
+    pub network: Option<String>,
     /// Current block height
-    pub block_height: u32,
+    pub block_height: Option<u32>,
     /// Most Recent Block Hash
     #[wasm_bindgen(getter_with_clone)]
-    pub block_hash: String,
+    pub block_hash: Option<String>,
     /// Available methods for this connection
     #[wasm_bindgen(getter_with_clone)]
     pub methods: Vec<String>,
@@ -567,7 +567,7 @@ impl From<GetInfoResponse> for JsGetInfoResponse {
         Self {
             alias: value.alias,
             color: value.color,
-            pubkey: value.pubkey,
+            pubkey: value.pubkey.map(|p| p.to_string()),
             network: value.network,
             block_height: value.block_height,
             block_hash: value.block_hash,
@@ -582,7 +582,7 @@ impl From<JsGetInfoResponse> for GetInfoResponse {
         Self {
             alias: value.alias,
             color: value.color,
-            pubkey: value.pubkey,
+            pubkey: value.pubkey.and_then(|p| p.parse().ok()),
             network: value.network,
             block_height: value.block_height,
             block_hash: value.block_hash,

--- a/crates/nostr/src/nips/nip47.rs
+++ b/crates/nostr/src/nips/nip47.rs
@@ -594,17 +594,29 @@ pub struct GetBalanceResponse {
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct GetInfoResponse {
     /// The alias of the lightning node
-    pub alias: String,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub alias: Option<String>,
     /// The color of the current node in hex code format
-    pub color: String,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color: Option<String>,
     /// Lightning Node's public key
-    pub pubkey: String,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pubkey: Option<secp256k1::PublicKey>,
     /// Active network
-    pub network: String,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub network: Option<String>,
     /// Current block height
-    pub block_height: u32,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub block_height: Option<u32>,
     /// Most Recent Block Hash
-    pub block_hash: String,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub block_hash: Option<String>,
     /// Available methods for this connection
     pub methods: Vec<String>,
     /// List of supported notifications for this connection (optional)


### PR DESCRIPTION
Make all `GetInfoResponse` fields optional, except for `methods`.

Ref https://github.com/nostr-protocol/nips/issues/1827
Closes https://github.com/rust-nostr/nostr/issues/795