### PR TITLE
Use `GroupId` for `mls_group_ids` and `&[u8; 32]` for `nostr_group_ids`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2913,6 +2913,7 @@ dependencies = [
  "lru",
  "nostr",
  "nostr-mls-storage",
+ "openmls",
  "openmls_memory_storage",
  "parking_lot",
 ]
@@ -2923,6 +2924,7 @@ version = "0.41.0"
 dependencies = [
  "nostr",
  "nostr-mls-storage",
+ "openmls",
  "openmls_sqlite_storage",
  "refinery",
  "rusqlite",
@@ -2937,6 +2939,7 @@ name = "nostr-mls-storage"
 version = "0.41.0"
 dependencies = [
  "nostr",
+ "openmls",
  "openmls_traits",
  "serde",
  "serde_json",

--- a/crates/nostr-mls-memory-storage/Cargo.toml
+++ b/crates/nostr-mls-memory-storage/Cargo.toml
@@ -15,5 +15,6 @@ keywords = ["nostr", "mls", "openmls", "memory"]
 lru.workspace = true
 nostr = { workspace = true, features = ["std"] }
 nostr-mls-storage.workspace = true
+openmls = { git = "https://github.com/openmls/openmls", rev = "4cc0f594b11262083ad9827b3b2033052c6ef99f", default-features = false }
 openmls_memory_storage = { git = "https://github.com/openmls/openmls", rev = "4cc0f594b11262083ad9827b3b2033052c6ef99f", default-features = false }
 parking_lot = "0.12"

--- a/crates/nostr-mls-memory-storage/src/groups.rs
+++ b/crates/nostr-mls-memory-storage/src/groups.rs
@@ -7,17 +7,9 @@ use nostr_mls_storage::groups::error::{GroupError, InvalidGroupState};
 use nostr_mls_storage::groups::types::*;
 use nostr_mls_storage::groups::GroupStorage;
 use nostr_mls_storage::messages::types::Message;
+use openmls::group::GroupId;
 
 use crate::NostrMlsMemoryStorage;
-
-/// Creates a compound key from an MLS group ID and epoch
-///
-/// The key is created by concatenating the MLS group ID and the epoch as bytes
-fn create_compound_key(mls_group_id: &[u8], epoch: u64) -> Vec<u8> {
-    let mut key = mls_group_id.to_vec();
-    key.extend_from_slice(&epoch.to_be_bytes());
-    key
-}
 
 impl GroupStorage for NostrMlsMemoryStorage {
     fn save_group(&self, group: Group) -> Result<(), GroupError> {
@@ -30,7 +22,7 @@ impl GroupStorage for NostrMlsMemoryStorage {
         // Store in the Nostr group ID cache
         {
             let mut cache = self.groups_by_nostr_id_cache.write();
-            cache.put(group.nostr_group_id.clone(), group);
+            cache.put(group.nostr_group_id, group);
         }
 
         Ok(())
@@ -43,20 +35,23 @@ impl GroupStorage for NostrMlsMemoryStorage {
         Ok(groups)
     }
 
-    fn find_group_by_mls_group_id(&self, mls_group_id: &[u8]) -> Result<Option<Group>, GroupError> {
+    fn find_group_by_mls_group_id(
+        &self,
+        mls_group_id: &GroupId,
+    ) -> Result<Option<Group>, GroupError> {
         let cache = self.groups_cache.read();
         Ok(cache.peek(mls_group_id).cloned())
     }
 
     fn find_group_by_nostr_group_id(
         &self,
-        nostr_group_id: &str,
+        nostr_group_id: &[u8; 32],
     ) -> Result<Option<Group>, GroupError> {
         let cache = self.groups_by_nostr_id_cache.read();
         Ok(cache.peek(nostr_group_id).cloned())
     }
 
-    fn messages(&self, mls_group_id: &[u8]) -> Result<Vec<Message>, GroupError> {
+    fn messages(&self, mls_group_id: &GroupId) -> Result<Vec<Message>, GroupError> {
         // Check if the group exists first
         self.find_group_by_mls_group_id(mls_group_id)?;
 
@@ -68,14 +63,14 @@ impl GroupStorage for NostrMlsMemoryStorage {
         }
     }
 
-    fn admins(&self, mls_group_id: &[u8]) -> Result<BTreeSet<PublicKey>, GroupError> {
+    fn admins(&self, mls_group_id: &GroupId) -> Result<BTreeSet<PublicKey>, GroupError> {
         match self.find_group_by_mls_group_id(mls_group_id)? {
             Some(group) => Ok(group.admin_pubkeys),
             None => Err(GroupError::InvalidState(InvalidGroupState::NoAdmins)),
         }
     }
 
-    fn group_relays(&self, mls_group_id: &[u8]) -> Result<BTreeSet<GroupRelay>, GroupError> {
+    fn group_relays(&self, mls_group_id: &GroupId) -> Result<BTreeSet<GroupRelay>, GroupError> {
         // Check if the group exists first
         self.find_group_by_mls_group_id(mls_group_id)?;
 
@@ -114,16 +109,15 @@ impl GroupStorage for NostrMlsMemoryStorage {
 
     fn get_group_exporter_secret(
         &self,
-        mls_group_id: &[u8],
+        mls_group_id: &GroupId,
         epoch: u64,
     ) -> Result<Option<GroupExporterSecret>, GroupError> {
         // Check if the group exists first
         self.find_group_by_mls_group_id(mls_group_id)?;
 
         let cache = self.group_exporter_secrets_cache.read();
-        // Create a compound key from mls_group_id and epoch
-        let key = create_compound_key(mls_group_id, epoch);
-        Ok(cache.peek(&key).cloned())
+        // Use tuple (GroupId, epoch) as key
+        Ok(cache.peek(&(mls_group_id.clone(), epoch)).cloned())
     }
 
     fn save_group_exporter_secret(
@@ -134,9 +128,9 @@ impl GroupStorage for NostrMlsMemoryStorage {
         self.find_group_by_mls_group_id(&group_exporter_secret.mls_group_id)?;
 
         let mut cache = self.group_exporter_secrets_cache.write();
-        // Create a compound key from mls_group_id and epoch
-        let key = create_compound_key(
-            &group_exporter_secret.mls_group_id,
+        // Use tuple (GroupId, epoch) as key
+        let key = (
+            group_exporter_secret.mls_group_id.clone(),
             group_exporter_secret.epoch,
         );
         cache.put(key, group_exporter_secret);

--- a/crates/nostr-mls-sqlite-storage/Cargo.toml
+++ b/crates/nostr-mls-sqlite-storage/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["nostr", "mls", "openmls", "sqlite"]
 [dependencies]
 nostr = { workspace = true, features = ["std"] }
 nostr-mls-storage.workspace = true
+openmls = { git = "https://github.com/openmls/openmls", rev = "4cc0f594b11262083ad9827b3b2033052c6ef99f", default-features = false }
 openmls_sqlite_storage = { git = "https://github.com/openmls/openmls", rev = "4cc0f594b11262083ad9827b3b2033052c6ef99f", default-features = false }
 refinery = { version = "0.8", features = ["rusqlite"] } # MSRV is 1.75.0
 rusqlite = { version = "0.32", features = ["bundled"] }

--- a/crates/nostr-mls-sqlite-storage/src/db.rs
+++ b/crates/nostr-mls-sqlite-storage/src/db.rs
@@ -14,6 +14,7 @@ use nostr_mls_storage::messages::types::{
 use nostr_mls_storage::welcomes::types::{
     ProcessedWelcome, ProcessedWelcomeState, Welcome, WelcomeState,
 };
+use openmls::group::GroupId;
 use rusqlite::types::Type;
 use rusqlite::{Error, Result as SqliteResult, Row};
 
@@ -45,8 +46,8 @@ fn map_invalid_blob_data(msg: &str) -> Error {
 
 /// Convert a row to a Group struct
 pub fn row_to_group(row: &Row) -> SqliteResult<Group> {
-    let mls_group_id: Vec<u8> = row.get("mls_group_id")?;
-    let nostr_group_id: String = row.get("nostr_group_id")?;
+    let mls_group_id: GroupId = GroupId::from_slice(row.get_ref("mls_group_id")?.as_blob()?);
+    let nostr_group_id: [u8; 32] = row.get("nostr_group_id")?;
     let name: String = row.get("name")?;
     let description: String = row.get("description")?;
 
@@ -88,7 +89,7 @@ pub fn row_to_group(row: &Row) -> SqliteResult<Group> {
 
 /// Convert a row to a GroupRelay struct
 pub fn row_to_group_relay(row: &Row) -> SqliteResult<GroupRelay> {
-    let mls_group_id: Vec<u8> = row.get("mls_group_id")?;
+    let mls_group_id: GroupId = GroupId::from_slice(row.get_ref("mls_group_id")?.as_blob()?);
     let relay_url: &str = row.get_ref("relay_url")?.as_str()?;
 
     // Parse relay URL
@@ -103,7 +104,7 @@ pub fn row_to_group_relay(row: &Row) -> SqliteResult<GroupRelay> {
 
 /// Convert a row to a GroupExporterSecret struct
 pub fn row_to_group_exporter_secret(row: &Row) -> SqliteResult<GroupExporterSecret> {
-    let mls_group_id: Vec<u8> = row.get("mls_group_id")?;
+    let mls_group_id: GroupId = GroupId::from_slice(row.get_ref("mls_group_id")?.as_blob()?);
     let epoch: u64 = row.get("epoch")?;
     let secret: Vec<u8> = row.get("secret")?;
 
@@ -119,7 +120,7 @@ pub fn row_to_message(row: &Row) -> SqliteResult<Message> {
     let id_blob: &[u8] = row.get_ref("id")?.as_blob()?;
     let pubkey_blob: &[u8] = row.get_ref("pubkey")?.as_blob()?;
     let kind_value: u16 = row.get("kind")?;
-    let mls_group_id: Vec<u8> = row.get("mls_group_id")?;
+    let mls_group_id: GroupId = GroupId::from_slice(row.get_ref("mls_group_id")?.as_blob()?);
     let created_at_value: u64 = row.get("created_at")?;
     let content: String = row.get("content")?;
     let tags_json: &str = row.get_ref("tags")?.as_str()?;
@@ -200,8 +201,8 @@ pub fn row_to_processed_message(row: &Row) -> SqliteResult<ProcessedMessage> {
 pub fn row_to_welcome(row: &Row) -> SqliteResult<Welcome> {
     let id_blob: &[u8] = row.get_ref("id")?.as_blob()?;
     let event_json: &str = row.get_ref("event")?.as_str()?;
-    let mls_group_id: Vec<u8> = row.get("mls_group_id")?;
-    let nostr_group_id: String = row.get("nostr_group_id")?;
+    let mls_group_id: GroupId = GroupId::from_slice(row.get_ref("mls_group_id")?.as_blob()?);
+    let nostr_group_id: [u8; 32] = row.get("nostr_group_id")?;
     let group_name: String = row.get("group_name")?;
     let group_description: String = row.get("group_description")?;
     let group_admin_pubkeys_json: &str = row.get_ref("group_admin_pubkeys")?.as_str()?;

--- a/crates/nostr-mls-sqlite-storage/src/lib.rs
+++ b/crates/nostr-mls-sqlite-storage/src/lib.rs
@@ -184,6 +184,7 @@ impl NostrMlsStorageProvider for NostrMlsSqliteStorage {
 mod tests {
     use std::collections::BTreeSet;
 
+    use openmls::group::GroupId;
     use tempfile::tempdir;
 
     use super::*;
@@ -297,10 +298,10 @@ mod tests {
         let storage = NostrMlsSqliteStorage::new_in_memory().unwrap();
 
         // Create a test group
-        let mls_group_id = vec![1, 2, 3, 4];
+        let mls_group_id = GroupId::from_slice(vec![1, 2, 3, 4].as_slice());
         let group = Group {
             mls_group_id: mls_group_id.clone(),
-            nostr_group_id: "test_group_123".to_string(),
+            nostr_group_id: [0u8; 32],
             name: "Test Group".to_string(),
             description: "A test group for exporter secrets".to_string(),
             admin_pubkeys: BTreeSet::new(),
@@ -353,7 +354,7 @@ mod tests {
         assert!(non_existent_epoch.is_none());
 
         // Test non-existent group
-        let non_existent_group_id = vec![9, 9, 9, 9];
+        let non_existent_group_id = GroupId::from_slice(&[9, 9, 9, 9]);
         let result = storage.get_group_exporter_secret(&non_existent_group_id, 0);
         assert!(result.is_err());
 

--- a/crates/nostr-mls-sqlite-storage/src/messages.rs
+++ b/crates/nostr-mls-sqlite-storage/src/messages.rs
@@ -33,7 +33,7 @@ impl MessageStorage for NostrMlsSqliteStorage {
                     message.id.as_bytes(),
                     message.pubkey.as_bytes(),
                     message.kind.as_u16(),
-                    message.mls_group_id,
+                    message.mls_group_id.as_slice(),
                     message.created_at.as_u64(),
                     message.content,
                     tags_json,
@@ -116,6 +116,7 @@ mod tests {
     use nostr_mls_storage::groups::types::{Group, GroupState, GroupType};
     use nostr_mls_storage::groups::GroupStorage;
     use nostr_mls_storage::messages::types::{MessageState, ProcessedMessageState};
+    use openmls::group::GroupId;
 
     use super::*;
 
@@ -124,10 +125,13 @@ mod tests {
         let storage = NostrMlsSqliteStorage::new_in_memory().unwrap();
 
         // First create a group (messages require a valid group foreign key)
-        let mls_group_id = vec![1, 2, 3, 4];
+        let mls_group_id = GroupId::from_slice(&[1, 2, 3, 4]);
+        let mut nostr_group_id = [0u8; 32];
+        nostr_group_id[0..13].copy_from_slice(b"test_group_12");
+
         let group = Group {
             mls_group_id: mls_group_id.clone(),
-            nostr_group_id: "test_group_123".to_string(),
+            nostr_group_id,
             name: "Test Group".to_string(),
             description: "A test group".to_string(),
             admin_pubkeys: BTreeSet::new(),

--- a/crates/nostr-mls-storage/Cargo.toml
+++ b/crates/nostr-mls-storage/Cargo.toml
@@ -13,6 +13,7 @@ keywords = ["nostr", "mls", "openmls"]
 
 [dependencies]
 nostr = { workspace = true, features = ["std"] }
+openmls = { git = "https://github.com/openmls/openmls", rev = "4cc0f594b11262083ad9827b3b2033052c6ef99f", default-features = false }
 openmls_traits = { git = "https://github.com/openmls/openmls", rev = "4cc0f594b11262083ad9827b3b2033052c6ef99f", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["std"] }

--- a/crates/nostr-mls-storage/src/groups/mod.rs
+++ b/crates/nostr-mls-storage/src/groups/mod.rs
@@ -10,6 +10,7 @@
 use std::collections::BTreeSet;
 
 use nostr::PublicKey;
+use openmls::group::GroupId;
 
 pub mod error;
 pub mod types;
@@ -24,25 +25,25 @@ pub trait GroupStorage {
     fn all_groups(&self) -> Result<Vec<Group>, GroupError>;
 
     /// Find a group by MLS group ID
-    fn find_group_by_mls_group_id(&self, mls_group_id: &[u8]) -> Result<Option<Group>, GroupError>;
+    fn find_group_by_mls_group_id(&self, group_id: &GroupId) -> Result<Option<Group>, GroupError>;
 
     /// Find a group by Nostr group ID
     fn find_group_by_nostr_group_id(
         &self,
-        nostr_group_id: &str,
+        nostr_group_id: &[u8; 32],
     ) -> Result<Option<Group>, GroupError>;
 
     /// Save a group
     fn save_group(&self, group: Group) -> Result<(), GroupError>;
 
     /// Get all messages for a group
-    fn messages(&self, mls_group_id: &[u8]) -> Result<Vec<Message>, GroupError>;
+    fn messages(&self, group_id: &GroupId) -> Result<Vec<Message>, GroupError>;
 
     /// Get all admins for a group
-    fn admins(&self, mls_group_id: &[u8]) -> Result<BTreeSet<PublicKey>, GroupError>;
+    fn admins(&self, group_id: &GroupId) -> Result<BTreeSet<PublicKey>, GroupError>;
 
     /// Get all relays for a group
-    fn group_relays(&self, mls_group_id: &[u8]) -> Result<BTreeSet<GroupRelay>, GroupError>;
+    fn group_relays(&self, group_id: &GroupId) -> Result<BTreeSet<GroupRelay>, GroupError>;
 
     /// Save a group relay
     fn save_group_relay(&self, group_relay: GroupRelay) -> Result<(), GroupError>;
@@ -50,7 +51,7 @@ pub trait GroupStorage {
     /// Get an exporter secret for a group and epoch
     fn get_group_exporter_secret(
         &self,
-        mls_group_id: &[u8],
+        group_id: &GroupId,
         epoch: u64,
     ) -> Result<Option<GroupExporterSecret>, GroupError>;
 

--- a/crates/nostr-mls-storage/src/messages/types.rs
+++ b/crates/nostr-mls-storage/src/messages/types.rs
@@ -5,6 +5,7 @@ use std::str::FromStr;
 
 use nostr::event::Kind;
 use nostr::{EventId, PublicKey, Tags, Timestamp, UnsignedEvent};
+use openmls::group::GroupId;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use super::error::MessageError;
@@ -35,7 +36,7 @@ pub struct Message {
     /// The kind of the message
     pub kind: Kind,
     /// The MLS group id of the message
-    pub mls_group_id: Vec<u8>,
+    pub mls_group_id: GroupId,
     /// The created at timestamp of the message
     pub created_at: Timestamp,
     /// The content of the message
@@ -254,9 +255,9 @@ mod tests {
                 .unwrap();
         let message = Message {
             id: EventId::all_zeros(),
-            pubkey: pubkey.clone(),
+            pubkey,
             kind: Kind::MlsGroupMessage,
-            mls_group_id: vec![1, 2, 3, 4],
+            mls_group_id: GroupId::from_slice(&[1, 2, 3, 4]),
             created_at: Timestamp::now(),
             content: "Test message".to_string(),
             tags: Tags::new(),

--- a/crates/nostr-mls-storage/src/welcomes/types.rs
+++ b/crates/nostr-mls-storage/src/welcomes/types.rs
@@ -5,6 +5,7 @@ use std::fmt;
 use std::str::FromStr;
 
 use nostr::{EventId, PublicKey, RelayUrl, Timestamp, UnsignedEvent};
+use openmls::group::GroupId;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use super::error::WelcomeError;
@@ -32,9 +33,9 @@ pub struct Welcome {
     /// The event that contains the welcome message
     pub event: UnsignedEvent,
     /// MLS group id
-    pub mls_group_id: Vec<u8>,
+    pub mls_group_id: GroupId,
     /// Nostr group id (from NostrGroupDataExtension)
-    pub nostr_group_id: String,
+    pub nostr_group_id: [u8; 32],
     /// Group name (from NostrGroupDataExtension)
     pub group_name: String,
     /// Group description (from NostrGroupDataExtension)

--- a/crates/nostr-mls/src/messages.rs
+++ b/crates/nostr-mls/src/messages.rs
@@ -11,6 +11,7 @@
 //! The message content is encrypted using both MLS group keys and NIP-44 encryption.
 //! Message state is tracked to handle processing status and failure scenarios.
 
+use nostr::util::hex;
 use nostr::{EventId, UnsignedEvent};
 use nostr_mls_storage::NostrMlsStorageProvider;
 use openmls::group::{GroupId, ValidationError};
@@ -63,7 +64,7 @@ where
         mls_group_id: &GroupId,
     ) -> Result<Vec<message_types::Message>, Error> {
         self.storage()
-            .messages(mls_group_id.as_slice())
+            .messages(mls_group_id)
             .map_err(|e| Error::Message(e.to_string()))
     }
 
@@ -159,7 +160,7 @@ where
         // Generate ephemeral key
         let ephemeral_nostr_keys: Keys = Keys::generate();
 
-        let tag: Tag = Tag::custom(TagKind::h(), [group.nostr_group_id]);
+        let tag: Tag = Tag::custom(TagKind::h(), [hex::encode(group.nostr_group_id)]);
         let event = EventBuilder::new(Kind::MlsGroupMessage, encrypted_content)
             .tag(tag)
             .sign_with_keys(&ephemeral_nostr_keys)?;
@@ -169,7 +170,7 @@ where
             id: rumor.id.unwrap(),
             pubkey: rumor.pubkey,
             kind: rumor.kind,
-            mls_group_id: mls_group_id.as_slice().to_vec(),
+            mls_group_id: mls_group_id.clone(),
             created_at: rumor.created_at,
             content: rumor.content.clone(),
             tags: rumor.tags.clone(),
@@ -344,7 +345,7 @@ where
                     id: rumor.id.unwrap(),
                     pubkey: rumor.pubkey,
                     kind: rumor.kind,
-                    mls_group_id: mls_group_id.as_slice().to_vec(),
+                    mls_group_id: mls_group_id.clone(),
                     created_at: rumor.created_at,
                     content: rumor.content.clone(),
                     tags: rumor.tags.clone(),

--- a/crates/nostr-mls/src/welcomes.rs
+++ b/crates/nostr-mls/src/welcomes.rs
@@ -71,8 +71,8 @@ where
                 .staged_welcome
                 .group_context()
                 .group_id()
-                .to_vec(),
-            nostr_group_id: welcome_preview.nostr_group_data.nostr_group_id(),
+                .clone(),
+            nostr_group_id: welcome_preview.nostr_group_data.nostr_group_id,
             name: welcome_preview.nostr_group_data.name.clone(),
             description: welcome_preview.nostr_group_data.description.clone(),
             admin_pubkeys: welcome_preview.nostr_group_data.admins.clone(),
@@ -111,8 +111,8 @@ where
                 .staged_welcome
                 .group_context()
                 .group_id()
-                .to_vec(),
-            nostr_group_id: welcome_preview.nostr_group_data.nostr_group_id(),
+                .clone(),
+            nostr_group_id: welcome_preview.nostr_group_data.nostr_group_id,
             group_name: welcome_preview.nostr_group_data.name,
             group_description: welcome_preview.nostr_group_data.description,
             group_admin_pubkeys: welcome_preview.nostr_group_data.admins,


### PR DESCRIPTION
### Description

- Updates all the mls crates to use `GroupId` values for the mls_group_ids in all types and method signatures.
- Updates all `nostr_group_id` values to use `&[u8; 32]` values instead of a mix of strings and byte arrays.

### Checklist

* [x] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [x] I ran `just precommit` or `just check` before committing
* [x] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
