### PR TITLE
mls-storage: replace `Vec` with `BTreeSet` for admins and relays

### DIFF
--- a/crates/nostr-mls-memory-storage/src/lib.rs
+++ b/crates/nostr-mls-memory-storage/src/lib.rs
@@ -10,6 +10,7 @@
 #![warn(missing_docs)]
 #![warn(rustdoc::bare_urls)]
 
+use std::collections::BTreeSet;
 use std::num::NonZeroUsize;
 
 use lru::LruCache;
@@ -58,7 +59,7 @@ pub struct NostrMlsMemoryStorage {
     /// LRU Cache for Group objects, keyed by Nostr group ID (String)
     groups_by_nostr_id_cache: RwLock<LruCache<String, Group>>,
     /// LRU Cache for GroupRelay objects, keyed by MLS group ID (`Vec<u8>`)
-    group_relays_cache: RwLock<LruCache<Vec<u8>, Vec<GroupRelay>>>,
+    group_relays_cache: RwLock<LruCache<Vec<u8>, BTreeSet<GroupRelay>>>,
     /// LRU Cache for Welcome objects, keyed by Event ID
     welcomes_cache: RwLock<LruCache<EventId, Welcome>>,
     /// LRU Cache for ProcessedWelcome objects, keyed by Event ID
@@ -164,6 +165,8 @@ impl NostrMlsStorageProvider for NostrMlsMemoryStorage {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
+
     use nostr::{EventId, Kind, PublicKey, RelayUrl, Tags, Timestamp, UnsignedEvent};
     use nostr_mls_storage::groups::types::{Group, GroupState, GroupType};
     use nostr_mls_storage::groups::GroupStorage;
@@ -230,7 +233,7 @@ mod tests {
             nostr_group_id: "test_group_123".to_string(),
             name: "Test Group".to_string(),
             description: "A test group".to_string(),
-            admin_pubkeys: vec![],
+            admin_pubkeys: BTreeSet::new(),
             last_message_id: None,
             last_message_at: None,
             group_type: GroupType::Group,
@@ -273,7 +276,7 @@ mod tests {
             nostr_group_id: "test_group_456".to_string(),
             name: "Another Test Group".to_string(),
             description: "Another test group".to_string(),
-            admin_pubkeys: vec![],
+            admin_pubkeys: BTreeSet::new(),
             last_message_id: None,
             last_message_at: None,
             group_type: GroupType::Group,
@@ -358,8 +361,8 @@ mod tests {
             nostr_group_id: "test_welcome_group".to_string(),
             group_name: "Test Welcome Group".to_string(),
             group_description: "A test welcome group".to_string(),
-            group_admin_pubkeys: vec![pubkey.to_hex()],
-            group_relays: vec!["wss://relay.example.com".to_string()],
+            group_admin_pubkeys: BTreeSet::from([pubkey]),
+            group_relays: BTreeSet::from([RelayUrl::parse("wss://relay.example.com").unwrap()]),
             welcomer: pubkey,
             member_count: 2,
             state: WelcomeState::Pending,
@@ -422,7 +425,7 @@ mod tests {
             nostr_group_id: "message_test_group".to_string(),
             name: "Message Test Group".to_string(),
             description: "A group for testing messages".to_string(),
-            admin_pubkeys: vec![],
+            admin_pubkeys: BTreeSet::new(),
             last_message_id: None,
             last_message_at: None,
             group_type: GroupType::Group,
@@ -531,7 +534,7 @@ mod tests {
             nostr_group_id: "custom_cache_group".to_string(),
             name: "Custom Cache Group".to_string(),
             description: "A group for testing custom cache size".to_string(),
-            admin_pubkeys: vec![],
+            admin_pubkeys: BTreeSet::new(),
             last_message_id: None,
             last_message_at: None,
             group_type: GroupType::Group,
@@ -560,7 +563,7 @@ mod tests {
             nostr_group_id: "default_impl_group".to_string(),
             name: "Default Implementation Group".to_string(),
             description: "A group for testing default implementation".to_string(),
-            admin_pubkeys: vec![],
+            admin_pubkeys: BTreeSet::new(),
             last_message_id: None,
             last_message_at: None,
             group_type: GroupType::Group,

--- a/crates/nostr-mls-sqlite-storage/src/db.rs
+++ b/crates/nostr-mls-sqlite-storage/src/db.rs
@@ -1,5 +1,6 @@
 //! Database utilities for SQLite storage.
 
+use std::collections::BTreeSet;
 use std::io::{Error as IoError, ErrorKind};
 use std::str::FromStr;
 
@@ -47,7 +48,7 @@ pub fn row_to_group(row: &Row) -> SqliteResult<Group> {
 
     // Parse admin pubkeys from JSON
     let admin_pubkeys_json: &str = row.get_ref("admin_pubkeys")?.as_str()?;
-    let admin_pubkeys: Vec<PublicKey> =
+    let admin_pubkeys: BTreeSet<PublicKey> =
         serde_json::from_str(admin_pubkeys_json).map_err(map_to_text_boxed_error)?;
 
     let last_message_id: Option<&[u8]> = row.get_ref("last_message_id")?.as_blob_or_null()?;
@@ -195,10 +196,10 @@ pub fn row_to_welcome(row: &Row) -> SqliteResult<Welcome> {
     let event: UnsignedEvent =
         UnsignedEvent::from_json(event_json).map_err(map_to_text_boxed_error)?;
 
-    let group_admin_pubkeys: Vec<String> =
+    let group_admin_pubkeys: BTreeSet<PublicKey> =
         serde_json::from_str(group_admin_pubkeys_json).map_err(map_to_text_boxed_error)?;
 
-    let group_relays: Vec<String> =
+    let group_relays: BTreeSet<RelayUrl> =
         serde_json::from_str(group_relays_json).map_err(map_to_text_boxed_error)?;
 
     let welcomer: PublicKey = PublicKey::from_slice(welcomer_blob)

--- a/crates/nostr-mls-sqlite-storage/src/messages.rs
+++ b/crates/nostr-mls-sqlite-storage/src/messages.rs
@@ -109,6 +109,8 @@ impl MessageStorage for NostrMlsSqliteStorage {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
+
     use nostr::{EventId, Kind, PublicKey, Tags, Timestamp, UnsignedEvent};
     use nostr_mls_storage::groups::types::{Group, GroupState, GroupType};
     use nostr_mls_storage::groups::GroupStorage;
@@ -127,7 +129,7 @@ mod tests {
             nostr_group_id: "test_group_123".to_string(),
             name: "Test Group".to_string(),
             description: "A test group".to_string(),
-            admin_pubkeys: vec![],
+            admin_pubkeys: BTreeSet::new(),
             last_message_id: None,
             last_message_at: None,
             group_type: GroupType::Group,

--- a/crates/nostr-mls-sqlite-storage/src/welcomes.rs
+++ b/crates/nostr-mls-sqlite-storage/src/welcomes.rs
@@ -141,7 +141,9 @@ impl WelcomeStorage for NostrMlsSqliteStorage {
 
 #[cfg(test)]
 mod tests {
-    use nostr::{EventId, Kind, PublicKey, Timestamp, UnsignedEvent};
+    use std::collections::BTreeSet;
+
+    use nostr::{EventId, Kind, PublicKey, RelayUrl, Timestamp, UnsignedEvent};
     use nostr_mls_storage::groups::types::{Group, GroupState, GroupType};
     use nostr_mls_storage::groups::GroupStorage;
     use nostr_mls_storage::welcomes::types::{ProcessedWelcomeState, WelcomeState};
@@ -159,7 +161,7 @@ mod tests {
             nostr_group_id: "test_group_123".to_string(),
             name: "Test Group".to_string(),
             description: "A test group".to_string(),
-            admin_pubkeys: vec![],
+            admin_pubkeys: BTreeSet::new(),
             last_message_id: None,
             last_message_at: None,
             group_type: GroupType::Group,
@@ -195,10 +197,8 @@ mod tests {
             nostr_group_id: "test_group_123".to_string(),
             group_name: "Test Group".to_string(),
             group_description: "A test group".to_string(),
-            group_admin_pubkeys: vec![
-                "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798".to_string(),
-            ],
-            group_relays: vec!["wss://relay.example.com".to_string()],
+            group_admin_pubkeys: BTreeSet::from([pubkey]),
+            group_relays: BTreeSet::from([RelayUrl::parse("wss://relay.example.com").unwrap()]),
             welcomer: pubkey,
             member_count: 3,
             state: WelcomeState::Pending,

--- a/crates/nostr-mls-storage/src/groups/mod.rs
+++ b/crates/nostr-mls-storage/src/groups/mod.rs
@@ -7,6 +7,8 @@
 //!
 //! Here we also define the storage traits that are used to store and retrieve groups
 
+use std::collections::BTreeSet;
+
 use nostr::PublicKey;
 
 pub mod error;
@@ -37,10 +39,10 @@ pub trait GroupStorage {
     fn messages(&self, mls_group_id: &[u8]) -> Result<Vec<Message>, GroupError>;
 
     /// Get all admins for a group
-    fn admins(&self, mls_group_id: &[u8]) -> Result<Vec<PublicKey>, GroupError>;
+    fn admins(&self, mls_group_id: &[u8]) -> Result<BTreeSet<PublicKey>, GroupError>;
 
     /// Get all relays for a group
-    fn group_relays(&self, mls_group_id: &[u8]) -> Result<Vec<GroupRelay>, GroupError>;
+    fn group_relays(&self, mls_group_id: &[u8]) -> Result<BTreeSet<GroupRelay>, GroupError>;
 
     /// Save a group relay
     fn save_group_relay(&self, group_relay: GroupRelay) -> Result<(), GroupError>;

--- a/crates/nostr-mls-storage/src/groups/types.rs
+++ b/crates/nostr-mls-storage/src/groups/types.rs
@@ -1,5 +1,6 @@
 //! Types for the groups module
 
+use std::collections::BTreeSet;
 use std::fmt;
 use std::str::FromStr;
 
@@ -140,7 +141,7 @@ pub struct Group {
     /// UTF-8 encoded (same value as the NostrGroupDataExtension)
     pub description: String,
     /// Hex encoded (same value as the NostrGroupDataExtension)
-    pub admin_pubkeys: Vec<PublicKey>,
+    pub admin_pubkeys: BTreeSet<PublicKey>,
     /// Hex encoded Nostr event ID of the last message in the group
     pub last_message_id: Option<EventId>,
     /// Timestamp of the last message in the group
@@ -268,7 +269,7 @@ mod tests {
             nostr_group_id: "test_id".to_string(),
             name: "Test Group".to_string(),
             description: "Test Description".to_string(),
-            admin_pubkeys: Vec::new(),
+            admin_pubkeys: BTreeSet::new(),
             last_message_id: None,
             last_message_at: None,
             group_type: GroupType::Group,

--- a/crates/nostr-mls-storage/src/welcomes/types.rs
+++ b/crates/nostr-mls-storage/src/welcomes/types.rs
@@ -1,9 +1,10 @@
 //! Types for the welcomes module
 
+use std::collections::BTreeSet;
 use std::fmt;
 use std::str::FromStr;
 
-use nostr::{EventId, PublicKey, Timestamp, UnsignedEvent};
+use nostr::{EventId, PublicKey, RelayUrl, Timestamp, UnsignedEvent};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use super::error::WelcomeError;
@@ -39,9 +40,9 @@ pub struct Welcome {
     /// Group description (from NostrGroupDataExtension)
     pub group_description: String,
     /// Group admin pubkeys (from NostrGroupDataExtension)
-    pub group_admin_pubkeys: Vec<String>,
+    pub group_admin_pubkeys: BTreeSet<PublicKey>,
     /// Group relays (from NostrGroupDataExtension)
-    pub group_relays: Vec<String>,
+    pub group_relays: BTreeSet<RelayUrl>,
     /// Pubkey of the user that sent the welcome
     pub welcomer: PublicKey,
     /// Member count of the group


### PR DESCRIPTION
Use a `BTreeSet` instead of a `Vec` for storing admin public keys and relay URLs.
This ensures unique elements, faster lookups and sorted results.