### PR TITLE
relay-builder: not have to manually send a pong

### DIFF
--- a/crates/nostr-relay-builder/src/local/inner.rs
+++ b/crates/nostr-relay-builder/src/local/inner.rs
@@ -251,9 +251,7 @@ impl InnerLocalRelay {
                                         tracing::error!("Can't send msg to client: {e}");
                                     }
                                 }
-                                Message::Ping(val) => {
-                                    let _ = tx.send(Message::Pong(val)).await;
-                                }
+                                Message::Ping(..) => {}
                                 Message::Pong(..) => {}
                                 Message::Close(..) => {}
                                 Message::Frame(..) => {}


### PR DESCRIPTION
### Description

While you can manually send a pong without causing any issues, the tungstenite-rs automatically sends a pong once it receives a ping.

### Notes to the reviewers

Should we add tests to verify the original behavior before doing this?

### Checklist

* [ ] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [ ] I ran `just precommit` or `just check` before committing
* [ ] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
