### PR TITLE
nostr: Handle uppercase `E` and `A` tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@
 - pool: add relay monitor ([Yuki Kishimoto] at https://github.com/rust-nostr/nostr/pull/851)
 - sdk: add `Options::pool` ([Yuki Kishimoto])
 
+### Fixed
+
+- nostr: handle `A` and `E` standard tags ([awiteb] at https://github.com/rust-nostr/nostr/pull/870)
+
 ### Deprecated
 
 - sdk: deprecate `Options::notification_channel_size` ([Yuki Kishimoto])


### PR DESCRIPTION
### Description

This patch let `TagStandard` parse uppercase `A` and `E` tags.

### Notes to the reviewers

Before this patch, the following code will not be run, now it run as indeed.

```rust
let root_e_tag = Tag::parse([
    "E",
    "f29d2b746426e17b8be4c35ba7ce095cde9e04a2b808b4d3c2a32a7a7b0fd22a",
    "",
    "00000001505e7e48927046e9bbaa728b1f3b511227e2200c578d6e6bb0c77eb9",
]).unwrap();

let root_a_tag = Tag::parse([
    "A",
    "30617:a008def15796fba9a0d6fab04e8fd57089285d9fd505da5a83fe8aad57a3564d:gitworkshop",
]).unwrap();

assert!(root_e_tag.as_standardized().is_some());
assert!(root_a_tag.as_standardized().is_some());
```

### Checklist

* [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [X] I ran `just precommit` or `just check` before committing
* [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
