### PR TITLE
nostr: Add `NIP-C0` (Code Snippets) support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 
 ### Added
 
+* nostr: add NIP-C0 (Code Snippets) support ([awiteb])
 * nostr: add `TagKind::u` constructor ([Yuki Kishimoto])
 * nostr: derive `Copy` for `HttpMethod` ([Yuki Kishimoto])
 * nostr: add `nip98::verify_auth_header` ([Yuki Kishimoto])

--- a/crates/nostr-sdk/examples/code_snippet.rs
+++ b/crates/nostr-sdk/examples/code_snippet.rs
@@ -1,0 +1,43 @@
+// Copyright (c) 2022-2023 Yuki Kishimoto
+// Copyright (c) 2023-2025 Rust Nostr Developers
+// Distributed under the MIT software license
+
+use nostr_sdk::prelude::*;
+
+const EXAMPLE_SNIPPET: &str = include_str!("code_snippet.rs");
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+
+    let keys = Keys::generate();
+    let client = Client::new(keys);
+
+    client.add_relay("wss://relay.damus.io").await?;
+    client.add_relay("wss://nos.lol").await?;
+    client.add_relay("wss://nostr.mom").await?;
+
+    client.connect().await;
+
+    // Build a code snippet for this example :)
+    let snippet: CodeSnippet = CodeSnippet::new(EXAMPLE_SNIPPET)
+        .name("code_snippts.rs")
+        .description("Snippet that snippet itself")
+        .language("rust")
+        .extension("rs")
+        .license("MIT");
+
+    let builder = EventBuilder::code_snippet(snippet);
+
+    let event = client.send_event_builder(builder).await?;
+    let nevent = Nip19Event::new(*event.id()).relays(vec![
+        RelayUrl::parse("wss://nos.lol")?,
+        RelayUrl::parse("wss://nostr.mom")?,
+    ]);
+
+    tracing::info!("Done, check the event `{}`", nevent.to_bech32()?);
+
+    client.shutdown().await;
+
+    Ok(())
+}

--- a/crates/nostr/README.md
+++ b/crates/nostr/README.md
@@ -172,6 +172,7 @@ The following crate feature flags are available:
 |     ✅     | [96 - HTTP File Storage Integration](https://github.com/nostr-protocol/nips/blob/master/96.md)                  |
 |     ✅     | [98 - HTTP Auth](https://github.com/nostr-protocol/nips/blob/master/98.md)                                      |
 |     ❌     | [99 - Classified Listings](https://github.com/nostr-protocol/nips/blob/master/99.md)                            |
+|     ✅     | [C0 - Code Snippets](https://github.com/nostr-protocol/nips/blob/master/C0.md)                                  |
 
 ## State
 

--- a/crates/nostr/src/event/builder.rs
+++ b/crates/nostr/src/event/builder.rs
@@ -1722,6 +1722,14 @@ impl EventBuilder {
         Self::new(Kind::UserStatus, content).tags(tags)
     }
 
+    /// Code Snippets
+    ///
+    /// <https://github.com/nostr-protocol/nips/blob/master/C0.md>
+    #[inline]
+    pub fn code_snippet(snippet: CodeSnippet) -> Self {
+        snippet.to_event_builder()
+    }
+
     /// Git Repository Announcement
     ///
     /// <https://github.com/nostr-protocol/nips/blob/master/34.md>

--- a/crates/nostr/src/event/kind.rs
+++ b/crates/nostr/src/event/kind.rs
@@ -155,6 +155,7 @@ kind_variants! {
     CashuWallet => 17375, "Cashu Wallet", "<https://github.com/nostr-protocol/nips/blob/master/60.md>",
     CashuWalletUnspentProof => 7375, "Cashu Wallet Unspent Proof", "<https://github.com/nostr-protocol/nips/blob/master/60.md>",
     CashuWalletSpendingHistory => 7376, "Cashu Wallet Spending History", "<https://github.com/nostr-protocol/nips/blob/master/60.md>",
+    CodeSnippet => 1337, "Code Snippets", "<https://github.com/nostr-protocol/nips/blob/master/C0.md>"
 }
 
 impl PartialEq for Kind {

--- a/crates/nostr/src/event/tag/kind.rs
+++ b/crates/nostr/src/event/tag/kind.rs
@@ -47,6 +47,10 @@ pub enum TagKind<'a> {
     CurrentParticipants,
     /// Delegation
     Delegation,
+    /// Required dependency
+    ///
+    /// <https://github.com/nostr-protocol/nips/blob/master/C0.md>
+    Dependency,
     /// Description
     Description,
     /// Size of the file in pixels
@@ -61,10 +65,18 @@ pub enum TagKind<'a> {
     ///
     /// <https://github.com/nostr-protocol/nips/blob/master/40.md>
     Expiration,
+    /// File extension
+    ///
+    /// <https://github.com/nostr-protocol/nips/blob/master/C0.md>
+    Extension,
     /// File
     File,
     /// Image
     Image,
+    /// License of the shared content
+    ///
+    /// <https://github.com/nostr-protocol/nips/blob/master/C0.md>
+    License,
     /// Lnurl
     Lnurl,
     /// Magnet
@@ -103,8 +115,16 @@ pub enum TagKind<'a> {
     Relay,
     /// Relays
     Relays,
+    /// Reference to the origin repository
+    ///
+    /// <https://github.com/nostr-protocol/nips/blob/master/C0.md>
+    Repository,
     /// Request
     Request,
+    /// Runtime or environment specification
+    ///
+    /// <https://github.com/nostr-protocol/nips/blob/master/C0.md>
+    Runtime,
     /// Size of the file in bytes
     Size,
     /// Starts
@@ -282,14 +302,17 @@ impl<'a> TagKind<'a> {
             Self::ContentWarning => "content-warning",
             Self::CurrentParticipants => "current_participants",
             Self::Delegation => "delegation",
+            Self::Dependency => "dep",
             Self::Description => "description",
             Self::Dim => "dim",
             Self::Emoji => "emoji",
             Self::Encrypted => "encrypted",
             Self::Ends => "ends",
             Self::Expiration => "expiration",
+            Self::Extension => "extension",
             Self::File => "file",
             Self::Image => "image",
+            Self::License => "license",
             Self::Lnurl => "lnurl",
             Self::Magnet => "magnet",
             Self::Maintainers => "maintainers",
@@ -307,7 +330,9 @@ impl<'a> TagKind<'a> {
             Self::Recording => "recording",
             Self::Relay => "relay",
             Self::Relays => "relays",
+            Self::Repository => "repo",
             Self::Request => "request",
+            Self::Runtime => "runtime",
             Self::Size => "size",
             Self::Starts => "starts",
             Self::Status => "status",
@@ -350,14 +375,17 @@ impl<'a> From<&'a str> for TagKind<'a> {
             "content-warning" => Self::ContentWarning,
             "current_participants" => Self::CurrentParticipants,
             "delegation" => Self::Delegation,
+            "dep" => Self::Dependency,
             "description" => Self::Description,
             "dim" => Self::Dim,
             "emoji" => Self::Emoji,
             "encrypted" => Self::Encrypted,
             "ends" => Self::Ends,
             "expiration" => Self::Expiration,
+            "extension" => Self::Extension,
             "file" => Self::File,
             "image" => Self::Image,
+            "license" => Self::License,
             "lnurl" => Self::Lnurl,
             "magnet" => Self::Magnet,
             "maintainers" => Self::Maintainers,
@@ -374,7 +402,9 @@ impl<'a> From<&'a str> for TagKind<'a> {
             "recording" => Self::Recording,
             "relay" => Self::Relay,
             "relays" => Self::Relays,
+            "repo" => Self::Repository,
             "request" => Self::Request,
+            "runtime" => Self::Runtime,
             "size" => Self::Size,
             "starts" => Self::Starts,
             "status" => Self::Status,
@@ -437,14 +467,29 @@ mod tests {
         assert_eq!(TagKind::from("clone"), TagKind::Clone);
         assert_eq!(TagKind::Clone.as_str(), "clone");
 
+        assert_eq!(TagKind::from("dep"), TagKind::Dependency);
+        assert_eq!(TagKind::Dependency.as_str(), "dep");
+
         assert_eq!(TagKind::from("expiration"), TagKind::Expiration);
         assert_eq!(TagKind::Expiration.as_str(), "expiration");
+
+        assert_eq!(TagKind::from("extension"), TagKind::Extension);
+        assert_eq!(TagKind::Extension.as_str(), "extension");
 
         assert_eq!(TagKind::from("file"), TagKind::File);
         assert_eq!(TagKind::File.as_str(), "file");
 
+        assert_eq!(TagKind::from("license"), TagKind::License);
+        assert_eq!(TagKind::License.as_str(), "license");
+
         assert_eq!(TagKind::from("maintainers"), TagKind::Maintainers);
         assert_eq!(TagKind::Maintainers.as_str(), "maintainers");
+
+        assert_eq!(TagKind::from("repo"), TagKind::Repository);
+        assert_eq!(TagKind::Repository.as_str(), "repo");
+
+        assert_eq!(TagKind::from("runtime"), TagKind::Runtime);
+        assert_eq!(TagKind::Runtime.as_str(), "runtime");
 
         assert_eq!(TagKind::from("tracker"), TagKind::Tracker);
         assert_eq!(TagKind::Tracker.as_str(), "tracker");

--- a/crates/nostr/src/event/tag/standard.rs
+++ b/crates/nostr/src/event/tag/standard.rs
@@ -231,6 +231,26 @@ pub enum TagStandard {
     ///
     /// <https://github.com/nostr-protocol/nips/blob/master/32.md>
     Label(Vec<String>),
+    /// Required dependency
+    ///
+    /// <https://github.com/nostr-protocol/nips/blob/master/C0.md>
+    Dependency(String),
+    /// File extension
+    ///
+    /// <https://github.com/nostr-protocol/nips/blob/master/C0.md>
+    Extension(String),
+    /// License of the shared content
+    ///
+    /// <https://github.com/nostr-protocol/nips/blob/master/C0.md>
+    License(String),
+    /// Runtime or environment specification
+    ///
+    /// <https://github.com/nostr-protocol/nips/blob/master/C0.md>
+    Runtime(String),
+    /// Reference to the origin repository
+    ///
+    /// <https://github.com/nostr-protocol/nips/blob/master/C0.md>
+    Repository(String),
     /// Protected event
     ///
     /// <https://github.com/nostr-protocol/nips/blob/master/70.md>
@@ -383,6 +403,7 @@ impl TagStandard {
                     character: Alphabet::U,
                     uppercase: false,
                 }) => Ok(Self::AbsoluteURL(Url::parse(tag_1)?)),
+                TagKind::Dependency => Ok(Self::Dependency(tag_1.to_string())),
                 TagKind::Relay => {
                     if tag_1 == ALL_RELAYS {
                         Ok(Self::AllRelays)
@@ -391,6 +412,10 @@ impl TagStandard {
                     }
                 }
                 TagKind::Expiration => Ok(Self::Expiration(Timestamp::from_str(tag_1)?)),
+                TagKind::Extension => Ok(Self::Extension(tag_1.to_string())),
+                TagKind::License => Ok(Self::License(tag_1.to_string())),
+                TagKind::Runtime => Ok(Self::Runtime(tag_1.to_string())),
+                TagKind::Repository => Ok(Self::Repository(tag_1.to_string())),
                 TagKind::Subject => Ok(Self::Subject(tag_1.to_string())),
                 TagKind::Challenge => Ok(Self::Challenge(tag_1.to_string())),
                 TagKind::Commit => Ok(Self::GitCommit(Sha1Hash::from_str(tag_1)?)),
@@ -602,6 +627,11 @@ impl TagStandard {
             Self::Relays(..) => TagKind::Relays,
             Self::Amount { .. } => TagKind::Amount,
             Self::Name(..) => TagKind::Name,
+            Self::Dependency(..) => TagKind::Dependency,
+            Self::Extension(..) => TagKind::Extension,
+            Self::License(..) => TagKind::License,
+            Self::Runtime(..) => TagKind::Runtime,
+            Self::Repository(..) => TagKind::Repository,
             Self::Lnurl(..) => TagKind::Lnurl,
             Self::Url(..) => TagKind::Url,
             Self::MimeType(..) => TagKind::SingleLetter(SingleLetterTag {
@@ -887,12 +917,13 @@ impl From<TagStandard> for Vec<String> {
                 }
                 tag
             }
-            TagStandard::Name(name) => {
-                vec![tag_kind, name]
-            }
-            TagStandard::Lnurl(lnurl) => {
-                vec![tag_kind, lnurl]
-            }
+            TagStandard::Name(name) => vec![tag_kind, name],
+            TagStandard::Dependency(dep) => vec![tag_kind, dep],
+            TagStandard::Extension(ext) => vec![tag_kind, ext],
+            TagStandard::License(license) => vec![tag_kind, license],
+            TagStandard::Runtime(runtime) => vec![tag_kind, runtime],
+            TagStandard::Repository(repo) => vec![tag_kind, repo],
+            TagStandard::Lnurl(lnurl) => vec![tag_kind, lnurl],
             TagStandard::Url(url) => vec![tag_kind, url.to_string()],
             TagStandard::MimeType(mime) => vec![tag_kind, mime],
             TagStandard::Aes256Gcm { key, iv } => vec![tag_kind, key, iv],
@@ -1640,6 +1671,31 @@ mod tests {
         );
 
         assert_eq!(
+            vec!["dep", "nostr"],
+            TagStandard::Dependency(String::from("nostr")).to_vec()
+        );
+
+        assert_eq!(
+            vec!["extension", "rs"],
+            TagStandard::Extension(String::from("rs")).to_vec()
+        );
+
+        assert_eq!(
+            vec!["license", "MIT"],
+            TagStandard::License(String::from("MIT")).to_vec()
+        );
+
+        assert_eq!(
+            vec!["runtime", "rustc 1.70.0"],
+            TagStandard::Runtime(String::from("rustc 1.70.0")).to_vec()
+        );
+
+        assert_eq!(
+            vec!["repo", "https://github.com/rust-nostr/nostr"],
+            TagStandard::Repository(String::from("https://github.com/rust-nostr/nostr")).to_vec()
+        );
+
+        assert_eq!(
             vec!["client", "voyage", "30023:a695f6b60119d9521934a691347d9f78e8770b56da16bb255ee286ddf9fda919:ipsum"],
             TagStandard::Client {
                 name: String::from("voyage"),
@@ -2264,6 +2320,31 @@ mod tests {
                 name: String::from("voyage"),
                 address: None
             }
+        );
+
+        assert_eq!(
+            TagStandard::parse(&["dep", "nostr"]).unwrap(),
+            TagStandard::Dependency(String::from("nostr"))
+        );
+
+        assert_eq!(
+            TagStandard::parse(&["extension", "rs"]).unwrap(),
+            TagStandard::Extension(String::from("rs"))
+        );
+
+        assert_eq!(
+            TagStandard::parse(&["license", "MIT"]).unwrap(),
+            TagStandard::License(String::from("MIT"))
+        );
+
+        assert_eq!(
+            TagStandard::parse(&["runtime", "rustc 1.70.0"]).unwrap(),
+            TagStandard::Runtime(String::from("rustc 1.70.0"))
+        );
+
+        assert_eq!(
+            TagStandard::parse(&["repo", "https://github.com/rust-nostr/nostr"]).unwrap(),
+            TagStandard::Repository(String::from("https://github.com/rust-nostr/nostr"))
         );
 
         assert_eq!(

--- a/crates/nostr/src/nips/mod.rs
+++ b/crates/nostr/src/nips/mod.rs
@@ -58,3 +58,4 @@ pub mod nip94;
 pub mod nip96;
 #[cfg(feature = "nip98")]
 pub mod nip98;
+pub mod nipc0;

--- a/crates/nostr/src/nips/nipc0.rs
+++ b/crates/nostr/src/nips/nipc0.rs
@@ -1,0 +1,164 @@
+// Copyright (c) 2022-2023 Yuki Kishimoto
+// Copyright (c) 2023-2025 Rust Nostr Developers
+// Distributed under the MIT software license
+
+//! NIPC0: Code Snippets
+//!
+//! <https://github.com/nostr-protocol/nips/blob/master/C0.md>
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use crate::{EventBuilder, Kind, Tag, TagStandard};
+
+/// Code snippet
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct CodeSnippet {
+    /// The code snippet.
+    pub snippet: String,
+    /// Programming language name.
+    /// Examples: "javascript", "python", "rust"
+    pub language: Option<String>,
+    /// Name of the code snippet, commonly a filename.
+    /// Examples: "hello-world.js", "quick-sort.py"
+    pub name: Option<String>,
+    /// File extension (without the dot).
+    /// Examples: "js", "py", "rs"
+    pub extension: Option<String>,
+    /// Brief description of what the code does
+    pub description: Option<String>,
+    /// Runtime or environment specification.
+    /// Example: "node v18.15.0", "python 3.11"
+    pub runtime: Option<String>,
+    /// License under which the code is shared.
+    /// Example: "MIT", "GPL-3.0", "Apache-2.0"
+    pub license: Option<String>,
+    /// Dependencies required for the code to run.
+    pub dependencies: Vec<String>,
+    /// Reference to a repository where this code originates.
+    pub repo: Option<String>,
+}
+
+impl CodeSnippet {
+    /// Create a new code snippet
+    #[inline]
+    pub fn new<T>(snippet: T) -> Self
+    where
+        T: Into<String>,
+    {
+        Self {
+            snippet: snippet.into(),
+            ..Default::default()
+        }
+    }
+
+    /// Set the programming language name (e.g. "javascript", "python", "rust").
+    #[inline]
+    pub fn language<T>(mut self, lang: T) -> Self
+    where
+        T: AsRef<str>,
+    {
+        self.language = Some(lang.as_ref().to_lowercase());
+        self
+    }
+
+    /// Set the name of the code snippet, commonly a filename.
+    #[inline]
+    pub fn name<T>(mut self, name: T) -> Self
+    where
+        T: Into<String>,
+    {
+        self.name = Some(name.into());
+        self
+    }
+
+    /// Set the file extension (without the dot).
+    #[inline]
+    pub fn extension<T>(mut self, extension: T) -> Self
+    where
+        T: Into<String>,
+    {
+        self.extension = Some(extension.into());
+        self
+    }
+
+    /// Set a brief description of what the code does
+    #[inline]
+    pub fn description<T>(mut self, description: T) -> Self
+    where
+        T: Into<String>,
+    {
+        self.description = Some(description.into());
+        self
+    }
+
+    /// Set the runtime or environment specification (e.g. "node v18.15.0", "python 3.11").
+    #[inline]
+    pub fn runtime<T>(mut self, runtime: T) -> Self
+    where
+        T: Into<String>,
+    {
+        self.runtime = Some(runtime.into());
+        self
+    }
+
+    /// Set the license under which the code is shared (e.g. "MIT", "GPL-3.0", "Apache-2.0").
+    #[inline]
+    pub fn license<T>(mut self, license: T) -> Self
+    where
+        T: Into<String>,
+    {
+        self.license = Some(license.into());
+        self
+    }
+
+    /// Add a dependency required for the code to run.
+    pub fn dependencies<T>(mut self, dep: T) -> Self
+    where
+        T: Into<String>,
+    {
+        let dep = dep.into();
+        if !self.dependencies.contains(&dep) {
+            self.dependencies.push(dep);
+        }
+        self
+    }
+
+    /// Set the repository where this code originates.
+    #[inline]
+    pub fn repo<T>(mut self, repo: T) -> Self
+    where
+        T: Into<String>,
+    {
+        self.repo = Some(repo.into());
+        self
+    }
+
+    /// Convert the code snippet to an event builder
+    #[allow(clippy::wrong_self_convention)]
+    pub(crate) fn to_event_builder(self) -> EventBuilder {
+        let mut tags: Vec<Tag> = Vec::new();
+
+        let mut add_if_some = |tag: Option<TagStandard>| {
+            if let Some(tag) = tag {
+                tags.push(Tag::from_standardized_without_cell(tag));
+            }
+        };
+
+        // `l` tag used for label in all event kinds except Code Snippets (1337)
+        // is used as the programming language
+        add_if_some(self.language.map(|l| TagStandard::Label(vec![l])));
+        add_if_some(self.name.map(TagStandard::Name));
+        add_if_some(self.extension.map(TagStandard::Extension));
+        add_if_some(self.description.map(TagStandard::Description));
+        add_if_some(self.runtime.map(TagStandard::Runtime));
+        add_if_some(self.license.map(TagStandard::License));
+        add_if_some(self.repo.map(TagStandard::Repository));
+
+        for dep in self.dependencies.into_iter() {
+            tags.push(TagStandard::Dependency(dep).into());
+        }
+
+        EventBuilder::new(Kind::CodeSnippet, self.snippet).tags(tags)
+    }
+}

--- a/crates/nostr/src/prelude.rs
+++ b/crates/nostr/src/prelude.rs
@@ -78,6 +78,7 @@ pub use crate::nips::nip94::{self, *};
 pub use crate::nips::nip96::{self, *};
 #[cfg(feature = "nip98")]
 pub use crate::nips::nip98::{self, *};
+pub use crate::nips::nipc0::{self, *};
 #[cfg(feature = "parser")]
 pub use crate::parser::{self, *};
 pub use crate::signer::{self, *};


### PR DESCRIPTION
### Description

[NIP-C0](https://github.com/nostr-protocol/nips/blob/master/C0.md) support. Closes #821 

#### Added:
- `EventBuilder::code_snippet`
- New tag kinds
  - dependency (`dep`)
  - extension (`extension`)
  - license (`license`)
  - runtime (`runtime`)
  - repository (`repo`)
- New struct `CodeSnippet` a builder struct.
- Example to make a snippet of itself. (Output [notebin.io/nevent1...](https://notebin.io/nevent1qvzqqqq98ypzq8y25sn49pp5vklwrkh7endxsdxs6pwr25pwxtyezrzpkc06lxfyqy28wumn8ghj7un9d3shjtnyv9kh2uewd9hsqgyzdkp6cuvjdfywgmg072xgm4deunc3wvnj2qujxvw36zywwp0fvvte7tzn))

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

None

### Checklist

* [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [X] I ran `just precommit` or `just check` before committing
* [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
