### PR TITLE
nostr: fix missing transactions object in serialization of nip47 ListTransactions response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@
 
 ### Fixed
 
+* nostr: fix missing `transactions` object in serialization of nip47 ListTransactions ResponseResult ([daywalker90])
+
 ### Removed
 
 ### Deprecated
@@ -1216,6 +1218,7 @@ added `nostrdb` storage backend, added NIP32 and completed NIP51 support and mor
 [cipres]: https://github.com/PancakesArchitect (nostr:npub1r3cnzta52fee26c83cnes8wvzkch3kud2kll67k402x04mttt26q0wfx0c)
 [awiteb]: https://git.4rs.nl (nostr:nprofile1qqsqqqqqq9g9uljgjfcyd6dm4fegk8em2yfz0c3qp3tc6mntkrrhawgpzfmhxue69uhkummnw3ezudrjwvhxumq3dg0ly)
 [magine]: https://github.com/ma233 (?)
+[daywalker90]: https://github.com/daywalker90 (nostr:npub1kuemsj7xryp0uje36dr53scn9mxxh8ema90hw9snu46633n9n2hqp3drjt)
 
 <!-- Tags -->
 [Unreleased]: https://github.com/rust-nostr/nostr/compare/v0.40.0...HEAD


### PR DESCRIPTION
### Description

Fixes the serialization of a nip47 ResponseResult::ListTransactions. They were missing the transactions object in the result. Including a simple test to serialize and deserialize and make sure it stays the same.



### Checklist

* [x] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [x] I ran `just precommit` or `just check` before committing
* [x] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
