### PR TITLE
nostr: rework nip46 module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 ### Breaking changes
 
+- nostr: rework nip46 module ([Yuki Kishimoto] at https://github.com/rust-nostr/nostr/pull/865)
 - pool: drop support for deprecated negentropy protocol ([Yuki Kishimoto] at https://github.com/rust-nostr/nostr/pull/853)
 - connect: encrypt NIP-46 events with NIP-44 instead of NIP-04 ([reyamir] at https://github.com/rust-nostr/nostr/pull/862)
 - connect: drop support for NIP-46 event decryption with NIP-04 ([Yuki Kishimoto] at https://github.com/rust-nostr/nostr/pull/864)

--- a/crates/nostr-cli/src/main.rs
+++ b/crates/nostr-cli/src/main.rs
@@ -361,7 +361,7 @@ async fn handle_command(command: ShellCommand, client: &Client) -> Result<()> {
 struct CustomActions;
 
 impl NostrConnectSignerActions for CustomActions {
-    fn approve(&self, public_key: &PublicKey, req: &nip46::Request) -> bool {
+    fn approve(&self, public_key: &PublicKey, req: &NostrConnectRequest) -> bool {
         println!("Public key: {public_key}");
         println!("{req:#?}\n");
         io::ask("Approve request?").unwrap_or_default()

--- a/crates/nostr-connect/examples/nostr-connect-signer.rs
+++ b/crates/nostr-connect/examples/nostr-connect-signer.rs
@@ -3,7 +3,6 @@
 // Distributed under the MIT software license
 
 use dialoguer::Confirm;
-use nostr::nips::nip46::Request;
 use nostr_connect::prelude::*;
 
 const SIGNER_SECRET_KEY: &str = "nsec12kcgs78l06p30jz7z7h3n2x2cy99nw2z6zspjdp7qc206887mwvs95lnkx";
@@ -38,7 +37,7 @@ async fn main() -> Result<()> {
 struct CustomActions;
 
 impl NostrConnectSignerActions for CustomActions {
-    fn approve(&self, public_key: &PublicKey, req: &Request) -> bool {
+    fn approve(&self, public_key: &PublicKey, req: &NostrConnectRequest) -> bool {
         println!("Public key: {public_key}");
         println!("{req:#?}\n");
         Confirm::new()

--- a/crates/nostr/src/event/builder.rs
+++ b/crates/nostr/src/event/builder.rs
@@ -15,8 +15,6 @@ use secp256k1::rand::{CryptoRng, Rng};
 use secp256k1::{Secp256k1, Signing, Verification};
 use serde_json::{json, Value};
 
-#[cfg(all(feature = "std", feature = "nip44", feature = "nip46"))]
-use crate::nips::nip46::Message as NostrConnectMessage;
 use crate::nips::nip62::VanishTarget;
 use crate::prelude::*;
 


### PR DESCRIPTION
- Rename the `Message` and `Request` structs to `NostrConnectMessage` and `NostrConnectRequest`
- Rename the `Method` enum to `NostrConnectMethod`
- Add `NostrConnectResponse` struct
- Change types of `NostrConnectMessage` variants
- Required to pass the request method when deserializing the response, to make sure to deserialize the correct type

Closes https://github.com/rust-nostr/nostr/issues/863