### PR TITLE
Add nostr mls sqlite storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * blossom: add new crate with Blossom support ([Daniel D’Aquino] at https://github.com/rust-nostr/nostr/pull/838)
 * mls-storage: add new crate with traits and types for mls storage implementations ([JeffG] at https://github.com/rust-nostr/nostr/pull/836)
 * mls-memory-storage: add an in-memory implementation for MLS ([JeffG] at https://github.com/rust-nostr/nostr/pull/839)
+* mls-sqlite-storage: a sqlite implementation for MLS ([JeffG] at https://github.com/rust-nostr/nostr/pull/842)
 
 ## v0.41.0 - 2025/04/15
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1117,7 +1117,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f9bc3564f74be6c35d49a7efee54380d7946ccc631323067f33fabb9246027"
 dependencies = [
  "derive-deftly-macros 0.14.2",
- "heck 0.5.0",
+ "heck 0.4.1",
 ]
 
 [[package]]
@@ -1127,7 +1127,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0015cb20a284ec944852820598af3aef6309ea8dc317a0304441272ed620f196"
 dependencies = [
  "derive-deftly-macros 1.0.1",
- "heck 0.5.0",
+ "heck 0.4.1",
 ]
 
 [[package]]
@@ -1136,8 +1136,8 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1b84d32b18d9a256d81e4fec2e4cfd0ab6dde5e5ff49be1713ae0adbd0060c2"
 dependencies = [
- "heck 0.5.0",
- "indexmap 2.5.0",
+ "heck 0.4.1",
+ "indexmap 1.9.3",
  "itertools 0.12.1",
  "proc-macro-crate",
  "proc-macro2",
@@ -1154,8 +1154,8 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b48e8e38a4aa565da767322b5ca55fb0f8347983c5bc7f7647db069405420479"
 dependencies = [
- "heck 0.5.0",
- "indexmap 2.5.0",
+ "heck 0.4.1",
+ "indexmap 1.9.3",
  "itertools 0.14.0",
  "proc-macro-crate",
  "proc-macro2",
@@ -1498,7 +1498,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1555,7 +1555,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e5768da2206272c81ef0b5e951a41862938a6070da63bcea197899942d3b947"
 dependencies = [
  "cfg-if",
- "rustix",
+ "rustix 0.38.44",
  "windows-sys 0.52.0",
 ]
 
@@ -2431,7 +2431,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -2477,6 +2477,12 @@ name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "lmdb-master-sys"
@@ -2809,6 +2815,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "nostr-mls-sqlite-storage"
+version = "0.41.0"
+dependencies = [
+ "nostr",
+ "nostr-mls-storage",
+ "openmls_sqlite_storage",
+ "refinery",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tracing",
+]
+
+[[package]]
 name = "nostr-mls-storage"
 version = "0.41.0"
 dependencies = [
@@ -3102,21 +3123,32 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 [[package]]
 name = "openmls_memory_storage"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea9cc9eb04ed97262fa96382d7dbf0adfebd5ecde7dbafc7070f9231dd9cf08b"
+source = "git+https://github.com/erskingardner/openmls?rev=88309e1bc79c129628f35c55e838be2d7277c335#88309e1bc79c129628f35c55e838be2d7277c335"
 dependencies = [
  "log",
  "openmls_traits",
  "serde",
  "serde_json",
+ "thiserror 2.0.8",
+]
+
+[[package]]
+name = "openmls_sqlite_storage"
+version = "0.1.0"
+source = "git+https://github.com/erskingardner/openmls?rev=88309e1bc79c129628f35c55e838be2d7277c335#88309e1bc79c129628f35c55e838be2d7277c335"
+dependencies = [
+ "log",
+ "openmls_traits",
+ "refinery",
+ "rusqlite",
+ "serde",
  "thiserror 1.0.64",
 ]
 
 [[package]]
 name = "openmls_traits"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443afa05406adc75fbfa0c3e04db93c5647b763861a474ae1aa8a99c362b80f8"
+source = "git+https://github.com/erskingardner/openmls?rev=88309e1bc79c129628f35c55e838be2d7277c335#88309e1bc79c129628f35c55e838be2d7277c335"
 dependencies = [
  "serde",
  "tls_codec",
@@ -3321,7 +3353,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
 dependencies = [
- "siphasher",
+ "siphasher 0.3.11",
 ]
 
 [[package]]
@@ -3635,6 +3667,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "refinery"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba5d693abf62492c37268512ff35b77655d2e957ca53dab85bf993fe9172d15"
+dependencies = [
+ "refinery-core",
+ "refinery-macros",
+]
+
+[[package]]
+name = "refinery-core"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a83581f18c1a4c3a6ebd7a174bdc665f17f618d79f7edccb6a0ac67e660b319"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "log",
+ "regex",
+ "rusqlite",
+ "serde",
+ "siphasher 1.0.1",
+ "thiserror 1.0.64",
+ "time",
+ "toml",
+ "url",
+ "walkdir",
+]
+
+[[package]]
+name = "refinery-macros"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c225407d8e52ef8cf094393781ecda9a99d6544ec28d90a6915751de259264"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "refinery-core",
+ "regex",
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3848,8 +3924,21 @@ dependencies = [
  "bitflags 2.9.0",
  "errno",
  "libc",
- "linux-raw-sys",
- "windows-sys 0.59.0",
+ "linux-raw-sys 0.4.14",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+dependencies = [
+ "bitflags 2.9.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4261,6 +4350,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4476,16 +4571,15 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.17.1"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
+checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
 dependencies = [
- "cfg-if",
  "fastrand",
  "getrandom 0.3.1",
  "once_cell",
- "rustix",
- "windows-sys 0.59.0",
+ "rustix 1.0.5",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6231,7 +6325,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix",
+ "rustix 0.38.44",
 ]
 
 [[package]]
@@ -6256,7 +6350,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ nostr-database = { version = "0.41", path = "./crates/nostr-database", default-f
 nostr-indexeddb = { version = "0.41", path = "./crates/nostr-indexeddb", default-features = false }
 nostr-lmdb = { version = "0.41", path = "./crates/nostr-lmdb", default-features = false }
 nostr-mls-memory-storage = { version = "0.41", path = "./crates/nostr-mls-memory-storage", default-features = false }
+nostr-mls-sqlite-storage = { version = "0.41", path = "./crates/nostr-mls-sqlite-storage", default-features = false }
 nostr-mls-storage = { version = "0.41", path = "./crates/nostr-mls-storage", default-features = false }
 nostr-ndb = { version = "0.41", path = "./crates/nostr-ndb", default-features = false }
 nostr-relay-builder = { version = "0.41", path = "./crates/nostr-relay-builder", default-features = false }

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The project is split up into several crates in the `crates/` directory:
         * [**nostr-indexeddb**](./crates/nostr-indexeddb): IndexedDB storage backend
     * [**nostr-mls-storage**](./crates/nostr-mls-storage): Storage traits for using MLS messaging
         * [**nostr-mls-memory-storage**](./crates/nostr-mls-memory-storage): In-memory storage for nostr-mls
+        * [**nostr-mls-sqlite-storage**](./crates/nostr-mls-sqlite-storage): Sqlite storage for nostr-mls
     * [**nostr-keyring**](./crates/nostr-keyring): Nostr Keyring
     * [**nostr-relay-pool**](./crates/nostr-relay-pool): Nostr Relay Pool
     * [**nostr-sdk**](./crates/nostr-sdk): High level client library

--- a/contrib/scripts/check-crates.sh
+++ b/contrib/scripts/check-crates.sh
@@ -43,6 +43,7 @@ buildargs=(
     "-p nostr-lmdb"
     "-p nostr-mls-storage"
     "-p nostr-mls-memory-storage"
+    "-p nostr-mls-sqlite-storage"
     "-p nostr-indexeddb --target wasm32-unknown-unknown"
     "-p nostr-ndb"
     "-p nostr-keyring"
@@ -62,6 +63,7 @@ skip_msrv=(
     "-p nostr-lmdb"                       # MSRV: 1.72.0
     "-p nostr-mls-storage"                # MSRV: 1.74.0
     "-p nostr-mls-memory-storage"         # MSRV: 1.74.0
+    "-p nostr-mls-sqlite-storage"         # MSRV: 1.74.0
     "-p nostr-keyring"                    # MSRV: 1.75.0
     "-p nostr-keyring --features async"   # MSRV: 1.75.0
     "-p nostr-sdk --features tor"         # MSRV: 1.77.0

--- a/contrib/scripts/release.sh
+++ b/contrib/scripts/release.sh
@@ -8,6 +8,7 @@ args=(
     "-p nostr-lmdb"
     "-p nostr-mls-storage"
     "-p nostr-mls-memory-storage"
+    "-p nostr-mls-sqlite-storage"
     "-p nostr-ndb"
     "-p nostr-indexeddb"
     "-p nostr-keyring"

--- a/crates/nostr-mls-memory-storage/Cargo.toml
+++ b/crates/nostr-mls-memory-storage/Cargo.toml
@@ -15,5 +15,5 @@ keywords = ["nostr", "mls", "openmls", "memory"]
 lru.workspace = true
 nostr = { workspace = true, features = ["std"] }
 nostr-mls-storage.workspace = true
-openmls_memory_storage = { version = "0.3", default-features = false }
+openmls_memory_storage = { git = "https://github.com/erskingardner/openmls", rev = "88309e1bc79c129628f35c55e838be2d7277c335", default-features = false }
 parking_lot = "0.12"

--- a/crates/nostr-mls-sqlite-storage/Cargo.toml
+++ b/crates/nostr-mls-sqlite-storage/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "nostr-mls-sqlite-storage"
+version = "0.41.0"
+edition = "2021"
+description = "Sqlite database for nostr-mls that implements the NostrMlsStorageProvider Trait"
+authors = ["Jeff Gardner <j@jeffg.me>", "Yuki Kishimoto <yukikishimoto@protonmail.com>", "Rust Nostr Developers"]
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+readme = "README.md"
+rust-version = "1.74.0"
+keywords = ["nostr", "mls", "openmls", "sqlite"]
+
+[dependencies]
+nostr = { workspace = true, features = ["std"] }
+nostr-mls-storage.workspace = true
+openmls_sqlite_storage = { git = "https://github.com/erskingardner/openmls", rev = "88309e1bc79c129628f35c55e838be2d7277c335", default-features = false }
+refinery = { version = "0.8", features = ["rusqlite"] } # MSRV is 1.75.0
+rusqlite = { version = "0.32", features = ["bundled"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+tracing = { workspace = true, features = ["std"] }
+
+[dev-dependencies]
+tempfile = "3.19.1"

--- a/crates/nostr-mls-sqlite-storage/README.md
+++ b/crates/nostr-mls-sqlite-storage/README.md
@@ -1,0 +1,15 @@
+# Nostr MLS Sqlite Storage
+
+Sqlite MLS storage backend for nostr apps
+
+## State
+
+**This library is in an ALPHA state**, things that are implemented generally work but the API will change in breaking ways.
+
+## Donations
+
+`rust-nostr` is free and open-source. This means we do not earn any revenue by selling it. Instead, we rely on your financial support. If you actively use any of the `rust-nostr` libs/software/services, then please [donate](https://rust-nostr.org/donate).
+
+## License
+
+This project is distributed under the MIT software license - see the [LICENSE](../../LICENSE) file for details

--- a/crates/nostr-mls-sqlite-storage/migrations/V100__initial.sql
+++ b/crates/nostr-mls-sqlite-storage/migrations/V100__initial.sql
@@ -1,0 +1,104 @@
+-- Initial database schema for nostr-mls-sqlite-storage
+
+-- Groups table
+CREATE TABLE IF NOT EXISTS groups (
+    mls_group_id BLOB PRIMARY KEY,
+    nostr_group_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    description TEXT NOT NULL,
+    admin_pubkeys JSONB NOT NULL,
+    last_message_id BLOB, -- Event ID as byte array
+    last_message_at INTEGER,
+    group_type TEXT NOT NULL,
+    epoch INTEGER NOT NULL,
+    state TEXT NOT NULL
+);
+
+-- Create unique index on nostr_group_id
+CREATE UNIQUE INDEX IF NOT EXISTS idx_groups_nostr_group_id ON groups(nostr_group_id);
+
+-- Group Relays table
+CREATE TABLE IF NOT EXISTS group_relays (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    mls_group_id BLOB NOT NULL,
+    relay_url TEXT NOT NULL,
+    FOREIGN KEY (mls_group_id) REFERENCES groups(mls_group_id) ON DELETE CASCADE,
+    UNIQUE(mls_group_id, relay_url)
+);
+
+-- Create index on mls_group_id for faster lookups
+CREATE INDEX IF NOT EXISTS idx_group_relays_mls_group_id ON group_relays(mls_group_id);
+
+-- Messages table
+CREATE TABLE IF NOT EXISTS messages (
+    id BLOB PRIMARY KEY,  -- Event ID as byte array
+    pubkey BLOB NOT NULL, -- Pubkey as byte array
+    kind INTEGER NOT NULL,
+    mls_group_id BLOB NOT NULL,
+    created_at INTEGER NOT NULL,
+    content TEXT NOT NULL,
+    tags JSONB NOT NULL,
+    event JSONB NOT NULL,
+    wrapper_event_id BLOB NOT NULL, -- Wrapper event ID as byte array
+    FOREIGN KEY (mls_group_id) REFERENCES groups(mls_group_id) ON DELETE CASCADE
+);
+
+-- Create indexes on messages table
+CREATE INDEX IF NOT EXISTS idx_messages_mls_group_id ON messages(mls_group_id);
+CREATE INDEX IF NOT EXISTS idx_messages_wrapper_event_id ON messages(wrapper_event_id);
+CREATE INDEX IF NOT EXISTS idx_messages_created_at ON messages(created_at);
+CREATE INDEX IF NOT EXISTS idx_messages_pubkey ON messages(pubkey);
+CREATE INDEX IF NOT EXISTS idx_messages_kind ON messages(kind);
+
+-- Processed Messages table
+CREATE TABLE IF NOT EXISTS processed_messages (
+    wrapper_event_id BLOB PRIMARY KEY, -- Wrapper event ID as byte array
+    message_event_id BLOB, -- Message event ID as byte array
+    processed_at INTEGER NOT NULL,
+    state TEXT NOT NULL,
+    failure_reason TEXT NOT NULL
+);
+
+-- Create index on message_event_id for faster lookups
+CREATE INDEX IF NOT EXISTS idx_processed_messages_message_event_id ON processed_messages(message_event_id);
+CREATE INDEX IF NOT EXISTS idx_processed_messages_state ON processed_messages(state);
+CREATE INDEX IF NOT EXISTS idx_processed_messages_processed_at ON processed_messages(processed_at);
+CREATE INDEX IF NOT EXISTS idx_processed_messages_wrapper_event_id ON processed_messages(wrapper_event_id);
+
+-- Welcome messages table
+CREATE TABLE IF NOT EXISTS welcomes (
+    id BLOB PRIMARY KEY,  -- Event ID as byte array
+    event JSONB NOT NULL,
+    mls_group_id BLOB NOT NULL,
+    nostr_group_id TEXT NOT NULL,
+    group_name TEXT NOT NULL,
+    group_description TEXT NOT NULL,
+    group_admin_pubkeys JSONB NOT NULL,
+    group_relays JSONB NOT NULL,
+    welcomer BLOB NOT NULL,  -- pubkey as byte array
+    member_count INTEGER NOT NULL,
+    state TEXT NOT NULL,
+    wrapper_event_id BLOB NOT NULL, -- Wrapper event ID as byte array
+    FOREIGN KEY (mls_group_id) REFERENCES groups(mls_group_id) ON DELETE CASCADE
+);
+
+-- Create indexes on welcomes table
+CREATE INDEX IF NOT EXISTS idx_welcomes_mls_group_id ON welcomes(mls_group_id);
+CREATE INDEX IF NOT EXISTS idx_welcomes_wrapper_event_id ON welcomes(wrapper_event_id);
+CREATE INDEX IF NOT EXISTS idx_welcomes_state ON welcomes(state);
+CREATE INDEX IF NOT EXISTS idx_welcomes_nostr_group_id ON welcomes(nostr_group_id);
+
+-- Processed Welcome messages table
+CREATE TABLE IF NOT EXISTS processed_welcomes (
+    wrapper_event_id BLOB PRIMARY KEY, -- Wrapper event ID as byte array
+    welcome_event_id BLOB, -- Welcome event ID as byte array
+    processed_at INTEGER NOT NULL,
+    state TEXT NOT NULL,
+    failure_reason TEXT NOT NULL
+);
+
+-- Create index on welcome_event_id for faster lookups
+CREATE INDEX IF NOT EXISTS idx_processed_welcomes_welcome_event_id ON processed_welcomes(welcome_event_id);
+CREATE INDEX IF NOT EXISTS idx_processed_welcomes_state ON processed_welcomes(state);
+CREATE INDEX IF NOT EXISTS idx_processed_welcomes_processed_at ON processed_welcomes(processed_at);
+CREATE INDEX IF NOT EXISTS idx_processed_welcomes_wrapper_event_id ON processed_welcomes(wrapper_event_id);

--- a/crates/nostr-mls-sqlite-storage/src/db.rs
+++ b/crates/nostr-mls-sqlite-storage/src/db.rs
@@ -1,0 +1,369 @@
+use std::str::FromStr;
+
+/// Database utilities for SQLite storage.
+use nostr::{EventId, Kind, PublicKey, RelayUrl, Tags, Timestamp, UnsignedEvent};
+use nostr_mls_storage::groups::types::{Group, GroupRelay, GroupState, GroupType};
+use nostr_mls_storage::messages::types::{Message, ProcessedMessage, ProcessedMessageState};
+use nostr_mls_storage::welcomes::types::{
+    ProcessedWelcome, ProcessedWelcomeState, Welcome, WelcomeState,
+};
+use rusqlite::{Result as SqliteResult, Row};
+
+/// Convert a row to a Group struct
+pub fn row_to_group(row: &Row) -> SqliteResult<Group> {
+    let mls_group_id: Vec<u8> = row.get("mls_group_id")?;
+    let nostr_group_id: String = row.get("nostr_group_id")?;
+    let name: String = row.get("name")?;
+    let description: String = row.get("description")?;
+
+    // Parse admin pubkeys from JSON
+    let admin_pubkeys_json: String = row.get("admin_pubkeys")?;
+    let admin_pubkeys: Vec<String> = serde_json::from_str(&admin_pubkeys_json).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e))
+    })?;
+
+    // Convert string pubkeys to PublicKey type
+    let admin_pubkeys: Vec<PublicKey> = admin_pubkeys
+        .iter()
+        .filter_map(|pk| PublicKey::parse(pk).ok())
+        .collect();
+
+    let last_message_id: Option<Vec<u8>> = row.get("last_message_id")?;
+    let last_message_at: Option<i64> = row.get("last_message_at")?;
+    let group_type: String = row.get("group_type")?;
+    let epoch: u64 = row.get::<_, i64>("epoch")? as u64;
+    let state: String = row.get("state")?;
+
+    let last_message_id = match last_message_id {
+        Some(id) => EventId::from_slice(&id).ok(),
+        None => None,
+    };
+
+    let last_message_at = last_message_at.map(|ts| Timestamp::from(ts as u64));
+
+    // Convert group_type and state to GroupType and GroupState
+    let group_type = GroupType::from_str(&group_type).map_err(|_| {
+        rusqlite::Error::FromSqlConversionFailure(
+            0,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Invalid group type",
+            )),
+        )
+    })?;
+    let state = GroupState::from_str(&state).map_err(|_| {
+        rusqlite::Error::FromSqlConversionFailure(
+            0,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Invalid group state",
+            )),
+        )
+    })?;
+    Ok(Group {
+        mls_group_id,
+        nostr_group_id,
+        name,
+        description,
+        admin_pubkeys,
+        last_message_id,
+        last_message_at,
+        group_type,
+        epoch,
+        state,
+    })
+}
+
+/// Convert a row to a GroupRelay struct
+pub fn row_to_group_relay(row: &Row) -> SqliteResult<GroupRelay> {
+    let mls_group_id: Vec<u8> = row.get("mls_group_id")?;
+    let relay_url: String = row.get("relay_url")?;
+
+    // Parse relay URL
+    let relay_url = RelayUrl::from_str(&relay_url).map_err(|_| {
+        rusqlite::Error::FromSqlConversionFailure(
+            0,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Invalid relay URL",
+            )),
+        )
+    })?;
+
+    Ok(GroupRelay {
+        mls_group_id,
+        relay_url,
+    })
+}
+
+/// Convert a row to a Message struct
+pub fn row_to_message(row: &Row) -> SqliteResult<Message> {
+    let id_blob: Vec<u8> = row.get("id")?;
+    let pubkey_blob: Vec<u8> = row.get("pubkey")?;
+    let kind_value: u16 = row.get("kind")?;
+    let mls_group_id: Vec<u8> = row.get("mls_group_id")?;
+    let created_at_value: u64 = row.get("created_at")?;
+    let content: String = row.get("content")?;
+    let tags_json: String = row.get("tags")?;
+    let event_json: String = row.get("event")?;
+    let wrapper_event_id_blob: Vec<u8> = row.get("wrapper_event_id")?;
+
+    // Parse values
+    let id = EventId::from_slice(&id_blob).map_err(|_| {
+        rusqlite::Error::FromSqlConversionFailure(
+            0,
+            rusqlite::types::Type::Blob,
+            Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Invalid event ID",
+            )),
+        )
+    })?;
+
+    let pubkey = PublicKey::from_slice(&pubkey_blob).map_err(|_| {
+        rusqlite::Error::FromSqlConversionFailure(
+            0,
+            rusqlite::types::Type::Blob,
+            Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Invalid public key",
+            )),
+        )
+    })?;
+
+    let kind = Kind::from(kind_value);
+    let created_at = Timestamp::from(created_at_value);
+
+    let tags: Tags = serde_json::from_str(&tags_json).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e))
+    })?;
+
+    let event: UnsignedEvent = serde_json::from_str(&event_json).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e))
+    })?;
+
+    let wrapper_event_id = EventId::from_slice(&wrapper_event_id_blob).map_err(|_| {
+        rusqlite::Error::FromSqlConversionFailure(
+            0,
+            rusqlite::types::Type::Blob,
+            Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Invalid wrapper event ID",
+            )),
+        )
+    })?;
+
+    Ok(Message {
+        id,
+        pubkey,
+        kind,
+        mls_group_id,
+        created_at,
+        content,
+        tags,
+        event,
+        wrapper_event_id,
+    })
+}
+
+/// Convert a row to a ProcessedMessage struct
+pub fn row_to_processed_message(row: &Row) -> SqliteResult<ProcessedMessage> {
+    let wrapper_event_id_blob: Vec<u8> = row.get("wrapper_event_id")?;
+    let message_event_id_blob: Option<Vec<u8>> = row.get("message_event_id")?;
+    let processed_at_value: i64 = row.get("processed_at")?;
+    let state_str: String = row.get("state")?;
+    let failure_reason: String = row.get("failure_reason")?;
+
+    // Parse values
+    let wrapper_event_id = EventId::from_slice(&wrapper_event_id_blob).map_err(|_| {
+        rusqlite::Error::FromSqlConversionFailure(
+            0,
+            rusqlite::types::Type::Blob,
+            Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Invalid wrapper event ID",
+            )),
+        )
+    })?;
+
+    let message_event_id = match message_event_id_blob {
+        Some(id_blob) => Some(EventId::from_slice(&id_blob).map_err(|_| {
+            rusqlite::Error::FromSqlConversionFailure(
+                0,
+                rusqlite::types::Type::Blob,
+                Box::new(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "Invalid message event ID",
+                )),
+            )
+        })?),
+        None => None,
+    };
+
+    let processed_at = Timestamp::from(processed_at_value as u64);
+    let state = ProcessedMessageState::from_str(&state_str).map_err(|_| {
+        rusqlite::Error::FromSqlConversionFailure(
+            0,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Invalid state",
+            )),
+        )
+    })?;
+
+    Ok(ProcessedMessage {
+        wrapper_event_id,
+        message_event_id,
+        processed_at,
+        state,
+        failure_reason,
+    })
+}
+
+/// Convert a row to a Welcome struct
+pub fn row_to_welcome(row: &Row) -> SqliteResult<Welcome> {
+    let id_blob: Vec<u8> = row.get("id")?;
+    let event_json: String = row.get("event")?;
+    let mls_group_id: Vec<u8> = row.get("mls_group_id")?;
+    let nostr_group_id: String = row.get("nostr_group_id")?;
+    let group_name: String = row.get("group_name")?;
+    let group_description: String = row.get("group_description")?;
+    let group_admin_pubkeys_json: String = row.get("group_admin_pubkeys")?;
+    let group_relays_json: String = row.get("group_relays")?;
+    let welcomer_blob: Vec<u8> = row.get("welcomer")?;
+    let member_count: i64 = row.get("member_count")?;
+    let state_str: String = row.get("state")?;
+    let wrapper_event_id_blob: Vec<u8> = row.get("wrapper_event_id")?;
+
+    // Parse values
+    let id = EventId::from_slice(&id_blob).map_err(|_| {
+        rusqlite::Error::FromSqlConversionFailure(
+            0,
+            rusqlite::types::Type::Blob,
+            Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Invalid event ID",
+            )),
+        )
+    })?;
+
+    let event: UnsignedEvent = serde_json::from_str(&event_json).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e))
+    })?;
+
+    let group_admin_pubkeys: Vec<String> = serde_json::from_str(&group_admin_pubkeys_json)
+        .map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e))
+        })?;
+
+    let group_relays: Vec<String> = serde_json::from_str(&group_relays_json).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e))
+    })?;
+
+    let welcomer = PublicKey::from_slice(&welcomer_blob).map_err(|_| {
+        rusqlite::Error::FromSqlConversionFailure(
+            0,
+            rusqlite::types::Type::Blob,
+            Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Invalid welcomer public key",
+            )),
+        )
+    })?;
+
+    let wrapper_event_id = EventId::from_slice(&wrapper_event_id_blob).map_err(|_| {
+        rusqlite::Error::FromSqlConversionFailure(
+            0,
+            rusqlite::types::Type::Blob,
+            Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Invalid wrapper event ID",
+            )),
+        )
+    })?;
+
+    let state = WelcomeState::from_str(&state_str).map_err(|_| {
+        rusqlite::Error::FromSqlConversionFailure(
+            0,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Invalid state",
+            )),
+        )
+    })?;
+
+    Ok(Welcome {
+        id,
+        event,
+        mls_group_id,
+        nostr_group_id,
+        group_name,
+        group_description,
+        group_admin_pubkeys,
+        group_relays,
+        welcomer,
+        member_count: member_count as u32,
+        state,
+        wrapper_event_id,
+    })
+}
+
+/// Convert a row to a ProcessedWelcome struct
+pub fn row_to_processed_welcome(row: &Row) -> SqliteResult<ProcessedWelcome> {
+    let wrapper_event_id_blob: Vec<u8> = row.get("wrapper_event_id")?;
+    let welcome_event_id_blob: Option<Vec<u8>> = row.get("welcome_event_id")?;
+    let processed_at_value: i64 = row.get("processed_at")?;
+    let state_str: String = row.get("state")?;
+    let failure_reason: String = row.get("failure_reason")?;
+
+    // Parse values
+    let wrapper_event_id = EventId::from_slice(&wrapper_event_id_blob).map_err(|_| {
+        rusqlite::Error::FromSqlConversionFailure(
+            0,
+            rusqlite::types::Type::Blob,
+            Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Invalid wrapper event ID",
+            )),
+        )
+    })?;
+
+    let welcome_event_id = match welcome_event_id_blob {
+        Some(id_blob) => Some(EventId::from_slice(&id_blob).map_err(|_| {
+            rusqlite::Error::FromSqlConversionFailure(
+                0,
+                rusqlite::types::Type::Blob,
+                Box::new(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "Invalid welcome event ID",
+                )),
+            )
+        })?),
+        None => None,
+    };
+
+    let processed_at = Timestamp::from(processed_at_value as u64);
+    let state = ProcessedWelcomeState::from_str(&state_str).map_err(|_| {
+        rusqlite::Error::FromSqlConversionFailure(
+            0,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Invalid state",
+            )),
+        )
+    })?;
+
+    Ok(ProcessedWelcome {
+        wrapper_event_id,
+        welcome_event_id,
+        processed_at,
+        state,
+        failure_reason,
+    })
+}

--- a/crates/nostr-mls-sqlite-storage/src/error.rs
+++ b/crates/nostr-mls-sqlite-storage/src/error.rs
@@ -1,0 +1,57 @@
+//! Error types for the SQLite storage implementation.
+
+use std::fmt;
+
+/// Error type for SQLite storage operations.
+#[derive(Debug)]
+pub enum Error {
+    /// SQLite database error
+    Database(String),
+
+    /// Error from rusqlite
+    Rusqlite(rusqlite::Error),
+
+    /// Error during database migration
+    Migration(String),
+
+    /// Error from OpenMLS
+    OpenMls(String),
+}
+
+impl std::error::Error for Error {}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Database(msg) => write!(f, "Database error: {}", msg),
+            Self::Rusqlite(err) => write!(f, "SQLite error: {}", err),
+            Self::Migration(msg) => write!(f, "Migration error: {}", msg),
+            Self::OpenMls(msg) => write!(f, "OpenMLS error: {}", msg),
+        }
+    }
+}
+
+impl From<rusqlite::Error> for Error {
+    fn from(err: rusqlite::Error) -> Self {
+        Self::Rusqlite(err)
+    }
+}
+
+impl From<refinery::Error> for Error {
+    fn from(err: refinery::Error) -> Self {
+        Self::Migration(err.to_string())
+    }
+}
+
+impl From<Error> for rusqlite::Error {
+    fn from(err: Error) -> Self {
+        rusqlite::Error::FromSqlConversionFailure(
+            0,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                err.to_string(),
+            )),
+        )
+    }
+}

--- a/crates/nostr-mls-sqlite-storage/src/groups.rs
+++ b/crates/nostr-mls-sqlite-storage/src/groups.rs
@@ -1,0 +1,331 @@
+//! Implementation of GroupStorage trait for SQLite storage.
+
+use nostr::PublicKey;
+use nostr_mls_storage::groups::error::GroupError;
+use nostr_mls_storage::groups::types::{Group, GroupRelay};
+use nostr_mls_storage::groups::GroupStorage;
+use nostr_mls_storage::messages::types::Message;
+use rusqlite::params;
+
+use crate::{db, NostrMlsSqliteStorage};
+
+impl GroupStorage for NostrMlsSqliteStorage {
+    fn all_groups(&self) -> Result<Vec<Group>, GroupError> {
+        let conn_guard = self.db_connection.lock().map_err(|_| {
+            GroupError::DatabaseError("Failed to acquire database lock".to_string())
+        })?;
+
+        let mut stmt = conn_guard
+            .prepare("SELECT * FROM groups")
+            .map_err(|e| GroupError::DatabaseError(e.to_string()))?;
+
+        let groups_iter = stmt
+            .query_map([], db::row_to_group)
+            .map_err(|e| GroupError::DatabaseError(e.to_string()))?;
+
+        let mut groups = Vec::new();
+        for group_result in groups_iter {
+            match group_result {
+                Ok(group) => groups.push(group),
+                Err(e) => {
+                    return Err(GroupError::DatabaseError(format!(
+                        "Error parsing group: {}",
+                        e
+                    )))
+                }
+            }
+        }
+
+        Ok(groups)
+    }
+
+    fn find_group_by_mls_group_id(&self, mls_group_id: &[u8]) -> Result<Option<Group>, GroupError> {
+        let conn_guard = self.db_connection.lock().map_err(|_| {
+            GroupError::DatabaseError("Failed to acquire database lock".to_string())
+        })?;
+
+        let mut stmt = conn_guard
+            .prepare("SELECT * FROM groups WHERE mls_group_id = ?")
+            .map_err(|e| GroupError::DatabaseError(e.to_string()))?;
+
+        let result = stmt.query_row(params![mls_group_id], db::row_to_group);
+
+        match result {
+            Ok(group) => Ok(Some(group)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(GroupError::DatabaseError(e.to_string())),
+        }
+    }
+
+    fn find_group_by_nostr_group_id(
+        &self,
+        nostr_group_id: &str,
+    ) -> Result<Option<Group>, GroupError> {
+        let conn_guard = self.db_connection.lock().map_err(|_| {
+            GroupError::DatabaseError("Failed to acquire database lock".to_string())
+        })?;
+
+        let mut stmt = conn_guard
+            .prepare("SELECT * FROM groups WHERE nostr_group_id = ?")
+            .map_err(|e| GroupError::DatabaseError(e.to_string()))?;
+
+        let result = stmt.query_row(params![nostr_group_id], db::row_to_group);
+
+        match result {
+            Ok(group) => Ok(Some(group)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(GroupError::DatabaseError(e.to_string())),
+        }
+    }
+
+    fn save_group(&self, group: Group) -> Result<(), GroupError> {
+        let conn_guard = self.db_connection.lock().map_err(|_| {
+            GroupError::DatabaseError("Failed to acquire database lock".to_string())
+        })?;
+
+        let admin_pubkeys_json = serde_json::to_string(
+            &group
+                .admin_pubkeys
+                .iter()
+                .map(|pk| pk.to_string())
+                .collect::<Vec<String>>(),
+        )
+        .map_err(|e| {
+            GroupError::DatabaseError(format!("Failed to serialize admin pubkeys: {}", e))
+        })?;
+
+        let last_message_id = group.last_message_id.as_ref().map(|id| id.to_bytes());
+        let last_message_at = group.last_message_at.as_ref().map(|ts| ts.as_u64());
+        let group_type_str: String = group.group_type.to_string();
+        let state_str: String = group.state.to_string();
+
+        conn_guard
+            .execute(
+                "INSERT OR REPLACE INTO groups
+             (mls_group_id, nostr_group_id, name, description, admin_pubkeys, last_message_id,
+              last_message_at, group_type, epoch, state)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                params![
+                    &group.mls_group_id,
+                    &group.nostr_group_id,
+                    &group.name,
+                    &group.description,
+                    &admin_pubkeys_json,
+                    &last_message_id,
+                    &last_message_at,
+                    &group_type_str,
+                    &(group.epoch as i64),
+                    &state_str
+                ],
+            )
+            .map_err(|e| GroupError::DatabaseError(e.to_string()))?;
+
+        Ok(())
+    }
+
+    fn messages(&self, mls_group_id: &[u8]) -> Result<Vec<Message>, GroupError> {
+        // First verify the group exists
+        let group = self.find_group_by_mls_group_id(mls_group_id)?;
+        if group.is_none() {
+            return Err(GroupError::InvalidParameters(format!(
+                "Group with MLS ID {:?} not found",
+                mls_group_id
+            )));
+        }
+
+        let conn_guard = self.db_connection.lock().map_err(|_| {
+            GroupError::DatabaseError("Failed to acquire database lock".to_string())
+        })?;
+
+        let mut stmt = conn_guard
+            .prepare("SELECT * FROM messages WHERE mls_group_id = ? ORDER BY created_at DESC")
+            .map_err(|e| GroupError::DatabaseError(e.to_string()))?;
+
+        let messages_iter = stmt
+            .query_map(params![mls_group_id], db::row_to_message)
+            .map_err(|e| GroupError::DatabaseError(e.to_string()))?;
+
+        let mut messages = Vec::new();
+        for message_result in messages_iter {
+            match message_result {
+                Ok(message) => messages.push(message),
+                Err(e) => {
+                    return Err(GroupError::DatabaseError(format!(
+                        "Error parsing message: {}",
+                        e
+                    )))
+                }
+            }
+        }
+
+        Ok(messages)
+    }
+
+    fn admins(&self, mls_group_id: &[u8]) -> Result<Vec<PublicKey>, GroupError> {
+        // Get the group which contains the admin_pubkeys
+        let group = self.find_group_by_mls_group_id(mls_group_id)?;
+
+        match group {
+            Some(group) => Ok(group.admin_pubkeys),
+            None => Err(GroupError::InvalidParameters(format!(
+                "Group with MLS ID {:?} not found",
+                mls_group_id
+            ))),
+        }
+    }
+
+    fn group_relays(&self, mls_group_id: &[u8]) -> Result<Vec<GroupRelay>, GroupError> {
+        // First verify the group exists
+        let group = self.find_group_by_mls_group_id(mls_group_id)?;
+        if group.is_none() {
+            return Err(GroupError::InvalidParameters(format!(
+                "Group with MLS ID {:?} not found",
+                mls_group_id
+            )));
+        }
+
+        let conn_guard = self.db_connection.lock().map_err(|_| {
+            GroupError::DatabaseError("Failed to acquire database lock".to_string())
+        })?;
+
+        let mut stmt = conn_guard
+            .prepare("SELECT * FROM group_relays WHERE mls_group_id = ?")
+            .map_err(|e| GroupError::DatabaseError(e.to_string()))?;
+
+        let relays_iter = stmt
+            .query_map(params![mls_group_id], db::row_to_group_relay)
+            .map_err(|e| GroupError::DatabaseError(e.to_string()))?;
+
+        let mut relays = Vec::new();
+        for relay_result in relays_iter {
+            match relay_result {
+                Ok(relay) => relays.push(relay),
+                Err(e) => {
+                    return Err(GroupError::DatabaseError(format!(
+                        "Error parsing group relay: {}",
+                        e
+                    )))
+                }
+            }
+        }
+
+        Ok(relays)
+    }
+
+    fn save_group_relay(&self, group_relay: GroupRelay) -> Result<(), GroupError> {
+        // First verify the group exists
+        let group = self.find_group_by_mls_group_id(&group_relay.mls_group_id)?;
+        if group.is_none() {
+            return Err(GroupError::InvalidParameters(format!(
+                "Group with MLS ID {:?} not found",
+                group_relay.mls_group_id
+            )));
+        }
+
+        let conn_guard = self.db_connection.lock().map_err(|_| {
+            GroupError::DatabaseError("Failed to acquire database lock".to_string())
+        })?;
+
+        conn_guard
+            .execute(
+                "INSERT OR REPLACE INTO group_relays (mls_group_id, relay_url) VALUES (?, ?)",
+                params![
+                    &group_relay.mls_group_id,
+                    &group_relay.relay_url.to_string()
+                ],
+            )
+            .map_err(|e| GroupError::DatabaseError(e.to_string()))?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nostr::RelayUrl;
+    use nostr_mls_storage::groups::types::{GroupState, GroupType};
+
+    use super::*;
+
+    #[test]
+    fn test_save_and_find_group() {
+        let storage = crate::NostrMlsSqliteStorage::new_in_memory().unwrap();
+
+        // Create a test group
+        let mls_group_id = vec![1, 2, 3, 4];
+        let group = Group {
+            mls_group_id: mls_group_id.clone(),
+            nostr_group_id: "test_group_123".to_string(),
+            name: "Test Group".to_string(),
+            description: "A test group".to_string(),
+            admin_pubkeys: vec![],
+            last_message_id: None,
+            last_message_at: None,
+            group_type: GroupType::Group,
+            epoch: 0,
+            state: GroupState::Active,
+        };
+
+        // Save the group
+        let result = storage.save_group(group.clone());
+        assert!(result.is_ok());
+
+        // Find by MLS group ID
+        let found_group = storage
+            .find_group_by_mls_group_id(&mls_group_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(found_group.nostr_group_id, "test_group_123");
+
+        // Find by Nostr group ID
+        let found_group = storage
+            .find_group_by_nostr_group_id("test_group_123")
+            .unwrap()
+            .unwrap();
+        assert_eq!(found_group.mls_group_id, mls_group_id);
+
+        // Get all groups
+        let all_groups = storage.all_groups().unwrap();
+        assert_eq!(all_groups.len(), 1);
+    }
+
+    #[test]
+    fn test_group_relay() {
+        let storage = crate::NostrMlsSqliteStorage::new_in_memory().unwrap();
+
+        // Create a test group
+        let mls_group_id = vec![1, 2, 3, 4];
+        let group = Group {
+            mls_group_id: mls_group_id.clone(),
+            nostr_group_id: "test_group_123".to_string(),
+            name: "Test Group".to_string(),
+            description: "A test group".to_string(),
+            admin_pubkeys: vec![],
+            last_message_id: None,
+            last_message_at: None,
+            group_type: GroupType::Group,
+            epoch: 0,
+            state: GroupState::Active,
+        };
+
+        // Save the group
+        let result = storage.save_group(group.clone());
+        assert!(result.is_ok());
+
+        // Create a group relay
+        let relay_url = RelayUrl::parse("wss://relay.example.com").unwrap();
+        let group_relay = GroupRelay {
+            mls_group_id: mls_group_id.clone(),
+            relay_url,
+        };
+
+        // Save the group relay
+        let result = storage.save_group_relay(group_relay.clone());
+        assert!(result.is_ok());
+
+        // Get group relays
+        let relays = storage.group_relays(&mls_group_id).unwrap();
+        assert_eq!(relays.len(), 1);
+        assert_eq!(relays[0].relay_url.to_string(), "wss://relay.example.com");
+    }
+}

--- a/crates/nostr-mls-sqlite-storage/src/lib.rs
+++ b/crates/nostr-mls-sqlite-storage/src/lib.rs
@@ -1,0 +1,285 @@
+//! SQLite-based storage implementation for Nostr MLS.
+//!
+//! This module provides a SQLite-based storage implementation for the Nostr MLS (Messaging Layer Security)
+//! crate. It implements the [`NostrMlsStorageProvider`] trait, allowing it to be used within the Nostr MLS context.
+//!
+//! SQLite-based storage is persistent and will be saved to a file. It's useful for production applications
+//! where data persistence is required.
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+#![warn(rustdoc::bare_urls)]
+
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use nostr_mls_storage::{Backend, NostrMlsStorageProvider};
+use openmls_sqlite_storage::Codec;
+use rusqlite::Connection;
+use serde::Serialize;
+
+mod db;
+pub mod error;
+mod groups;
+mod messages;
+mod migrations;
+mod welcomes;
+
+/// A codec for JSON serialization and deserialization.
+#[derive(Default)]
+pub struct JsonCodec;
+
+impl Codec for JsonCodec {
+    type Error = serde_json::Error;
+
+    fn to_vec<T: Serialize>(value: &T) -> Result<Vec<u8>, Self::Error> {
+        serde_json::to_vec(value)
+    }
+
+    fn from_slice<T: serde::de::DeserializeOwned>(slice: &[u8]) -> Result<T, Self::Error> {
+        serde_json::from_slice(slice)
+    }
+}
+
+// Define a type alias for the specific SqliteStorageProvider we're using
+type MlsStorage = openmls_sqlite_storage::SqliteStorageProvider<JsonCodec, rusqlite::Connection>;
+
+/// A SQLite-based storage implementation for Nostr MLS.
+///
+/// This struct implements the NostrMlsStorageProvider trait for SQLite databases.
+/// It directly interfaces with a SQLite database for storing MLS data.
+pub struct NostrMlsSqliteStorage {
+    /// The OpenMLS storage implementation
+    openmls_storage: MlsStorage,
+    /// The SQLite connection
+    db_connection: Arc<Mutex<Connection>>,
+}
+
+impl NostrMlsSqliteStorage {
+    /// Creates a new [`NostrMlsSqliteStorage`] with the provided file path.
+    ///
+    /// # Arguments
+    ///
+    /// * `file_path` - Path to the SQLite database file.
+    ///
+    /// # Returns
+    ///
+    /// A Result containing a new instance of [`NostrMlsSqliteStorage`] or an error.
+    pub fn new<P: AsRef<Path>>(file_path: P) -> Result<Self, error::Error> {
+        // Create or open the SQLite database
+        let mls_connection = Connection::open(&file_path)?;
+
+        // Enable foreign keys
+        mls_connection.execute_batch("PRAGMA foreign_keys = ON;")?;
+
+        // Create OpenMLS storage
+        let mut openmls_storage = openmls_sqlite_storage::SqliteStorageProvider::<
+            JsonCodec,
+            Connection,
+        >::new(mls_connection);
+
+        // Initialize the OpenMLS storage
+        if let Err(e) = openmls_storage.initialize() {
+            return Err(error::Error::OpenMls(e.to_string()));
+        }
+
+        // Create a new connection for the Nostr MLS storage
+        let mut nostr_mls_connection = Connection::open(&file_path)?;
+
+        // Enable foreign keys
+        nostr_mls_connection.execute_batch("PRAGMA foreign_keys = ON;")?;
+
+        // Apply migrations
+        migrations::run_migrations(&mut nostr_mls_connection)?;
+
+        Ok(Self {
+            openmls_storage,
+            db_connection: Arc::new(Mutex::new(nostr_mls_connection)),
+        })
+    }
+
+    /// Creates a new in-memory [`NostrMlsSqliteStorage`] for testing purposes.
+    ///
+    /// # Returns
+    ///
+    /// A Result containing a new in-memory instance of [`NostrMlsSqliteStorage`] or an error.
+    #[cfg(test)]
+    pub fn new_in_memory() -> Result<Self, error::Error> {
+        // Create an in-memory SQLite database
+        let mls_connection = Connection::open_in_memory()?;
+
+        // Enable foreign keys
+        mls_connection.execute_batch("PRAGMA foreign_keys = ON;")?;
+
+        // Create OpenMLS storage
+        let mut openmls_storage = openmls_sqlite_storage::SqliteStorageProvider::<
+            JsonCodec,
+            Connection,
+        >::new(mls_connection);
+
+        // Initialize the OpenMLS storage
+        if let Err(e) = openmls_storage.initialize() {
+            return Err(error::Error::OpenMls(e.to_string()));
+        }
+
+        // For in-memory databases, we need to share the connection
+        // to keep the database alive, so we will clone the connection
+        // and let OpenMLS use a new handle
+        let mut nostr_mls_connection = Connection::open_in_memory()?;
+
+        // Enable foreign keys
+        nostr_mls_connection.execute_batch("PRAGMA foreign_keys = ON;")?;
+
+        // Setup the schema in this connection as well
+        migrations::run_migrations(&mut nostr_mls_connection)?;
+
+        Ok(Self {
+            openmls_storage,
+            db_connection: Arc::new(Mutex::new(nostr_mls_connection)),
+        })
+    }
+}
+
+/// Implementation of [`NostrMlsStorageProvider`] for SQLite-based storage.
+impl NostrMlsStorageProvider for NostrMlsSqliteStorage {
+    type OpenMlsStorageProvider = MlsStorage;
+
+    /// Returns the backend type.
+    ///
+    /// # Returns
+    ///
+    /// [`Backend::SQLite`] indicating this is a SQLite-based storage implementation.
+    fn backend(&self) -> Backend {
+        Backend::SQLite
+    }
+
+    /// Get a reference to the openmls storage provider.
+    ///
+    /// This method provides access to the underlying OpenMLS storage provider.
+    /// This is primarily useful for internal operations and testing.
+    ///
+    /// # Returns
+    ///
+    /// A reference to the openmls storage implementation.
+    fn openmls_storage(&self) -> &Self::OpenMlsStorageProvider {
+        &self.openmls_storage
+    }
+
+    /// Get a mutable reference to the openmls storage provider.
+    ///
+    /// This method provides mutable access to the underlying OpenMLS storage provider.
+    /// This is primarily useful for internal operations and testing.
+    ///
+    /// # Returns
+    ///
+    /// A mutable reference to the openmls storage implementation.
+    fn openmls_storage_mut(&mut self) -> &mut Self::OpenMlsStorageProvider {
+        &mut self.openmls_storage
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn test_new_in_memory() {
+        let storage = NostrMlsSqliteStorage::new_in_memory();
+        assert!(storage.is_ok());
+        let storage = storage.unwrap();
+        assert_eq!(storage.backend(), Backend::SQLite);
+    }
+
+    #[test]
+    fn test_backend_type() {
+        let storage = NostrMlsSqliteStorage::new_in_memory().unwrap();
+        assert_eq!(storage.backend(), Backend::SQLite);
+        assert!(storage.backend().is_persistent());
+    }
+
+    #[test]
+    fn test_file_based_storage() {
+        let temp_dir = tempdir().unwrap();
+        let db_path = temp_dir.path().join("test_db.sqlite");
+
+        // Create a new storage
+        let storage = NostrMlsSqliteStorage::new(&db_path);
+        assert!(storage.is_ok());
+
+        // Verify file exists
+        assert!(db_path.exists());
+
+        // Create a second instance that connects to the same file
+        let storage2 = NostrMlsSqliteStorage::new(&db_path);
+        assert!(storage2.is_ok());
+
+        // Clean up
+        drop(storage);
+        drop(storage2);
+        temp_dir.close().unwrap();
+    }
+
+    #[test]
+    fn test_invalid_path() {
+        let invalid_path = "/nonexistent/directory/db.sqlite";
+        let storage = NostrMlsSqliteStorage::new(invalid_path);
+        assert!(storage.is_err());
+
+        if let Err(err) = storage {
+            match err {
+                error::Error::Rusqlite(_) => {} // Expected error type
+                _ => panic!("Expected Rusqlite error, got {:?}", err),
+            }
+        }
+    }
+
+    #[test]
+    fn test_openmls_storage_access() {
+        let storage = NostrMlsSqliteStorage::new_in_memory().unwrap();
+
+        // Test that we can get a reference to the openmls storage
+        let _openmls_storage = storage.openmls_storage();
+
+        // Test mutable accessor
+        let mut mutable_storage = NostrMlsSqliteStorage::new_in_memory().unwrap();
+        let _mutable_ref = mutable_storage.openmls_storage_mut();
+    }
+
+    #[test]
+    fn test_database_tables() {
+        let temp_dir = tempdir().unwrap();
+        let db_path = temp_dir.path().join("migration_test.sqlite");
+
+        // Create a new SQLite database
+        let storage = NostrMlsSqliteStorage::new(&db_path).unwrap();
+
+        // Verify the database has been properly initialized with migrations
+        {
+            let conn_guard = storage.db_connection.lock().unwrap();
+
+            // Check if the tables exist
+            let mut stmt = conn_guard
+                .prepare("SELECT name FROM sqlite_master WHERE type='table'")
+                .unwrap();
+            let table_names: Vec<String> = stmt
+                .query_map([], |row| row.get(0))
+                .unwrap()
+                .map(|r| r.unwrap())
+                .collect();
+
+            // Check for essential tables
+            assert!(table_names.contains(&"groups".to_string()));
+            assert!(table_names.contains(&"messages".to_string()));
+            assert!(table_names.contains(&"welcomes".to_string()));
+            assert!(table_names.contains(&"processed_messages".to_string()));
+            assert!(table_names.contains(&"processed_welcomes".to_string()));
+            assert!(table_names.contains(&"group_relays".to_string()));
+        } // conn_guard is dropped here when it goes out of scope
+
+        // Drop explicitly to release all resources
+        drop(storage);
+        temp_dir.close().unwrap();
+    }
+}

--- a/crates/nostr-mls-sqlite-storage/src/messages.rs
+++ b/crates/nostr-mls-sqlite-storage/src/messages.rs
@@ -1,0 +1,238 @@
+//! Implementation of MessageStorage trait for SQLite storage.
+
+use nostr::EventId;
+use nostr_mls_storage::messages::error::MessageError;
+use nostr_mls_storage::messages::types::{Message, ProcessedMessage};
+use nostr_mls_storage::messages::MessageStorage;
+use rusqlite::params;
+
+use crate::{db, NostrMlsSqliteStorage};
+
+impl MessageStorage for NostrMlsSqliteStorage {
+    fn save_message(&self, message: Message) -> Result<(), MessageError> {
+        let conn_guard = self.db_connection.lock().map_err(|_| {
+            MessageError::DatabaseError("Failed to acquire database lock".to_string())
+        })?;
+
+        // Serialize complex types to JSON
+        let tags_json = serde_json::to_string(&message.tags)
+            .map_err(|e| MessageError::DatabaseError(format!("Failed to serialize tags: {}", e)))?;
+
+        let event_json = serde_json::to_string(&message.event).map_err(|e| {
+            MessageError::DatabaseError(format!("Failed to serialize event: {}", e))
+        })?;
+
+        conn_guard
+            .execute(
+                "INSERT OR REPLACE INTO messages
+             (id, pubkey, kind, mls_group_id, created_at, content, tags, event, wrapper_event_id)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                params![
+                    &message.id.to_bytes(),
+                    &message.pubkey.to_bytes(),
+                    &message.kind.as_u16(),
+                    &message.mls_group_id,
+                    &message.created_at.as_u64(),
+                    &message.content,
+                    &tags_json,
+                    &event_json,
+                    &message.wrapper_event_id.to_bytes(),
+                ],
+            )
+            .map_err(|e| MessageError::DatabaseError(e.to_string()))?;
+
+        Ok(())
+    }
+
+    fn find_message_by_event_id(
+        &self,
+        event_id: &EventId,
+    ) -> Result<Option<Message>, MessageError> {
+        let conn_guard = self.db_connection.lock().map_err(|_| {
+            MessageError::DatabaseError("Failed to acquire database lock".to_string())
+        })?;
+
+        let mut stmt = conn_guard
+            .prepare("SELECT * FROM messages WHERE id = ?")
+            .map_err(|e| MessageError::DatabaseError(e.to_string()))?;
+
+        let result = stmt.query_row(params![event_id.to_bytes()], db::row_to_message);
+
+        match result {
+            Ok(message) => Ok(Some(message)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(MessageError::DatabaseError(e.to_string())),
+        }
+    }
+
+    fn find_processed_message_by_event_id(
+        &self,
+        event_id: &EventId,
+    ) -> Result<Option<ProcessedMessage>, MessageError> {
+        let conn_guard = self.db_connection.lock().map_err(|_| {
+            MessageError::DatabaseError("Failed to acquire database lock".to_string())
+        })?;
+
+        let mut stmt = conn_guard
+            .prepare("SELECT * FROM processed_messages WHERE wrapper_event_id = ?")
+            .map_err(|e| MessageError::DatabaseError(e.to_string()))?;
+
+        let result = stmt.query_row(params![event_id.to_bytes()], db::row_to_processed_message);
+
+        match result {
+            Ok(message) => Ok(Some(message)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(MessageError::DatabaseError(e.to_string())),
+        }
+    }
+
+    fn save_processed_message(
+        &self,
+        processed_message: ProcessedMessage,
+    ) -> Result<(), MessageError> {
+        let conn_guard = self.db_connection.lock().map_err(|_| {
+            MessageError::DatabaseError("Failed to acquire database lock".to_string())
+        })?;
+
+        // Convert message_event_id to string if it exists
+        let message_event_id = processed_message
+            .message_event_id
+            .as_ref()
+            .map(|id| id.to_bytes());
+
+        let state_str: String = processed_message.state.to_string();
+
+        conn_guard
+            .execute(
+                "INSERT OR REPLACE INTO processed_messages
+             (wrapper_event_id, message_event_id, processed_at, state, failure_reason)
+             VALUES (?, ?, ?, ?, ?)",
+                params![
+                    &processed_message.wrapper_event_id.to_bytes(),
+                    &message_event_id,
+                    &processed_message.processed_at.as_u64(),
+                    &state_str,
+                    &processed_message.failure_reason
+                ],
+            )
+            .map_err(|e| MessageError::DatabaseError(e.to_string()))?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nostr::{EventId, Kind, PublicKey, Tags, Timestamp, UnsignedEvent};
+    use nostr_mls_storage::groups::types::{Group, GroupState, GroupType};
+    use nostr_mls_storage::groups::GroupStorage;
+    use nostr_mls_storage::messages::types::ProcessedMessageState;
+
+    use super::*;
+
+    #[test]
+    fn test_save_and_find_message() {
+        let storage = crate::NostrMlsSqliteStorage::new_in_memory().unwrap();
+
+        // First create a group (messages require a valid group foreign key)
+        let mls_group_id = vec![1, 2, 3, 4];
+        let group = Group {
+            mls_group_id: mls_group_id.clone(),
+            nostr_group_id: "test_group_123".to_string(),
+            name: "Test Group".to_string(),
+            description: "A test group".to_string(),
+            admin_pubkeys: vec![],
+            last_message_id: None,
+            last_message_at: None,
+            group_type: GroupType::Group,
+            epoch: 0,
+            state: GroupState::Active,
+        };
+
+        // Save the group
+        let result = storage.save_group(group);
+        assert!(result.is_ok());
+
+        // Create a test message
+        let event_id =
+            EventId::parse("6a2affe9878ebcf50c10cf74c7b25aad62e0db9fb347f6aafeda30e9f578f260")
+                .unwrap();
+        let pubkey =
+            PublicKey::parse("79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798")
+                .unwrap();
+        let wrapper_event_id =
+            EventId::parse("3287abd422284bc3679812c373c52ed4aa0af4f7c57b9c63ec440f6c3ed6c3a2")
+                .unwrap();
+
+        let message = Message {
+            id: event_id,
+            pubkey,
+            kind: Kind::from(1u16),
+            mls_group_id: mls_group_id.clone(),
+            created_at: Timestamp::now(),
+            content: "Test message content".to_string(),
+            tags: Tags::new(),
+            event: UnsignedEvent::new(
+                pubkey,
+                Timestamp::now(),
+                Kind::from(9u16),
+                vec![],
+                "content".to_string(),
+            ),
+            wrapper_event_id,
+        };
+
+        // Save the message
+        let result = storage.save_message(message.clone());
+        assert!(result.is_ok());
+
+        // Find by event ID
+        let found_message = storage
+            .find_message_by_event_id(&event_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(found_message.id, event_id);
+        assert_eq!(found_message.pubkey, pubkey);
+        assert_eq!(found_message.content, "Test message content");
+    }
+
+    #[test]
+    fn test_processed_message() {
+        let storage = crate::NostrMlsSqliteStorage::new_in_memory().unwrap();
+
+        // Create a test processed message
+        let wrapper_event_id =
+            EventId::parse("3287abd422284bc3679812c373c52ed4aa0af4f7c57b9c63ec440f6c3ed6c3a2")
+                .unwrap();
+        let message_event_id =
+            EventId::parse("6a2affe9878ebcf50c10cf74c7b25aad62e0db9fb347f6aafeda30e9f578f260")
+                .unwrap();
+
+        let processed_message = ProcessedMessage {
+            wrapper_event_id,
+            message_event_id: Some(message_event_id),
+            processed_at: Timestamp::from(1_000_000_000u64),
+            state: ProcessedMessageState::Processed,
+            failure_reason: "".to_string(),
+        };
+
+        // Save the processed message
+        let result = storage.save_processed_message(processed_message.clone());
+        assert!(result.is_ok());
+
+        // Find by event ID
+        let found_processed_message = storage
+            .find_processed_message_by_event_id(&wrapper_event_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(found_processed_message.wrapper_event_id, wrapper_event_id);
+        assert_eq!(
+            found_processed_message.message_event_id.unwrap(),
+            message_event_id
+        );
+        assert_eq!(
+            found_processed_message.state,
+            ProcessedMessageState::Processed
+        );
+    }
+}

--- a/crates/nostr-mls-sqlite-storage/src/migrations.rs
+++ b/crates/nostr-mls-sqlite-storage/src/migrations.rs
@@ -1,0 +1,32 @@
+use rusqlite::Connection;
+
+// Embed the SQL migrations
+refinery::embed_migrations!("migrations");
+
+/// Run database migrations to set up or upgrade the database schema.
+/// We use a custom migration table name to avoid conflicts with migrations from the OpenMls SqliteStorage crate.
+///
+/// # Arguments
+///
+/// * `conn` - The SQLite database connection.
+///
+/// # Returns
+///
+/// Result indicating success or failure of the migration process.
+pub fn run_migrations(conn: &mut Connection) -> Result<(), crate::error::Error> {
+    // Run the migrations
+    let report = migrations::runner()
+        .set_migration_table_name("_refinery_schema_history_nostr_mls")
+        .run(conn)?;
+
+    // Log the results
+    for migration in report.applied_migrations() {
+        tracing::info!(
+            "Applied migration: {} (version: {})",
+            migration.name(),
+            migration.version()
+        );
+    }
+
+    Ok(())
+}

--- a/crates/nostr-mls-sqlite-storage/src/welcomes.rs
+++ b/crates/nostr-mls-sqlite-storage/src/welcomes.rs
@@ -1,0 +1,285 @@
+//! Implementation of WelcomeStorage trait for SQLite storage.
+
+use nostr::EventId;
+use nostr_mls_storage::welcomes::error::WelcomeError;
+use nostr_mls_storage::welcomes::types::{ProcessedWelcome, Welcome};
+use nostr_mls_storage::welcomes::WelcomeStorage;
+use rusqlite::params;
+
+use crate::{db, NostrMlsSqliteStorage};
+
+impl WelcomeStorage for NostrMlsSqliteStorage {
+    fn save_welcome(&self, welcome: Welcome) -> Result<(), WelcomeError> {
+        let conn_guard = self.db_connection.lock().map_err(|_| {
+            WelcomeError::DatabaseError("Failed to acquire database lock".to_string())
+        })?;
+
+        // Serialize complex types to JSON
+        let event_json = serde_json::to_string(&welcome.event).map_err(|e| {
+            WelcomeError::DatabaseError(format!("Failed to serialize event: {}", e))
+        })?;
+
+        let group_admin_pubkeys_json = serde_json::to_string(&welcome.group_admin_pubkeys)
+            .map_err(|e| {
+                WelcomeError::DatabaseError(format!("Failed to serialize admin pubkeys: {}", e))
+            })?;
+
+        let group_relays_json = serde_json::to_string(&welcome.group_relays).map_err(|e| {
+            WelcomeError::DatabaseError(format!("Failed to serialize group relays: {}", e))
+        })?;
+
+        let state_str: String = welcome.state.to_string();
+
+        conn_guard
+            .execute(
+                "INSERT OR REPLACE INTO welcomes
+             (id, event, mls_group_id, nostr_group_id, group_name, group_description,
+              group_admin_pubkeys, group_relays, welcomer, member_count, state, wrapper_event_id)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                params![
+                    &welcome.id.to_bytes(),
+                    &event_json,
+                    &welcome.mls_group_id,
+                    &welcome.nostr_group_id,
+                    &welcome.group_name,
+                    &welcome.group_description,
+                    &group_admin_pubkeys_json,
+                    &group_relays_json,
+                    &welcome.welcomer.to_bytes(),
+                    &(welcome.member_count as i64),
+                    &state_str,
+                    &welcome.wrapper_event_id.to_bytes()
+                ],
+            )
+            .map_err(|e| WelcomeError::DatabaseError(e.to_string()))?;
+
+        Ok(())
+    }
+
+    fn find_welcome_by_event_id(
+        &self,
+        event_id: &EventId,
+    ) -> Result<Option<Welcome>, WelcomeError> {
+        let conn_guard = self.db_connection.lock().map_err(|_| {
+            WelcomeError::DatabaseError("Failed to acquire database lock".to_string())
+        })?;
+
+        let mut stmt = conn_guard
+            .prepare("SELECT * FROM welcomes WHERE id = ?")
+            .map_err(|e| WelcomeError::DatabaseError(e.to_string()))?;
+
+        match stmt.query_row(params![event_id.to_bytes()], db::row_to_welcome) {
+            Ok(welcome) => Ok(Some(welcome)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(WelcomeError::DatabaseError(e.to_string())),
+        }
+    }
+
+    fn pending_welcomes(&self) -> Result<Vec<Welcome>, WelcomeError> {
+        let conn_guard = self.db_connection.lock().map_err(|_| {
+            WelcomeError::DatabaseError("Failed to acquire database lock".to_string())
+        })?;
+
+        let mut stmt = conn_guard
+            .prepare("SELECT * FROM welcomes WHERE state = 'pending'")
+            .map_err(|e| WelcomeError::DatabaseError(e.to_string()))?;
+
+        let welcomes_iter = stmt
+            .query_map([], db::row_to_welcome)
+            .map_err(|e| WelcomeError::DatabaseError(e.to_string()))?;
+
+        let mut welcomes = Vec::new();
+        for welcome_result in welcomes_iter {
+            match welcome_result {
+                Ok(welcome) => welcomes.push(welcome),
+                Err(e) => {
+                    return Err(WelcomeError::DatabaseError(format!(
+                        "Error parsing welcome: {}",
+                        e
+                    )))
+                }
+            }
+        }
+
+        Ok(welcomes)
+    }
+
+    fn save_processed_welcome(
+        &self,
+        processed_welcome: ProcessedWelcome,
+    ) -> Result<(), WelcomeError> {
+        let conn_guard = self.db_connection.lock().map_err(|_| {
+            WelcomeError::DatabaseError("Failed to acquire database lock".to_string())
+        })?;
+
+        // Convert welcome_event_id to string if it exists
+        let welcome_event_id = processed_welcome
+            .welcome_event_id
+            .as_ref()
+            .map(|id| id.to_bytes());
+
+        let state_str: String = processed_welcome.state.to_string();
+
+        conn_guard
+            .execute(
+                "INSERT OR REPLACE INTO processed_welcomes
+             (wrapper_event_id, welcome_event_id, processed_at, state, failure_reason)
+             VALUES (?, ?, ?, ?, ?)",
+                params![
+                    &processed_welcome.wrapper_event_id.to_bytes(),
+                    &welcome_event_id,
+                    &processed_welcome.processed_at.as_u64(),
+                    &state_str,
+                    &processed_welcome.failure_reason
+                ],
+            )
+            .map_err(|e| WelcomeError::DatabaseError(e.to_string()))?;
+
+        Ok(())
+    }
+
+    fn find_processed_welcome_by_event_id(
+        &self,
+        event_id: &EventId,
+    ) -> Result<Option<ProcessedWelcome>, WelcomeError> {
+        let conn_guard = self.db_connection.lock().map_err(|_| {
+            WelcomeError::DatabaseError("Failed to acquire database lock".to_string())
+        })?;
+
+        let mut stmt = conn_guard
+            .prepare("SELECT * FROM processed_welcomes WHERE wrapper_event_id = ?")
+            .map_err(|e| WelcomeError::DatabaseError(e.to_string()))?;
+
+        match stmt.query_row(params![event_id.to_bytes()], db::row_to_processed_welcome) {
+            Ok(welcome) => Ok(Some(welcome)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(WelcomeError::DatabaseError(e.to_string())),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nostr::{EventId, Kind, PublicKey, Timestamp, UnsignedEvent};
+    use nostr_mls_storage::groups::types::{Group, GroupState, GroupType};
+    use nostr_mls_storage::groups::GroupStorage;
+    use nostr_mls_storage::welcomes::types::{ProcessedWelcomeState, WelcomeState};
+
+    use super::*;
+
+    #[test]
+    fn test_save_and_find_welcome() {
+        let storage = crate::NostrMlsSqliteStorage::new_in_memory().unwrap();
+
+        // First create a group (welcomes require a valid group foreign key)
+        let mls_group_id = vec![1, 2, 3, 4];
+        let group = Group {
+            mls_group_id: mls_group_id.clone(),
+            nostr_group_id: "test_group_123".to_string(),
+            name: "Test Group".to_string(),
+            description: "A test group".to_string(),
+            admin_pubkeys: vec![],
+            last_message_id: None,
+            last_message_at: None,
+            group_type: GroupType::Group,
+            epoch: 0,
+            state: GroupState::Active,
+        };
+
+        // Save the group
+        let result = storage.save_group(group);
+        assert!(result.is_ok());
+
+        // Create a test welcome
+        let event_id =
+            EventId::parse("6a2affe9878ebcf50c10cf74c7b25aad62e0db9fb347f6aafeda30e9f578f260")
+                .unwrap();
+        let pubkey =
+            PublicKey::parse("79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798")
+                .unwrap();
+        let wrapper_event_id =
+            EventId::parse("3287abd422284bc3679812c373c52ed4aa0af4f7c57b9c63ec440f6c3ed6c3a2")
+                .unwrap();
+
+        let welcome = Welcome {
+            id: event_id,
+            event: UnsignedEvent::new(
+                pubkey,
+                Timestamp::now(),
+                Kind::MlsWelcome,
+                vec![],
+                "content".to_string(),
+            ),
+            mls_group_id: mls_group_id.clone(),
+            nostr_group_id: "test_group_123".to_string(),
+            group_name: "Test Group".to_string(),
+            group_description: "A test group".to_string(),
+            group_admin_pubkeys: vec![
+                "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798".to_string(),
+            ],
+            group_relays: vec!["wss://relay.example.com".to_string()],
+            welcomer: pubkey,
+            member_count: 3,
+            state: WelcomeState::Pending,
+            wrapper_event_id,
+        };
+
+        // Save the welcome
+        let result = storage.save_welcome(welcome.clone());
+        assert!(result.is_ok());
+
+        // Find by event ID
+        let found_welcome = storage
+            .find_welcome_by_event_id(&event_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(found_welcome.id, event_id);
+        assert_eq!(found_welcome.nostr_group_id, "test_group_123");
+        assert_eq!(found_welcome.state, WelcomeState::Pending);
+
+        // Test pending welcomes
+        let pending_welcomes = storage.pending_welcomes().unwrap();
+        assert_eq!(pending_welcomes.len(), 1);
+        assert_eq!(pending_welcomes[0].id, event_id);
+    }
+
+    #[test]
+    fn test_processed_welcome() {
+        let storage = crate::NostrMlsSqliteStorage::new_in_memory().unwrap();
+
+        // Create a test processed welcome
+        let wrapper_event_id =
+            EventId::parse("6a2affe9878ebcf50c10cf74c7b25aad62e0db9fb347f6aafeda30e9f578f260")
+                .unwrap();
+        let welcome_event_id =
+            EventId::parse("3287abd422284bc3679812c373c52ed4aa0af4f7c57b9c63ec440f6c3ed6c3a2")
+                .unwrap();
+
+        let processed_welcome = ProcessedWelcome {
+            wrapper_event_id,
+            welcome_event_id: Some(welcome_event_id),
+            processed_at: Timestamp::from(1_000_000_000u64),
+            state: ProcessedWelcomeState::Processed,
+            failure_reason: "".to_string(),
+        };
+
+        // Save the processed welcome
+        let result = storage.save_processed_welcome(processed_welcome.clone());
+        assert!(result.is_ok());
+
+        // Find by event ID
+        let found_processed_welcome = storage
+            .find_processed_welcome_by_event_id(&wrapper_event_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(found_processed_welcome.wrapper_event_id, wrapper_event_id);
+        assert_eq!(
+            found_processed_welcome.welcome_event_id.unwrap(),
+            welcome_event_id
+        );
+        assert_eq!(
+            found_processed_welcome.state,
+            ProcessedWelcomeState::Processed
+        );
+    }
+}

--- a/crates/nostr-mls-storage/Cargo.toml
+++ b/crates/nostr-mls-storage/Cargo.toml
@@ -13,6 +13,6 @@ keywords = ["nostr", "mls", "openmls"]
 
 [dependencies]
 nostr = { workspace = true, features = ["std"] }
-openmls_traits = { version = "0.3", default-features = false }
+openmls_traits = { git = "https://github.com/erskingardner/openmls", rev = "88309e1bc79c129628f35c55e838be2d7277c335", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["std"] }


### PR DESCRIPTION
### Description

Adds nostr-mls sqlite storage adpater. 

### Notes to the reviewers

I've had to return to using my fork of the openmls library. I couldn't figure out a better way to use patch to force the linking of the native sqlite library properly - it doesn't seem to function properly with native libs. 

This includes the commit that changes trait method return signatures.

### Checklist

* [x] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [x] I ran `just precommit` or `just check` before committing
* [x] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
