### PR TITLE
pool: allow user to set internal notification_channel_size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 * pool: drop `RelayFiltering` ([Yuki Kishimoto])
 * pool: remove `Relay` constructors ([Yuki Kishimoto])
 * pool: change `RelayPool::new` signature ([Yuki Kishimoto])
+* pool: now can set the notification channel size of a single `Relay` using `RelayOptions` ([magine])
 * sdk: change `Client::fetch_metadata` output ([Yuki Kishimoto]) 
 * sdk: remove `Client::state` ([Yuki Kishimoto])
 
@@ -1177,6 +1178,7 @@ added `nostrdb` storage backend, added NIP32 and completed NIP51 support and mor
 [Francisco Calderón]: https://github.com/grunch (nostr:npub1qqqqqqqx2tj99mng5qgc07cgezv5jm95dj636x4qsq7svwkwmwnse3rfkq)
 [cipres]: https://github.com/PancakesArchitect (nostr:npub1r3cnzta52fee26c83cnes8wvzkch3kud2kll67k402x04mttt26q0wfx0c)
 [awiteb]: https://git.4rs.nl (nostr:nprofile1qqsqqqqqq9g9uljgjfcyd6dm4fegk8em2yfz0c3qp3tc6mntkrrhawgpzfmhxue69uhkummnw3ezudrjwvhxumq3dg0ly)
+[magine]: https://github.com/ma233 (?)
 
 <!-- Tags -->
 [Unreleased]: https://github.com/rust-nostr/nostr/compare/v0.39.0...HEAD

--- a/crates/nostr-relay-pool/src/relay/constants.rs
+++ b/crates/nostr-relay-pool/src/relay/constants.rs
@@ -11,6 +11,9 @@ pub(super) const WAIT_FOR_OK_TIMEOUT: Duration = Duration::from_secs(10);
 pub(super) const WAIT_FOR_AUTHENTICATION_TIMEOUT: Duration = Duration::from_secs(7);
 pub(super) const DEFAULT_CONNECTION_TIMEOUT: Duration = Duration::from_secs(60);
 
+/// Relay default notification channel size
+pub const DEFAULT_NOTIFICATION_CHANNEL_SIZE: usize = 2048;
+
 /// Max relay size
 pub const MAX_MESSAGE_SIZE: u32 = 5 * 1024 * 1024; // 5 MB
 /// Max event size

--- a/crates/nostr-relay-pool/src/relay/inner.rs
+++ b/crates/nostr-relay-pool/src/relay/inner.rs
@@ -159,7 +159,8 @@ impl AtomicDestroyer for InnerRelay {
 
 impl InnerRelay {
     pub(super) fn new(url: RelayUrl, state: SharedState, opts: RelayOptions) -> Self {
-        let (relay_notification_sender, ..) = broadcast::channel::<RelayNotification>(2048);
+        let (relay_notification_sender, ..) =
+            broadcast::channel::<RelayNotification>(opts.notification_channel_size);
 
         Self {
             url,

--- a/crates/nostr-relay-pool/src/relay/options.rs
+++ b/crates/nostr-relay-pool/src/relay/options.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use async_wsocket::ConnectionMode;
 use tokio::sync::watch::{self, Receiver, Sender};
 
-use super::constants::DEFAULT_RETRY_INTERVAL;
+use super::constants::{DEFAULT_NOTIFICATION_CHANNEL_SIZE, DEFAULT_RETRY_INTERVAL};
 use super::flags::RelayServiceFlags;
 use crate::RelayLimits;
 
@@ -23,6 +23,7 @@ pub struct RelayOptions {
     pub(super) adjust_retry_interval: bool,
     pub(super) limits: RelayLimits,
     pub(super) max_avg_latency: Option<Duration>,
+    pub(super) notification_channel_size: usize,
 }
 
 impl Default for RelayOptions {
@@ -35,6 +36,7 @@ impl Default for RelayOptions {
             adjust_retry_interval: true,
             limits: RelayLimits::default(),
             max_avg_latency: None,
+            notification_channel_size: DEFAULT_NOTIFICATION_CHANNEL_SIZE,
         }
     }
 }
@@ -119,6 +121,13 @@ impl RelayOptions {
     #[inline]
     pub fn max_avg_latency(mut self, max: Option<Duration>) -> Self {
         self.max_avg_latency = max;
+        self
+    }
+
+    /// Notification channel size (default: [`DEFAULT_NOTIFICATION_CHANNEL_SIZE`])
+    #[inline]
+    pub fn notification_channel_size(mut self, size: usize) -> Self {
+        self.notification_channel_size = size;
         self
     }
 }


### PR DESCRIPTION
### Description

This PR adds a `notification_channel_size` option to `RelayOptions`, allowing users to set the size of the internal notification sender channel for `InnerRelay`.

### Notes to the reviewers

I'm not sure if I should also update codes in bindings.

### Checklist

* [x] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [x] I ran `just precommit` or `just check` before committing
* [x] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
