### PR TITLE
pool: add connection admission policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * nostr: add optional relay URL arg to `Tag::coordinate` ([Yuki Kishimoto])
 * pool: remove `Error::Failed` variant ([Yuki Kishimoto])
 * pool: returns `Output` instead of an error if the message/event sending fails for all relays ([Yuki Kishimoto])
+* pool: add `reason` field to `AdmitStatus::Rejected` variant ([Yuki Kishimoto])
 
 ### Changed
 
@@ -49,6 +50,7 @@
 * nostr: add `push`, `pop`, `insert` and `extend` methods to the `Tag` struct ([Yuki Kishimoto])
 * nostr: add `nip47::Notification` ([daywalker90])
 * pool: add `Relay::ban` method ([Yuki Kishimoto])
+* pool: add `AdmitPolicy::admit_connection` method ([Yuki Kishimoto])
 
 ### Fixed
 

--- a/crates/nostr-relay-pool/src/relay/error.rs
+++ b/crates/nostr-relay-pool/src/relay/error.rs
@@ -61,6 +61,11 @@ pub enum Error {
     NotConnected,
     /// Relay banned
     Banned,
+    /// Connection rejected
+    ConnectionRejected {
+        /// Reason
+        reason: Option<String>,
+    },
     /// Received termination request
     TerminationRequest,
     /// Received shutdown
@@ -143,6 +148,10 @@ impl fmt::Display for Error {
             Self::NotReady => write!(f, "relay is initialized but not ready"),
             Self::NotConnected => write!(f, "relay not connected"),
             Self::Banned => write!(f, "relay banned"),
+            Self::ConnectionRejected { reason } => {
+                let reason: &str = reason.as_deref().unwrap_or("unknown");
+                write!(f, "connection rejected: reason={reason}")
+            }
             Self::TerminationRequest => write!(f, "received termination request"),
             Self::ReceivedShutdown => write!(f, "received shutdown"),
             Self::RelayMessage(message) => write!(f, "{message}"),

--- a/crates/nostr-sdk/examples/blacklist.rs
+++ b/crates/nostr-sdk/examples/blacklist.rs
@@ -21,10 +21,10 @@ impl AdmitPolicy for Filtering {
     ) -> BoxedFuture<'a, Result<AdmitStatus, PolicyError>> {
         Box::pin(async move {
             if self.muted_public_keys.contains(&event.pubkey) {
-                return Ok(AdmitStatus::Rejected);
+                return Ok(AdmitStatus::rejected("Muted"));
             }
 
-            Ok(AdmitStatus::Success)
+            Ok(AdmitStatus::success())
         })
     }
 }

--- a/crates/nostr-sdk/examples/whitelist.rs
+++ b/crates/nostr-sdk/examples/whitelist.rs
@@ -21,10 +21,10 @@ impl AdmitPolicy for WoT {
     ) -> BoxedFuture<'a, Result<AdmitStatus, PolicyError>> {
         Box::pin(async move {
             if self.allowed_public_keys.contains(&event.pubkey) {
-                return Ok(AdmitStatus::Success);
+                return Ok(AdmitStatus::success());
             }
 
-            Ok(AdmitStatus::Rejected)
+            Ok(AdmitStatus::rejected("Not in whitelist"))
         })
     }
 }


### PR DESCRIPTION
Implemented connection-level admission policies allowing fine-grained control over which relays can connect.
