### PR TITLE
Add nostr-mls-storage crate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ many-events.json.zst
 .idea/
 .vscode/
 env/
+.repomix-*.txt
+vibe-tools.config.json
+.cursor/rules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@
 
 -->
 
+## Unreleased
+
+### Added
+
+* mls-storage: add new crate with traits and types for mls storage implementations ([JeffG])
+
 ## v0.41.0 - 2025/04/15
 
 ### Breaking changes
@@ -73,8 +79,8 @@
 
 ### Summary
 
-Add NIP-38 and NIP-62 support, add nostr parser, to easily parse any text and extract nostr URIs, URLs and more, 
-extend `Tags` capabilities (i.e., add deduplication support), add admission policies, to selectively select which events to allow receiving and which to reject, 
+Add NIP-38 and NIP-62 support, add nostr parser, to easily parse any text and extract nostr URIs, URLs and more,
+extend `Tags` capabilities (i.e., add deduplication support), add admission policies, to selectively select which events to allow receiving and which to reject,
 add Mac Catalyst support for Swift package, many cleanups, refactoring and performance improvements and more!
 
 ### Breaking changes
@@ -99,7 +105,7 @@ add Mac Catalyst support for Swift package, many cleanups, refactoring and perfo
 * pool: remove `Relay` constructors ([Yuki Kishimoto])
 * pool: change `RelayPool::new` signature ([Yuki Kishimoto])
 * pool: now can set the notification channel size of a single `Relay` using `RelayOptions` ([magine])
-* sdk: change `Client::fetch_metadata` output ([Yuki Kishimoto]) 
+* sdk: change `Client::fetch_metadata` output ([Yuki Kishimoto])
 * sdk: remove `Client::state` ([Yuki Kishimoto])
 
 ### Changed
@@ -183,7 +189,7 @@ add Mac Catalyst support for Swift package, many cleanups, refactoring and perfo
 ### Summary
 
 Add NIP96 support, add NIP22 helpers, NIP01 adjustments, add `try_connect` and `wait_for_connection` methods for better connection handling,
-support for custom WebSocket clients (both in Rust, Python, Kotlin and Swift), new JVM bindings, 
+support for custom WebSocket clients (both in Rust, Python, Kotlin and Swift), new JVM bindings,
 huge reduction of UniFFI bindings binaries size, many cleanups, refactoring and performance improvements and more!
 
 ### Breaking changes
@@ -345,7 +351,7 @@ NIP35 support, better logs and docs, performance improvements, bugs fix and more
 * nostr: include public key of root and parent author in `EventBuilder::comment` ([Yuki Kishimoto])
 * nostr: dedup tags in `EventBuilder::text_note_reply` and `EventBuilder::comment` ([Yuki Kishimoto])
 * nostr: don't use reply event as root `e` tag i no root is set in `EventBuilder::text_note_reply` ([Yuki Kishimoto])
-* database: add manual trait implementations for `BTreeCappedSet` ([Yuki Kishimoto]) 
+* database: add manual trait implementations for `BTreeCappedSet` ([Yuki Kishimoto])
 * database: replace LRU with custom memory cache for IDs tracking ([Yuki Kishimoto])
 * lmdb: use `async-utility` to spawn blocking tasks ([Yuki Kishimoto])
 * ndb: bump `nostr-ndb` to 0.5 ([Yuki Kishimoto])
@@ -362,7 +368,7 @@ NIP35 support, better logs and docs, performance improvements, bugs fix and more
 * sdk: refactor POW difficulty management ([Yuki Kishimoto])
 * connect: require `fmt::Debug`, `Send` and `Sync` for `AuthUrlHandler` ([Yuki Kishimoto])
 * connect: improve secret matching for `NostrConnectRemoteSigner` ([Yuki Kishimoto])
-* connect: support both NIP04 and NIP44 for message decryption ([erskingardner])
+* connect: support both NIP04 and NIP44 for message decryption ([JeffG])
 * zapper: bump `webln` to 0.4 ([Yuki Kishimoto])
 * zapper: require `fmt::Debug`, `Send` and `Sync` for `NostrZapper` ([Yuki Kishimoto])
 * bindings: refactor `SendEventOutput` and `SubscribeOutput` ([Yuki Kishimoto])
@@ -371,7 +377,7 @@ NIP35 support, better logs and docs, performance improvements, bugs fix and more
 
 * nostr: add `Tags::challenge` method ([Yuki Kishimoto])
 * nostr: add `RelayUrl::is_local_addr` ([Yuki Kishimoto])
-* nostr: add `TagKind::k` constructor ([Yuki Kishimoto]) 
+* nostr: add `TagKind::k` constructor ([Yuki Kishimoto])
 * nostr: impl `IntoIterator` for `Tag` ([Yuki Kishimoto])
 * nostr: add NIP35 support ([1wErt3r])
 * nostr: add `Kind::is_addressable` and `ADDRESSABLE_RANGE` ([Yuki Kishimoto])
@@ -425,7 +431,7 @@ NIP35 support, better logs and docs, performance improvements, bugs fix and more
 
 ### Summary
 
-Add support to NIP17 relay list in SDK (when `gossip` option is enabled), add NIP22 and NIP73 support, 
+Add support to NIP17 relay list in SDK (when `gossip` option is enabled), add NIP22 and NIP73 support,
 fix Swift Package, many performance improvements and bug fixes and more!
 
 From this release all the rust features are disabled by default (except `std` feature in `nostr` crate).
@@ -433,7 +439,7 @@ From this release all the rust features are disabled by default (except `std` fe
 ### Breaking changes
 
 * Use `RelayUrl` struct instead of `Url` for relay urls ([Yuki Kishimoto])
-* nostr: change `EventBuilder::gift_wrap` (and linked methods) args to take `extra_tags` instead of `expiration` ([erskingardner])
+* nostr: change `EventBuilder::gift_wrap` (and linked methods) args to take `extra_tags` instead of `expiration` ([JeffG])
 * nostr: change `EventBuilder::gift_wrap` (and linked methods) args to take an `EventBuilder` rumor instead of `UnsignedEvent` ([Yuki Kishimoto])
 * nostr: change `EventBuilder::private_msg_rumor` arg to take `extra_tags` instead of `reply_to` ([Yuki Kishimoto])
 * nostr: remove `tags` arg from `EventBuilder::new` ([Yuki Kishimoto])
@@ -467,7 +473,7 @@ From this release all the rust features are disabled by default (except `std` fe
 * pool: update retry interval calculation ([Yuki Kishimoto])
 * pool: try fetch relay information document only once every hour ([Yuki Kishimoto])
 * pool: not allow to add relays after `RelayPool` shutdown ([Yuki Kishimoto])
-* pool: rename `RelayOptions::retry_sec` to `RelayOptions::retry_interval` ([Yuki Kishimoto]) 
+* pool: rename `RelayOptions::retry_sec` to `RelayOptions::retry_interval` ([Yuki Kishimoto])
 * pool: rename `RelayOptions::adjust_retry_sec` to `RelayOptions::adjust_retry_interval` ([Yuki Kishimoto])
 * pool: request NIP11 document only after a successful WebSocket connection ([Yuki Kishimoto])
 * pool: immediately terminate relay connection on `Relay::disconnect` call ([Yuki Kishimoto])
@@ -485,7 +491,7 @@ From this release all the rust features are disabled by default (except `std` fe
 
 ### Added
 
-* nostr: add NIP104 tag and event kinds ([erskingardner])
+* nostr: add NIP104 tag and event kinds ([JeffG])
 * nostr: add `SingleLetterTag::as_str` and `TagKind::as_str` ([Yuki Kishimoto])
 * nostr: add `Kind::Comment` ([reyamir])
 * nostr: add `EventBuilder::comment` ([reyamir])
@@ -674,7 +680,7 @@ Note for devs who are using `nostr-protocol` (Python), `org.rust-nostr:nostr` (K
 
 ### Summary
 
-Add gossip model support, deprecate `SQLite` database in favor of `LMDB` 
+Add gossip model support, deprecate `SQLite` database in favor of `LMDB`
 (fork of [pocket](https://github.com/mikedilger/pocket) database),
 add support to negentropy v1 (old version is still supported!), add `MockRelay` (a local disposable relay for tests),
 allow usage of embedded tor client on mobile devices, many improvements, bugs fix and more!
@@ -811,7 +817,7 @@ allow usage of embedded tor client on mobile devices, many improvements, bugs fi
 Add embedded tor client support, allow to open databases with a limited capacity (automatically discard old events when max capacity is reached),
 add `Client::stream_events_of` as alternative method to `Client::get_events_of` (stream events instead of waiting for `EOSE` and collect into a list),
 add search capability (NIP50) support to `Filter::match_event` and databases, add NIP31 and NIP70 support,
-add option to autoconnect relay on `Client::add_relay` method call (currently disabled by default), rework the `get_events_of` methods behaviour for 
+add option to autoconnect relay on `Client::add_relay` method call (currently disabled by default), rework the `get_events_of` methods behaviour for
 better consistency (`RelayPool::get_events_of` and `Relay::get_events_of` get events only from remote relay/s while
 `Client::get_events_of` allow to choose the source of events: `database`, `relays` or `both`), bugs fix and more!
 
@@ -895,7 +901,7 @@ better consistency (`RelayPool::get_events_of` and `Relay::get_events_of` get ev
 
 Better outputs for send/batch/reconcile methods (ex. you can now easily know where a message/event is successfully published and where/why failed),
 allow to change NIP42 option after client initialization, increase max stack size for JS bindings to prevent "memory access out of bounds" error,
-expose more objects/methods for JS bindings, dry run option for negentropy reconciliation, get NIP46 relay from NIP05 profile, 
+expose more objects/methods for JS bindings, dry run option for negentropy reconciliation, get NIP46 relay from NIP05 profile,
 bug fixes (NIP-42 auth not works correctly, NIP-46 "ACK" message not handled, ...) and more!
 
 ### Changed
@@ -1214,7 +1220,7 @@ added `nostrdb` storage backend, added NIP32 and completed NIP51 support and mor
 [w3irdrobot]: <https://github.com/w3irdrobot> (nostr:npub17q5n2z8naw0xl6vu9lvt560lg33pdpe29k0k09umlfxm3vc4tqrq466f2y)
 [nanikamado]: <https://github.com/nanikamado> (?)
 [rodant]: <https://github.com/rodant> (nostr:npub1w80jzxf36fhwgyfp622m6s7tcl3cy5z7xva4cy75q9kwm92zm8tsclzqjv)
-[erskingardner]: <https://github.com/erskingardner> (nostr:npub1zuuajd7u3sx8xu92yav9jwxpr839cs0kc3q6t56vd5u9q033xmhsk6c2uc)
+[JeffG]: <https://github.com/erskingardner> (nostr:npub1zuuajd7u3sx8xu92yav9jwxpr839cs0kc3q6t56vd5u9q033xmhsk6c2uc)
 [J. Azad EMERY]: <https://github.com/ethicnology> (?)
 [v0l]: <https://github.com/v0l> (nostr:npub1v0lxxxxutpvrelsksy8cdhgfux9l6a42hsj2qzquu2zk7vc9qnkszrqj49)
 [arkanoider]: <https://github.com/arkanoider> (nostr:npub1qqpn4ym6tc5ul6d2kjxnzx3sv9trekp53678ut9fe3wrxa6yvhjsnql2ng)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2779,6 +2779,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nostr-mls-storage"
+version = "0.41.0"
+dependencies = [
+ "nostr",
+ "openmls_traits",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "nostr-ndb"
 version = "0.41.0"
 dependencies = [
@@ -3058,6 +3068,16 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "openmls_traits"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "443afa05406adc75fbfa0c3e04db93c5647b763861a474ae1aa8a99c362b80f8"
+dependencies = [
+ "serde",
+ "tls_codec",
+]
 
 [[package]]
 name = "opentimestamps"
@@ -4549,6 +4569,28 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tls_codec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
+dependencies = [
+ "serde",
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
 
 [[package]]
 name = "tokio"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,12 @@ nostr-connect = { version = "0.41", path = "./crates/nostr-connect", default-fea
 nostr-database = { version = "0.41", path = "./crates/nostr-database", default-features = false }
 nostr-indexeddb = { version = "0.41", path = "./crates/nostr-indexeddb", default-features = false }
 nostr-lmdb = { version = "0.41", path = "./crates/nostr-lmdb", default-features = false }
+nostr-mls-storage = { version = "0.41", path = "./crates/nostr-mls-storage", default-features = false }
 nostr-ndb = { version = "0.41", path = "./crates/nostr-ndb", default-features = false }
 nostr-relay-builder = { version = "0.41", path = "./crates/nostr-relay-builder", default-features = false }
 nostr-relay-pool = { version = "0.41", path = "./crates/nostr-relay-pool", default-features = false }
 nostr-sdk = { version = "0.41", path = "./crates/nostr-sdk", default-features = false }
+serde = { version = "1.0", default-features = false }
 serde_json = { version = "1.0", default-features = false }
 tokio = { version = ">=1.37", default-features = false }
 tracing = { version = "0.1", default-features = false }

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The project is split up into several crates in the `crates/` directory:
         * [**nostr-lmdb**](./crates/nostr-lmdb): LMDB storage backend
         * [**nostr-ndb**](./crates/nostr-ndb): [nostrdb](https://github.com/damus-io/nostrdb) storage backend
         * [**nostr-indexeddb**](./crates/nostr-indexeddb): IndexedDB storage backend
+    * [**nostr-mls-storage**](./crates/nostr-mls-storage): Storage traits for using MLS messaging
     * [**nostr-keyring**](./crates/nostr-keyring): Nostr Keyring
     * [**nostr-relay-pool**](./crates/nostr-relay-pool): Nostr Relay Pool
     * [**nostr-sdk**](./crates/nostr-sdk): High level client library
@@ -20,7 +21,7 @@ The project is split up into several crates in the `crates/` directory:
 
 ### Embedded
 
-**nostr** crate can be used in [`no_std`](https://docs.rust-embedded.org/book/intro/no-std.html) environments. 
+**nostr** crate can be used in [`no_std`](https://docs.rust-embedded.org/book/intro/no-std.html) environments.
 Check the example in the [`embedded/`](./crates/nostr/examples/embedded) directory.
 
 ## Book

--- a/contrib/scripts/check-crates.sh
+++ b/contrib/scripts/check-crates.sh
@@ -41,6 +41,7 @@ buildargs=(
     "-p nostr --all-features"                                     # All features
     "-p nostr-database"
     "-p nostr-lmdb"
+    "-p nostr-mls-storage"
     "-p nostr-indexeddb --target wasm32-unknown-unknown"
     "-p nostr-ndb"
     "-p nostr-keyring"
@@ -58,6 +59,7 @@ buildargs=(
 
 skip_msrv=(
     "-p nostr-lmdb"                       # MSRV: 1.72.0
+    "-p nostr-mls-storage"                # MSRV: 1.74.0
     "-p nostr-keyring"                    # MSRV: 1.75.0
     "-p nostr-keyring --features async"   # MSRV: 1.75.0
     "-p nostr-sdk --features tor"         # MSRV: 1.77.0

--- a/contrib/scripts/release.sh
+++ b/contrib/scripts/release.sh
@@ -6,6 +6,7 @@ args=(
     "-p nostr"
     "-p nostr-database"
     "-p nostr-lmdb"
+    "-p nostr-mls-storage"
     "-p nostr-ndb"
     "-p nostr-indexeddb"
     "-p nostr-keyring"

--- a/crates/nostr-mls-storage/Cargo.toml
+++ b/crates/nostr-mls-storage/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "nostr-mls-storage"
+version = "0.41.0"
+edition = "2021"
+description = "Storage abstraction for nostr-mls that wraps OpenMLS storage backends"
+authors = ["Jeff Gardner <j@jeffg.me>", "Yuki Kishimoto <yukikishimoto@protonmail.com>", "Rust Nostr Developers"]
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+readme = "README.md"
+rust-version = "1.74.0"
+keywords = ["nostr", "mls", "openmls"]
+
+[dependencies]
+nostr = { workspace = true, features = ["std"] }
+openmls_traits = { version = "0.3", default-features = false }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true, features = ["std"] }

--- a/crates/nostr-mls-storage/README.md
+++ b/crates/nostr-mls-storage/README.md
@@ -1,0 +1,19 @@
+# Nostr MLS Storage
+
+This crate provides an abstraction for the storage layer that MLS requires.
+
+## NostrMlsStorageProvider trait
+
+THis library contains the `NostrMlsStorageProvider` trait.
+
+## State
+
+**This library is in an ALPHA state**, things that are implemented generally work but the API will change in breaking ways.
+
+## Donations
+
+`rust-nostr` is free and open-source. This means we do not earn any revenue by selling it. Instead, we rely on your financial support. If you actively use any of the `rust-nostr` libs/software/services, then please [donate](https://rust-nostr.org/donate).
+
+## License
+
+This project is distributed under the MIT software license - see the [LICENSE](../../LICENSE) file for details

--- a/crates/nostr-mls-storage/src/groups/error.rs
+++ b/crates/nostr-mls-storage/src/groups/error.rs
@@ -1,0 +1,26 @@
+//! Error types for the groups module
+
+use std::fmt;
+
+/// Error types for the groups module
+#[derive(Debug)]
+pub enum GroupError {
+    /// Invalid parameters
+    InvalidParameters(String),
+    /// Database error
+    DatabaseError(String),
+    /// Group not found
+    NotFound,
+}
+
+impl std::error::Error for GroupError {}
+
+impl fmt::Display for GroupError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidParameters(message) => write!(f, "Invalid parameters: {}", message),
+            Self::DatabaseError(message) => write!(f, "Database error: {}", message),
+            Self::NotFound => write!(f, "Group not found"),
+        }
+    }
+}

--- a/crates/nostr-mls-storage/src/groups/mod.rs
+++ b/crates/nostr-mls-storage/src/groups/mod.rs
@@ -1,0 +1,44 @@
+//! Groups module
+//!
+//! This module is responsible for storing and retrieving groups
+//! It also handles the parsing of group content
+//!
+//! The groups are stored in the database and can be retrieved by MLS group ID or Nostr group ID
+//!
+//! Here we also define the storage traits that are used to store and retrieve groups
+
+use nostr::PublicKey;
+
+pub mod error;
+pub mod types;
+
+use self::error::GroupError;
+use self::types::*;
+use crate::messages::types::Message;
+
+/// Storage traits for the groups module
+pub trait GroupStorage {
+    /// Get all groups
+    fn all_groups(&self) -> Result<Vec<Group>, GroupError>;
+
+    /// Find a group by MLS group ID
+    fn find_group_by_mls_group_id(&self, mls_group_id: &[u8]) -> Result<Group, GroupError>;
+
+    /// Find a group by Nostr group ID
+    fn find_group_by_nostr_group_id(&self, nostr_group_id: &str) -> Result<Group, GroupError>;
+
+    /// Save a group
+    fn save_group(&self, group: Group) -> Result<Group, GroupError>;
+
+    /// Get all messages for a group
+    fn messages(&self, mls_group_id: &[u8]) -> Result<Vec<Message>, GroupError>;
+
+    /// Get all admins for a group
+    fn admins(&self, mls_group_id: &[u8]) -> Result<Vec<PublicKey>, GroupError>;
+
+    /// Get all relays for a group
+    fn group_relays(&self, mls_group_id: &[u8]) -> Result<Vec<GroupRelay>, GroupError>;
+
+    /// Save a group relay
+    fn save_group_relay(&self, group_relay: GroupRelay) -> Result<GroupRelay, GroupError>;
+}

--- a/crates/nostr-mls-storage/src/groups/types.rs
+++ b/crates/nostr-mls-storage/src/groups/types.rs
@@ -1,0 +1,287 @@
+//! Types for the groups module
+
+use std::fmt;
+use std::str::FromStr;
+
+use nostr::{EventId, PublicKey, RelayUrl, Timestamp};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use super::error::GroupError;
+
+/// The type of Nostr MLS group
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum GroupType {
+    /// A group with only two members
+    DirectMessage,
+    /// A group with more than two members
+    Group,
+}
+
+impl fmt::Display for GroupType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl GroupType {
+    /// Get as `&str`
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::DirectMessage => "direct_message",
+            Self::Group => "group",
+        }
+    }
+}
+
+impl FromStr for GroupType {
+    type Err = GroupError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "direct_message" => Ok(Self::DirectMessage),
+            "group" => Ok(Self::Group),
+            _ => Err(GroupError::InvalidParameters(format!(
+                "Invalid group type: {}",
+                s
+            ))),
+        }
+    }
+}
+
+impl Serialize for GroupType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for GroupType {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s: String = String::deserialize(deserializer)?;
+        Self::from_str(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+/// The state of the group, this matches the MLS group state
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum GroupState {
+    /// The group is active
+    Active,
+    /// The group is inactive
+    Inactive,
+}
+
+impl fmt::Display for GroupState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl GroupState {
+    /// Get as `&str`
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Active => "active",
+            Self::Inactive => "inactive",
+        }
+    }
+}
+
+impl FromStr for GroupState {
+    type Err = GroupError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "active" => Ok(Self::Active),
+            "inactive" => Ok(Self::Inactive),
+            _ => Err(GroupError::InvalidParameters(format!(
+                "Invalid group state: {}",
+                s
+            ))),
+        }
+    }
+}
+
+impl Serialize for GroupState {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for GroupState {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s: String = String::deserialize(deserializer)?;
+        Self::from_str(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+/// A Nostr MLS group
+///
+/// Stores metadata about the group
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Group {
+    /// This is the MLS group ID, this will serve as the PK in the DB and doesn't change
+    pub mls_group_id: Vec<u8>,
+    /// Hex encoded (same value as the NostrGroupDataExtension) this is the group_id used in Nostr events
+    pub nostr_group_id: String,
+    /// UTF-8 encoded (same value as the NostrGroupDataExtension)
+    pub name: String,
+    /// UTF-8 encoded (same value as the NostrGroupDataExtension)
+    pub description: String,
+    /// Hex encoded (same value as the NostrGroupDataExtension)
+    pub admin_pubkeys: Vec<PublicKey>,
+    /// Hex encoded Nostr event ID of the last message in the group
+    pub last_message_id: Option<EventId>,
+    /// Timestamp of the last message in the group
+    pub last_message_at: Option<Timestamp>,
+    /// Type of Nostr MLS group
+    pub group_type: GroupType,
+    /// Epoch of the group
+    pub epoch: u64,
+    /// The state of the group
+    pub state: GroupState,
+}
+
+/// A Nostr MLS group relay
+///
+/// Stores a relay URL and the MLS group ID it belongs to
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GroupRelay {
+    /// The relay URL
+    pub relay_url: RelayUrl,
+    /// The MLS group ID
+    pub mls_group_id: Vec<u8>,
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn test_group_type_from_str() {
+        assert_eq!(
+            GroupType::from_str("direct_message").unwrap(),
+            GroupType::DirectMessage
+        );
+        assert_eq!(GroupType::from_str("group").unwrap(), GroupType::Group);
+
+        let err = GroupType::from_str("invalid").unwrap_err();
+        match err {
+            GroupError::InvalidParameters(msg) => {
+                assert!(msg.contains("Invalid group type: invalid"));
+            }
+            _ => panic!("Expected InvalidParameters error"),
+        }
+    }
+
+    #[test]
+    fn test_group_type_to_string() {
+        assert_eq!(GroupType::DirectMessage.to_string(), "direct_message");
+        assert_eq!(GroupType::Group.to_string(), "group");
+    }
+
+    #[test]
+    fn test_group_type_serialization() {
+        let direct_message = GroupType::DirectMessage;
+        let serialized = serde_json::to_string(&direct_message).unwrap();
+        assert_eq!(serialized, r#""direct_message""#);
+
+        let group = GroupType::Group;
+        let serialized = serde_json::to_string(&group).unwrap();
+        assert_eq!(serialized, r#""group""#);
+    }
+
+    #[test]
+    fn test_group_type_deserialization() {
+        let direct_message: GroupType = serde_json::from_str(r#""direct_message""#).unwrap();
+        assert_eq!(direct_message, GroupType::DirectMessage);
+
+        let group: GroupType = serde_json::from_str(r#""group""#).unwrap();
+        assert_eq!(group, GroupType::Group);
+
+        // Test snake_case works
+        let direct_message: GroupType = serde_json::from_str(r#""direct_message""#).unwrap();
+        assert_eq!(direct_message, GroupType::DirectMessage);
+    }
+
+    #[test]
+    fn test_group_state_from_str() {
+        assert_eq!(GroupState::from_str("active").unwrap(), GroupState::Active);
+        assert_eq!(
+            GroupState::from_str("inactive").unwrap(),
+            GroupState::Inactive
+        );
+
+        let err = GroupState::from_str("invalid").unwrap_err();
+        match err {
+            GroupError::InvalidParameters(msg) => {
+                assert!(msg.contains("Invalid group state: invalid"));
+            }
+            _ => panic!("Expected InvalidParameters error"),
+        }
+    }
+
+    #[test]
+    fn test_group_state_to_string() {
+        assert_eq!(GroupState::Active.to_string(), "active");
+        assert_eq!(GroupState::Inactive.to_string(), "inactive");
+    }
+
+    #[test]
+    fn test_group_state_serialization() {
+        let active = GroupState::Active;
+        let serialized = serde_json::to_string(&active).unwrap();
+        assert_eq!(serialized, r#""active""#);
+
+        let inactive = GroupState::Inactive;
+        let serialized = serde_json::to_string(&inactive).unwrap();
+        assert_eq!(serialized, r#""inactive""#);
+    }
+
+    #[test]
+    fn test_group_state_deserialization() {
+        let active: GroupState = serde_json::from_str(r#""active""#).unwrap();
+        assert_eq!(active, GroupState::Active);
+
+        let inactive: GroupState = serde_json::from_str(r#""inactive""#).unwrap();
+        assert_eq!(inactive, GroupState::Inactive);
+    }
+
+    #[test]
+    fn test_group_serialization() {
+        // Simple test to ensure Group can be serialized
+        let group = Group {
+            mls_group_id: vec![1, 2, 3],
+            nostr_group_id: "test_id".to_string(),
+            name: "Test Group".to_string(),
+            description: "Test Description".to_string(),
+            admin_pubkeys: Vec::new(),
+            last_message_id: None,
+            last_message_at: None,
+            group_type: GroupType::Group,
+            epoch: 0,
+            state: GroupState::Active,
+        };
+
+        let serialized = serde_json::to_value(&group).unwrap();
+        assert_eq!(serialized["mls_group_id"], json!([1, 2, 3]));
+        assert_eq!(serialized["nostr_group_id"], json!("test_id"));
+        assert_eq!(serialized["name"], json!("Test Group"));
+        assert_eq!(serialized["description"], json!("Test Description"));
+        assert_eq!(serialized["group_type"], json!("group"));
+        assert_eq!(serialized["state"], json!("active"));
+    }
+}

--- a/crates/nostr-mls-storage/src/lib.rs
+++ b/crates/nostr-mls-storage/src/lib.rs
@@ -1,0 +1,80 @@
+//! Nostr MLS storage - A set of storage provider traits and types for implementing MLS storage
+//! It is designed to be used in conjunction with the `openmls` crate.
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+#![warn(rustdoc::bare_urls)]
+
+use openmls_traits::storage::StorageProvider;
+
+pub mod groups;
+pub mod messages;
+pub mod welcomes;
+
+use self::groups::GroupStorage;
+use self::messages::MessageStorage;
+use self::welcomes::WelcomeStorage;
+
+const CURRENT_VERSION: u16 = 1;
+
+/// Backend
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Backend {
+    /// Memory
+    Memory,
+    /// SQLite
+    SQLite,
+}
+
+impl Backend {
+    /// Check if it's a persistent backend
+    ///
+    /// All values different from [`Backend::Memory`] are considered persistent
+    pub fn is_persistent(&self) -> bool {
+        !matches!(self, Self::Memory)
+    }
+}
+
+/// Storage provider for the Nostr MLS storage
+pub trait NostrMlsStorageProvider: GroupStorage + MessageStorage + WelcomeStorage {
+    /// The OpenMLS storage provider
+    type OpenMlsStorageProvider: StorageProvider<CURRENT_VERSION>;
+
+    /// Returns the backend type.
+    ///
+    /// # Returns
+    ///
+    /// [`Backend::Memory`] indicating this is a memory-based storage implementation.
+    fn backend(&self) -> Backend;
+
+    /// Get a reference to the openmls storage provider.
+    ///
+    /// This method provides access to the underlying OpenMLS storage provider.
+    /// This is primarily useful for internal operations and testing.
+    ///
+    /// # Returns
+    ///
+    /// A reference to the openmls storage implementation.
+    fn openmls_storage(&self) -> &Self::OpenMlsStorageProvider;
+
+    /// Get a mutable reference to the openmls storage provider.
+    ///
+    /// This method provides mutable access to the underlying OpenMLS storage provider.
+    /// This is primarily useful for internal operations and testing.
+    ///
+    /// # Returns
+    ///
+    /// A mutable reference to the openmls storage implementation.
+    fn openmls_storage_mut(&mut self) -> &mut Self::OpenMlsStorageProvider;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_backend_is_persistent() {
+        assert!(!Backend::Memory.is_persistent());
+        assert!(Backend::SQLite.is_persistent());
+    }
+}

--- a/crates/nostr-mls-storage/src/messages/error.rs
+++ b/crates/nostr-mls-storage/src/messages/error.rs
@@ -1,0 +1,26 @@
+//! Error types for the messages module
+
+use std::fmt;
+
+/// Error types for the messages module
+#[derive(Debug)]
+pub enum MessageError {
+    /// Invalid parameters
+    InvalidParameters(String),
+    /// Database error
+    DatabaseError(String),
+    /// Message not found
+    NotFound,
+}
+
+impl std::error::Error for MessageError {}
+
+impl fmt::Display for MessageError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidParameters(message) => write!(f, "Invalid parameters: {}", message),
+            Self::DatabaseError(message) => write!(f, "Database error: {}", message),
+            Self::NotFound => write!(f, "Message not found"),
+        }
+    }
+}

--- a/crates/nostr-mls-storage/src/messages/mod.rs
+++ b/crates/nostr-mls-storage/src/messages/mod.rs
@@ -1,0 +1,36 @@
+//! Messages module
+//!
+//! This module is responsible for storing and retrieving messages
+//!
+//! The messages are stored in the database and can be retrieved by event ID
+//!
+//! Here we also define the storage traits that are used to store and retrieve messages
+
+use nostr::EventId;
+
+pub mod error;
+pub mod types;
+
+use self::error::MessageError;
+use self::types::*;
+
+/// Storage traits for the messages module
+pub trait MessageStorage {
+    /// Save a message
+    fn save_message(&self, message: Message) -> Result<Message, MessageError>;
+
+    /// Find a message by event ID
+    fn find_message_by_event_id(&self, event_id: EventId) -> Result<Message, MessageError>;
+
+    /// Find a processed message by event ID
+    fn find_processed_message_by_event_id(
+        &self,
+        event_id: EventId,
+    ) -> Result<ProcessedMessage, MessageError>;
+
+    /// Save a processed message
+    fn save_processed_message(
+        &self,
+        processed_message: ProcessedMessage,
+    ) -> Result<ProcessedMessage, MessageError>;
+}

--- a/crates/nostr-mls-storage/src/messages/types.rs
+++ b/crates/nostr-mls-storage/src/messages/types.rs
@@ -1,0 +1,177 @@
+//! Types for the messages module
+
+use std::fmt;
+use std::str::FromStr;
+
+use nostr::event::Kind;
+use nostr::{EventId, PublicKey, Tags, Timestamp, UnsignedEvent};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use super::error::MessageError;
+
+/// A processed message, this stores data about whether we have processed a message or not
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProcessedMessage {
+    /// The event id of the processed message
+    pub wrapper_event_id: EventId,
+    /// The event id of the rumor event (kind 445 group message)
+    pub message_event_id: Option<EventId>,
+    /// The timestamp of when the message was processed
+    pub processed_at: Timestamp,
+    /// The state of the message
+    pub state: ProcessedMessageState,
+    /// The reason the message failed to be processed
+    pub failure_reason: String,
+}
+
+/// This is the processed rumor message that represents a message in a group
+/// We store the deconstructed messages but also the UnsignedEvent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Message {
+    /// The event id of the message
+    pub id: EventId,
+    /// The pubkey of the author of the message
+    pub pubkey: PublicKey,
+    /// The kind of the message
+    pub kind: Kind,
+    /// The MLS group id of the message
+    pub mls_group_id: Vec<u8>,
+    /// The created at timestamp of the message
+    pub created_at: Timestamp,
+    /// The content of the message
+    pub content: String,
+    /// The tags of the message
+    pub tags: Tags,
+    /// The event that contains the message
+    pub event: UnsignedEvent,
+    /// The event id of the 1059 event that contained the message
+    pub wrapper_event_id: EventId,
+}
+
+/// The Processing State of the message,
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ProcessedMessageState {
+    /// The message was successfully processed and stored in the database
+    Processed,
+    /// The message failed to be processed and stored in the database
+    Failed,
+}
+
+impl fmt::Display for ProcessedMessageState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl ProcessedMessageState {
+    /// Get as `&str`
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Processed => "processed",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+impl FromStr for ProcessedMessageState {
+    type Err = MessageError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "processed" => Ok(Self::Processed),
+            "failed" => Ok(Self::Failed),
+            _ => Err(MessageError::InvalidParameters(format!(
+                "Invalid processed message state: {}",
+                s
+            ))),
+        }
+    }
+}
+
+impl Serialize for ProcessedMessageState {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for ProcessedMessageState {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s: String = String::deserialize(deserializer)?;
+        Self::from_str(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn test_processed_message_state_from_str() {
+        assert_eq!(
+            ProcessedMessageState::from_str("processed").unwrap(),
+            ProcessedMessageState::Processed
+        );
+        assert_eq!(
+            ProcessedMessageState::from_str("failed").unwrap(),
+            ProcessedMessageState::Failed
+        );
+
+        let err = ProcessedMessageState::from_str("invalid").unwrap_err();
+        match err {
+            MessageError::InvalidParameters(msg) => {
+                assert!(msg.contains("Invalid processed message state: invalid"));
+            }
+            _ => panic!("Expected InvalidParameters error"),
+        }
+    }
+
+    #[test]
+    fn test_processed_message_state_to_string() {
+        assert_eq!(ProcessedMessageState::Processed.to_string(), "processed");
+        assert_eq!(ProcessedMessageState::Failed.to_string(), "failed");
+    }
+
+    #[test]
+    fn test_processed_message_state_serialization() {
+        let processed = ProcessedMessageState::Processed;
+        let serialized = serde_json::to_string(&processed).unwrap();
+        assert_eq!(serialized, r#""processed""#);
+
+        let failed = ProcessedMessageState::Failed;
+        let serialized = serde_json::to_string(&failed).unwrap();
+        assert_eq!(serialized, r#""failed""#);
+    }
+
+    #[test]
+    fn test_processed_message_state_deserialization() {
+        let processed: ProcessedMessageState = serde_json::from_str(r#""processed""#).unwrap();
+        assert_eq!(processed, ProcessedMessageState::Processed);
+
+        let failed: ProcessedMessageState = serde_json::from_str(r#""failed""#).unwrap();
+        assert_eq!(failed, ProcessedMessageState::Failed);
+    }
+
+    #[test]
+    fn test_processed_message_serialization() {
+        // Create a processed message to test serialization
+        let processed_message = ProcessedMessage {
+            wrapper_event_id: EventId::all_zeros(), // Using all_zeros for testing
+            message_event_id: None,
+            processed_at: Timestamp::now(),
+            state: ProcessedMessageState::Processed,
+            failure_reason: String::new(),
+        };
+
+        let serialized = serde_json::to_value(&processed_message).unwrap();
+        assert_eq!(serialized["state"], json!("processed"));
+        assert_eq!(serialized["failure_reason"], json!(""));
+    }
+}

--- a/crates/nostr-mls-storage/src/welcomes/error.rs
+++ b/crates/nostr-mls-storage/src/welcomes/error.rs
@@ -1,0 +1,26 @@
+//! Error types for the welcomes module
+
+use std::fmt;
+
+/// Error types for the welcomes module
+#[derive(Debug)]
+pub enum WelcomeError {
+    /// Invalid parameters
+    InvalidParameters(String),
+    /// Database error
+    DatabaseError(String),
+    /// Welcome not found
+    NotFound,
+}
+
+impl std::error::Error for WelcomeError {}
+
+impl fmt::Display for WelcomeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidParameters(message) => write!(f, "Invalid parameters: {}", message),
+            Self::DatabaseError(message) => write!(f, "Database error: {}", message),
+            Self::NotFound => write!(f, "Welcome not found"),
+        }
+    }
+}

--- a/crates/nostr-mls-storage/src/welcomes/mod.rs
+++ b/crates/nostr-mls-storage/src/welcomes/mod.rs
@@ -1,0 +1,40 @@
+//! Welcomes module
+//!
+//! This module is responsible for storing and retrieving welcomes
+//! It also handles the parsing of welcome content
+//!
+//! The welcomes are stored in the database and can be retrieved by event ID
+//!
+//! Here we also define the storage traits that are used to store and retrieve welcomes
+
+use nostr::EventId;
+
+pub mod error;
+pub mod types;
+
+use self::error::WelcomeError;
+use self::types::*;
+
+/// Storage traits for the welcomes module
+pub trait WelcomeStorage {
+    /// Save a welcome
+    fn save_welcome(&self, welcome: Welcome) -> Result<Welcome, WelcomeError>;
+
+    /// Find a welcome by event ID
+    fn find_welcome_by_event_id(&self, event_id: EventId) -> Result<Welcome, WelcomeError>;
+
+    /// Get all pending welcomes
+    fn pending_welcomes(&self) -> Result<Vec<Welcome>, WelcomeError>;
+
+    /// Save a processed welcome
+    fn save_processed_welcome(
+        &self,
+        processed_welcome: ProcessedWelcome,
+    ) -> Result<ProcessedWelcome, WelcomeError>;
+
+    /// Find a processed welcome by event ID
+    fn find_processed_welcome_by_event_id(
+        &self,
+        event_id: EventId,
+    ) -> Result<ProcessedWelcome, WelcomeError>;
+}

--- a/crates/nostr-mls-storage/src/welcomes/types.rs
+++ b/crates/nostr-mls-storage/src/welcomes/types.rs
@@ -1,0 +1,318 @@
+//! Types for the welcomes module
+
+use std::fmt;
+use std::str::FromStr;
+
+use nostr::{EventId, PublicKey, Timestamp, UnsignedEvent};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use super::error::WelcomeError;
+
+/// A processed welcome, this stores data about whether we have processed a welcome or not
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProcessedWelcome {
+    /// The event id of the processed welcome
+    pub wrapper_event_id: EventId,
+    /// The event id of the rumor event (kind 444 welcome message)
+    pub welcome_event_id: Option<EventId>,
+    /// The timestamp of when the welcome was processed
+    pub processed_at: Timestamp,
+    /// The state of the welcome
+    pub state: ProcessedWelcomeState,
+    /// The reason the welcome failed to be processed
+    pub failure_reason: String,
+}
+
+/// A welcome message
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Welcome {
+    /// The event id of the kind 444 welcome
+    pub id: EventId,
+    /// The event that contains the welcome message
+    pub event: UnsignedEvent,
+    /// MLS group id
+    pub mls_group_id: Vec<u8>,
+    /// Nostr group id (from NostrGroupDataExtension)
+    pub nostr_group_id: String,
+    /// Group name (from NostrGroupDataExtension)
+    pub group_name: String,
+    /// Group description (from NostrGroupDataExtension)
+    pub group_description: String,
+    /// Group admin pubkeys (from NostrGroupDataExtension)
+    pub group_admin_pubkeys: Vec<String>,
+    /// Group relays (from NostrGroupDataExtension)
+    pub group_relays: Vec<String>,
+    /// Pubkey of the user that sent the welcome
+    pub welcomer: PublicKey,
+    /// Member count of the group
+    pub member_count: u32,
+    /// The state of the welcome
+    pub state: WelcomeState,
+    /// The event id of the 1059 event that contained the welcome
+    pub wrapper_event_id: EventId,
+}
+
+/// The processing state of a welcome
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ProcessedWelcomeState {
+    /// The welcome was successfully processed and stored in the database
+    Processed,
+    /// The welcome failed to be processed and stored in the database
+    Failed,
+}
+
+impl fmt::Display for ProcessedWelcomeState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl ProcessedWelcomeState {
+    /// Get as `&str`
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Processed => "processed",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+impl FromStr for ProcessedWelcomeState {
+    type Err = WelcomeError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "processed" => Ok(Self::Processed),
+            "failed" => Ok(Self::Failed),
+            _ => Err(WelcomeError::InvalidParameters(format!(
+                "Invalid processed welcome state: {}",
+                s
+            ))),
+        }
+    }
+}
+
+impl Serialize for ProcessedWelcomeState {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for ProcessedWelcomeState {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s: String = String::deserialize(deserializer)?;
+        Self::from_str(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+/// The state of a welcome
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum WelcomeState {
+    /// The welcome is pending
+    Pending,
+    /// The welcome was accepted
+    Accepted,
+    /// The welcome was declined
+    Declined,
+    /// The welcome was ignored
+    Ignored,
+}
+
+impl fmt::Display for WelcomeState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl WelcomeState {
+    /// Get as `&str`
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Pending => "pending",
+            Self::Accepted => "accepted",
+            Self::Declined => "declined",
+            Self::Ignored => "ignored",
+        }
+    }
+}
+
+impl FromStr for WelcomeState {
+    type Err = WelcomeError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "pending" => Ok(Self::Pending),
+            "accepted" => Ok(Self::Accepted),
+            "declined" => Ok(Self::Declined),
+            "ignored" => Ok(Self::Ignored),
+            _ => Err(WelcomeError::InvalidParameters(format!(
+                "Invalid welcome state: {}",
+                s
+            ))),
+        }
+    }
+}
+
+impl Serialize for WelcomeState {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for WelcomeState {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s: String = String::deserialize(deserializer)?;
+        Self::from_str(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn test_processed_welcome_state_from_str() {
+        assert_eq!(
+            ProcessedWelcomeState::from_str("processed").unwrap(),
+            ProcessedWelcomeState::Processed
+        );
+        assert_eq!(
+            ProcessedWelcomeState::from_str("failed").unwrap(),
+            ProcessedWelcomeState::Failed
+        );
+
+        let err = ProcessedWelcomeState::from_str("invalid").unwrap_err();
+        match err {
+            WelcomeError::InvalidParameters(msg) => {
+                assert!(msg.contains("Invalid processed welcome state: invalid"));
+            }
+            _ => panic!("Expected InvalidParameters error"),
+        }
+    }
+
+    #[test]
+    fn test_processed_welcome_state_to_string() {
+        assert_eq!(ProcessedWelcomeState::Processed.to_string(), "processed");
+        assert_eq!(ProcessedWelcomeState::Failed.to_string(), "failed");
+    }
+
+    #[test]
+    fn test_processed_welcome_state_serialization() {
+        let processed = ProcessedWelcomeState::Processed;
+        let serialized = serde_json::to_string(&processed).unwrap();
+        assert_eq!(serialized, r#""processed""#);
+
+        let failed = ProcessedWelcomeState::Failed;
+        let serialized = serde_json::to_string(&failed).unwrap();
+        assert_eq!(serialized, r#""failed""#);
+    }
+
+    #[test]
+    fn test_processed_welcome_state_deserialization() {
+        let processed: ProcessedWelcomeState = serde_json::from_str(r#""processed""#).unwrap();
+        assert_eq!(processed, ProcessedWelcomeState::Processed);
+
+        let failed: ProcessedWelcomeState = serde_json::from_str(r#""failed""#).unwrap();
+        assert_eq!(failed, ProcessedWelcomeState::Failed);
+    }
+
+    #[test]
+    fn test_welcome_state_from_str() {
+        assert_eq!(
+            WelcomeState::from_str("pending").unwrap(),
+            WelcomeState::Pending
+        );
+        assert_eq!(
+            WelcomeState::from_str("accepted").unwrap(),
+            WelcomeState::Accepted
+        );
+        assert_eq!(
+            WelcomeState::from_str("declined").unwrap(),
+            WelcomeState::Declined
+        );
+        assert_eq!(
+            WelcomeState::from_str("ignored").unwrap(),
+            WelcomeState::Ignored
+        );
+
+        let err = WelcomeState::from_str("invalid").unwrap_err();
+        match err {
+            WelcomeError::InvalidParameters(msg) => {
+                assert!(msg.contains("Invalid welcome state: invalid"));
+            }
+            _ => panic!("Expected InvalidParameters error"),
+        }
+    }
+
+    #[test]
+    fn test_welcome_state_to_string() {
+        assert_eq!(WelcomeState::Pending.to_string(), "pending");
+        assert_eq!(WelcomeState::Accepted.to_string(), "accepted");
+        assert_eq!(WelcomeState::Declined.to_string(), "declined");
+        assert_eq!(WelcomeState::Ignored.to_string(), "ignored");
+    }
+
+    #[test]
+    fn test_welcome_state_serialization() {
+        let pending = WelcomeState::Pending;
+        let serialized = serde_json::to_string(&pending).unwrap();
+        assert_eq!(serialized, r#""pending""#);
+
+        let accepted = WelcomeState::Accepted;
+        let serialized = serde_json::to_string(&accepted).unwrap();
+        assert_eq!(serialized, r#""accepted""#);
+
+        let declined = WelcomeState::Declined;
+        let serialized = serde_json::to_string(&declined).unwrap();
+        assert_eq!(serialized, r#""declined""#);
+
+        let ignored = WelcomeState::Ignored;
+        let serialized = serde_json::to_string(&ignored).unwrap();
+        assert_eq!(serialized, r#""ignored""#);
+    }
+
+    #[test]
+    fn test_welcome_state_deserialization() {
+        let pending: WelcomeState = serde_json::from_str(r#""pending""#).unwrap();
+        assert_eq!(pending, WelcomeState::Pending);
+
+        let accepted: WelcomeState = serde_json::from_str(r#""accepted""#).unwrap();
+        assert_eq!(accepted, WelcomeState::Accepted);
+
+        let declined: WelcomeState = serde_json::from_str(r#""declined""#).unwrap();
+        assert_eq!(declined, WelcomeState::Declined);
+
+        let ignored: WelcomeState = serde_json::from_str(r#""ignored""#).unwrap();
+        assert_eq!(ignored, WelcomeState::Ignored);
+    }
+
+    #[test]
+    fn test_processed_welcome_serialization() {
+        // Create a processed welcome to test serialization
+        let processed_welcome = ProcessedWelcome {
+            wrapper_event_id: EventId::all_zeros(), // Using all_zeros for testing
+            welcome_event_id: None,
+            processed_at: Timestamp::now(),
+            state: ProcessedWelcomeState::Processed,
+            failure_reason: String::new(),
+        };
+
+        let serialized = serde_json::to_value(&processed_welcome).unwrap();
+        assert_eq!(serialized["state"], json!("processed"));
+        assert_eq!(serialized["failure_reason"], json!(""));
+    }
+}

--- a/crates/nostr/Cargo.toml
+++ b/crates/nostr/Cargo.toml
@@ -77,7 +77,7 @@ regex = { version = "1.11", default-features = false, features = ["perf", "unico
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "socks"], optional = true }
 scrypt = { version = "0.11", default-features = false, optional = true }
 secp256k1 = { version = "0.29", default-features = false, features = ["rand", "serde"] }
-serde = { version = "1.0", default-features = false, features = ["derive"] }
+serde = { workspace = true, default-features = false, features = ["derive"] }
 serde_json.workspace = true
 unicode-normalization = { version = "0.1", default-features = false, optional = true }
 url = { version = "2.5", default-features = false, features = ["serde"], optional = true } # Used in std


### PR DESCRIPTION
### Description

This adds just the nostr-mls-storage crate. This crate provides a storage abstraction layer (traits) and wrapper around the OpenMLS StorageProvider traits.

### Checklist

* [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [X] I ran `just precommit` or `just check` before committing (failing on trying to compile nostr-indexdb for wasm)
* [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
