### PR TITLE
docs: add FFI bindings information to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ The project is split up into several crates in the `crates/` directory:
 * Binaries (tools):
     * [**nostr-cli**](./crates/nostr-cli): Nostr CLI
 
+> Note: FFI bindings (Kotlin/Android, JVM, Python, Swift) are maintained in a separate repository at https://github.com/rust-nostr/nostr-sdk-ffi
+
 ### Embedded
 
 **nostr** crate can be used in [`no_std`](https://docs.rust-embedded.org/book/intro/no-std.html) environments.

--- a/contrib/release/RELEASE_STEPS.md
+++ b/contrib/release/RELEASE_STEPS.md
@@ -1,5 +1,7 @@
 # Release Checks
 
+> Note: FFI bindings (Kotlin/Android, JVM, Python, Swift) are maintained in a separate repository at https://github.com/rust-nostr/nostr-sdk-ffi
+
 * Run `just check` to verify that everything compile
 
 * Try to compile `kotlin` bindings (`nostr-sdk-ffi`) since compilation could fail during gradlew due to enumerations names.


### PR DESCRIPTION
### Description

adds FFI bindings information to documentation

### Checklist

* [x] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [x] I ran `just precommit` or `just check` before committing