### PR TITLE
More mls methods

### DIFF
--- a/crates/nostr-mls-memory-storage/src/lib.rs
+++ b/crates/nostr-mls-memory-storage/src/lib.rs
@@ -350,12 +350,12 @@ mod tests {
         let group_exporter_secret_0 = GroupExporterSecret {
             mls_group_id: mls_group_id.clone(),
             epoch: 0,
-            secret: vec![1, 2, 3, 4],
+            secret: [0u8; 32],
         };
         let group_exporter_secret_1 = GroupExporterSecret {
             mls_group_id: mls_group_id.clone(),
             epoch: 1,
-            secret: vec![5, 6, 7, 8],
+            secret: [0u8; 32],
         };
         nostr_storage
             .save_group_exporter_secret(group_exporter_secret_0.clone())

--- a/crates/nostr-mls-sqlite-storage/src/db.rs
+++ b/crates/nostr-mls-sqlite-storage/src/db.rs
@@ -106,7 +106,7 @@ pub fn row_to_group_relay(row: &Row) -> SqliteResult<GroupRelay> {
 pub fn row_to_group_exporter_secret(row: &Row) -> SqliteResult<GroupExporterSecret> {
     let mls_group_id: GroupId = GroupId::from_slice(row.get_ref("mls_group_id")?.as_blob()?);
     let epoch: u64 = row.get("epoch")?;
-    let secret: Vec<u8> = row.get("secret")?;
+    let secret: [u8; 32] = row.get("secret")?;
 
     Ok(GroupExporterSecret {
         mls_group_id,

--- a/crates/nostr-mls-sqlite-storage/src/error.rs
+++ b/crates/nostr-mls-sqlite-storage/src/error.rs
@@ -40,6 +40,12 @@ impl From<refinery::Error> for Error {
     }
 }
 
+impl From<std::io::Error> for Error {
+    fn from(e: std::io::Error) -> Self {
+        Self::Database(format!("IO error: {}", e))
+    }
+}
+
 impl From<Error> for rusqlite::Error {
     fn from(err: Error) -> Self {
         rusqlite::Error::FromSqlConversionFailure(

--- a/crates/nostr-mls-sqlite-storage/src/groups.rs
+++ b/crates/nostr-mls-sqlite-storage/src/groups.rs
@@ -385,7 +385,7 @@ mod tests {
         let secret1 = GroupExporterSecret {
             mls_group_id: mls_group_id.clone(),
             epoch: 1,
-            secret: vec![5, 6, 7, 8],
+            secret: [0u8; 32],
         };
 
         // Save the secret
@@ -396,13 +396,13 @@ mod tests {
             .get_group_exporter_secret(&mls_group_id, 1)
             .unwrap()
             .unwrap();
-        assert_eq!(retrieved_secret.secret, vec![5, 6, 7, 8]);
+        assert_eq!(retrieved_secret.secret, [0u8; 32]);
 
         // Create a second secret with same group_id and epoch but different secret value
         let secret2 = GroupExporterSecret {
             mls_group_id: mls_group_id.clone(),
             epoch: 1,
-            secret: vec![9, 10, 11, 12],
+            secret: [0u8; 32],
         };
 
         // Save the second secret - this should replace the first one due to the "OR REPLACE" in the SQL
@@ -413,13 +413,13 @@ mod tests {
             .get_group_exporter_secret(&mls_group_id, 1)
             .unwrap()
             .unwrap();
-        assert_eq!(retrieved_secret.secret, vec![9, 10, 11, 12]);
+        assert_eq!(retrieved_secret.secret, [0u8; 32]);
 
         // Verify we can still save a different epoch
         let secret3 = GroupExporterSecret {
             mls_group_id: mls_group_id.clone(),
             epoch: 2,
-            secret: vec![13, 14, 15, 16],
+            secret: [0u8; 32],
         };
 
         storage.save_group_exporter_secret(secret3).unwrap();
@@ -434,7 +434,7 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        assert_eq!(retrieved_secret1.secret, vec![9, 10, 11, 12]);
-        assert_eq!(retrieved_secret2.secret, vec![13, 14, 15, 16]);
+        assert_eq!(retrieved_secret1.secret, [0u8; 32]);
+        assert_eq!(retrieved_secret2.secret, [0u8; 32]);
     }
 }

--- a/crates/nostr-mls-sqlite-storage/src/lib.rs
+++ b/crates/nostr-mls-sqlite-storage/src/lib.rs
@@ -78,6 +78,11 @@ impl NostrMlsSqliteStorage {
     where
         P: AsRef<Path>,
     {
+        // Ensure parent directory exists
+        if let Some(parent) = file_path.as_ref().parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
         // Create or open the SQLite database
         let mls_connection: Connection = Connection::open(&file_path)?;
 
@@ -224,20 +229,6 @@ mod tests {
         drop(storage);
         drop(storage2);
         temp_dir.close().unwrap();
-    }
-
-    #[test]
-    fn test_invalid_path() {
-        let invalid_path = "/nonexistent/directory/db.sqlite";
-        let storage = NostrMlsSqliteStorage::new(invalid_path);
-        assert!(storage.is_err());
-
-        if let Err(err) = storage {
-            match err {
-                Error::Rusqlite(_) => {} // Expected error type
-                _ => panic!("Expected Rusqlite error, got {:?}", err),
-            }
-        }
     }
 
     #[test]

--- a/crates/nostr-mls-sqlite-storage/src/lib.rs
+++ b/crates/nostr-mls-sqlite-storage/src/lib.rs
@@ -319,13 +319,13 @@ mod tests {
         let secret_epoch_0 = GroupExporterSecret {
             mls_group_id: mls_group_id.clone(),
             epoch: 0,
-            secret: vec![1, 2, 3, 4],
+            secret: [0u8; 32],
         };
 
         let secret_epoch_1 = GroupExporterSecret {
             mls_group_id: mls_group_id.clone(),
             epoch: 1,
-            secret: vec![5, 6, 7, 8],
+            secret: [0u8; 32],
         };
 
         // Save the exporter secrets
@@ -362,7 +362,7 @@ mod tests {
         let updated_secret_0 = GroupExporterSecret {
             mls_group_id: mls_group_id.clone(),
             epoch: 0,
-            secret: vec![9, 10, 11, 12],
+            secret: [0u8; 32],
         };
         storage
             .save_group_exporter_secret(updated_secret_0.clone())
@@ -378,7 +378,7 @@ mod tests {
         let invalid_secret = GroupExporterSecret {
             mls_group_id: non_existent_group_id.clone(),
             epoch: 0,
-            secret: vec![1, 2, 3, 4],
+            secret: [0u8; 32],
         };
         let result = storage.save_group_exporter_secret(invalid_secret);
         assert!(result.is_err());

--- a/crates/nostr-mls-storage/src/groups/types.rs
+++ b/crates/nostr-mls-storage/src/groups/types.rs
@@ -178,7 +178,7 @@ pub struct GroupExporterSecret {
     /// The epoch
     pub epoch: u64,
     /// The secret
-    pub secret: Vec<u8>,
+    pub secret: [u8; 32],
 }
 
 #[cfg(test)]
@@ -311,27 +311,33 @@ mod tests {
     #[test]
     fn test_group_exporter_secret_serialization() {
         let secret = GroupExporterSecret {
-            mls_group_id: GroupId::from_slice(vec![1, 2, 3].as_slice()),
+            mls_group_id: GroupId::from_slice(&[1, 2, 3]),
             epoch: 42,
-            secret: vec![4, 5, 6],
+            secret: [0u8; 32],
         };
 
         let serialized = serde_json::to_value(&secret).unwrap();
         assert_eq!(serialized["mls_group_id"]["value"]["vec"], json!([1, 2, 3]));
         assert_eq!(serialized["epoch"], json!(42));
-        assert_eq!(serialized["secret"], json!([4, 5, 6]));
+        assert_eq!(
+            serialized["secret"],
+            json!([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0
+            ])
+        );
 
         // Test deserialization
         let deserialized: GroupExporterSecret = serde_json::from_value(serialized).unwrap();
         assert_eq!(deserialized.epoch, 42);
-        assert_eq!(deserialized.secret, vec![4, 5, 6]);
+        assert_eq!(deserialized.secret, [0u8; 32]);
     }
 
     #[test]
     fn test_group_relay_serialization() {
         let relay = GroupRelay {
             relay_url: RelayUrl::from_str("wss://relay.example.com").unwrap(),
-            mls_group_id: GroupId::from_slice(vec![1, 2, 3].as_slice()),
+            mls_group_id: GroupId::from_slice(&[1, 2, 3]),
         };
 
         let serialized = serde_json::to_value(&relay).unwrap();

--- a/crates/nostr-mls/examples/mls_memory.rs
+++ b/crates/nostr-mls/examples/mls_memory.rs
@@ -30,10 +30,14 @@ async fn main() -> Result<()> {
 
     // Create key package for Bob
     // This would be published to the Nostr network for other users to find
-    let bob_key_package_event: Event = bob_nostr_mls
-        .create_key_package(&bob_keys, [relay_url.clone()])
-        .await?;
+    let (bob_key_package_encoded, tags) =
+        bob_nostr_mls.create_key_package_for_event(&bob_keys.public_key(), [relay_url.clone()])?;
 
+    let bob_key_package_event = EventBuilder::new(Kind::MlsKeyPackage, bob_key_package_encoded)
+        .tags(tags)
+        .build(bob_keys.public_key())
+        .sign(&bob_keys)
+        .await?;
     // ================================
     // We're now acting as Alice
     // ================================

--- a/crates/nostr-mls/examples/mls_sqlite.rs
+++ b/crates/nostr-mls/examples/mls_sqlite.rs
@@ -36,8 +36,13 @@ async fn main() -> Result<()> {
 
     // Create key package for Bob
     // This would be published to the Nostr network for other users to find
-    let bob_key_package_event: Event = bob_nostr_mls
-        .create_key_package(&bob_keys, [relay_url.clone()])
+    let (bob_key_package_encoded, tags) =
+        bob_nostr_mls.create_key_package_for_event(&bob_keys.public_key(), [relay_url.clone()])?;
+
+    let bob_key_package_event = EventBuilder::new(Kind::MlsKeyPackage, bob_key_package_encoded)
+        .tags(tags)
+        .build(bob_keys.public_key())
+        .sign(&bob_keys)
         .await?;
 
     // ================================

--- a/crates/nostr-mls/examples/mls_sqlite.rs
+++ b/crates/nostr-mls/examples/mls_sqlite.rs
@@ -145,7 +145,7 @@ async fn main() -> Result<()> {
 
     // The resulting serialized message is the MLS encrypted message that Bob sent
     // Now Bob can process the MLS message content and do what's needed with it
-    bob_nostr_mls.process_message(&bob_mls_group_id, &message_event)?;
+    bob_nostr_mls.process_message(&message_event)?;
 
     let messages = bob_nostr_mls.get_messages(&bob_mls_group_id).unwrap();
     let message = messages.first().unwrap();
@@ -197,10 +197,7 @@ async fn main() -> Result<()> {
     );
 
     tracing::info!("Alice about to process message");
-    alice_nostr_mls.process_message(
-        &GroupId::from_slice(alice_group.mls_group_id.as_slice()),
-        &message_event,
-    )?;
+    alice_nostr_mls.process_message(&message_event)?;
 
     let messages = alice_nostr_mls
         .get_messages(&GroupId::from_slice(alice_group.mls_group_id.as_slice()))

--- a/crates/nostr-mls/src/error.rs
+++ b/crates/nostr-mls/src/error.rs
@@ -75,6 +75,8 @@ pub enum Error {
     SelfUpdate(String),
     /// Welcome error
     Welcome(String),
+    /// We're missing a Welcome for an existing ProcessedWelcome
+    MissingWelcomeForProcessedWelcome,
     /// Provider error
     Provider(String),
     /// Group not found
@@ -128,6 +130,9 @@ impl fmt::Display for Error {
             Self::Message(e) => write!(f, "{e}"),
             Self::CannotDecryptOwnMessage => write!(f, "cannot decrypt own message"),
             Self::Welcome(e) => write!(f, "{e}"),
+            Self::MissingWelcomeForProcessedWelcome => {
+                write!(f, "missing welcome for processed welcome")
+            }
             Self::MergePendingCommit(e) => write!(f, "{e}"),
             Self::SelfUpdate(e) => write!(f, "{e}"),
             Self::Provider(e) => write!(f, "{e}"),

--- a/crates/nostr-mls/src/groups.rs
+++ b/crates/nostr-mls/src/groups.rs
@@ -116,7 +116,7 @@ where
     ///
     /// * `Ok(GroupExporterSecret)` - The exported secret
     /// * `Err(Error)` - If the group is not found or there is an error exporting the secret
-    pub(crate) fn exporter_secret(
+    pub fn exporter_secret(
         &self,
         group_id: &GroupId,
     ) -> Result<group_types::GroupExporterSecret, Error> {

--- a/crates/nostr-mls/src/groups.rs
+++ b/crates/nostr-mls/src/groups.rs
@@ -130,8 +130,12 @@ where
             Some(group_exporter_secret) => Ok(group_exporter_secret),
             // If it's not already in the storage, export the secret and save it
             None => {
-                let export_secret: Vec<u8> =
-                    group.export_secret(&self.provider, "nostr", b"nostr", 32)?;
+                let export_secret: [u8; 32] = group
+                    .export_secret(&self.provider, "nostr", b"nostr", 32)?
+                    .try_into()
+                    .map_err(|_| {
+                        Error::Group("Failed to convert export secret to [u8; 32]".to_string())
+                    })?;
                 let group_exporter_secret = group_types::GroupExporterSecret {
                     mls_group_id: group_id.clone(),
                     epoch: group.epoch().as_u64(),


### PR DESCRIPTION
### Description

This adds and changes several of the public interfaces of the nostr-mls crate. These changes are based on trying to implement this new crate into White Noise and finding places where the interface felt wrong or created more work than necessary for client implementations.

A list of the main changes: 

- Removed the `create_key_package_event` method in favor of just returning the constituent parts and allowing consumers to create the event. This helps avoid async bounds issues.
- Expose the exporter_secret methods so that consumers can directly access those secrets when needed. In White Noise's case, these are used to encrypt media files that are uploaded to blossom servers. 
- Ensure that we create parent directories when creating a new Sqlite database.
- Update a few method params
