### PR TITLE
pool: returns `Output` instead of an error if the message/event sending fails for all relays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@
 
 ### Breaking changes
 
+* pool: remove `Error::Failed` variant ([Yuki Kishimoto])
+* pool: returns `Output` instead of an error if the message/event sending fails for all relays ([Yuki Kishimoto])
+
 ### Changed
 
 * lmdb: enable POSIX semaphores for macOS and iOS targets ([Yuki Kishimoto])

--- a/crates/nostr-relay-pool/src/pool/error.rs
+++ b/crates/nostr-relay-pool/src/pool/error.rs
@@ -33,8 +33,6 @@ pub enum Error {
     NoRelays,
     /// No relays specified
     NoRelaysSpecified,
-    /// Failed
-    Failed,
     /// Negentropy reconciliation failed
     NegentropyReconciliationFailed,
     /// Relay not found
@@ -56,7 +54,6 @@ impl fmt::Display for Error {
             Self::TooManyRelays { limit } => write!(f, "too many relays (limit: {limit})"),
             Self::NoRelays => write!(f, "no relays"),
             Self::NoRelaysSpecified => write!(f, "no relays specified"),
-            Self::Failed => write!(f, "completed without success"), // TODO: better error?
             Self::NegentropyReconciliationFailed => write!(f, "negentropy reconciliation failed"),
             Self::RelayNotFound => write!(f, "relay not found"),
             Self::Shutdown => write!(f, "relay pool is shutdown"),

--- a/crates/nostr-relay-pool/src/pool/mod.rs
+++ b/crates/nostr-relay-pool/src/pool/mod.rs
@@ -673,10 +673,6 @@ impl RelayPool {
             }
         }
 
-        if output.success.is_empty() {
-            return Err(Error::Failed);
-        }
-
         Ok(output)
     }
 
@@ -752,10 +748,6 @@ impl RelayPool {
                     output.failed.insert(url, e.to_string());
                 }
             }
-        }
-
-        if output.success.is_empty() {
-            return Err(Error::Failed);
         }
 
         Ok(output)
@@ -916,10 +908,6 @@ impl RelayPool {
                     output.failed.insert(url, e.to_string());
                 }
             }
-        }
-
-        if output.success.is_empty() {
-            return Err(Error::Failed);
         }
 
         Ok(output)


### PR DESCRIPTION
Instead of returning `Error::Failed`, return the `Output` to allow better analysis of the failure causes. Remove `Error::Failed` variant.

Closes https://github.com/rust-nostr/nostr/issues/822
