### PR TITLE
pool: add `AuthenticationMiddleware` (WIP)

### DIFF
--- a/crates/nostr-relay-pool/src/pool/builder.rs
+++ b/crates/nostr-relay-pool/src/pool/builder.rs
@@ -6,13 +6,12 @@
 
 use std::sync::Arc;
 
-use nostr::NostrSigner;
 use nostr_database::{MemoryDatabase, NostrDatabase};
 
 use super::options::RelayPoolOptions;
 use super::RelayPool;
 use crate::monitor::Monitor;
-use crate::policy::AdmitPolicy;
+use crate::policy::{AdmitPolicy, AuthenticationMiddleware};
 use crate::transport::websocket::{DefaultWebsocketTransport, WebSocketTransport};
 
 /// Relay Pool builder
@@ -22,6 +21,10 @@ pub struct RelayPoolBuilder {
     pub websocket_transport: Arc<dyn WebSocketTransport>,
     /// Admission policy
     pub admit_policy: Option<Arc<dyn AdmitPolicy>>,
+    /// Authentication middleware
+    ///
+    /// <https://github.com/nostr-protocol/nips/blob/master/42.md>
+    pub auth_middleware: Option<Arc<dyn AuthenticationMiddleware>>,
     /// Relay monitor
     pub monitor: Option<Monitor>,
     /// Relay pool options
@@ -29,8 +32,6 @@ pub struct RelayPoolBuilder {
     // Private stuff
     #[doc(hidden)]
     pub __database: Arc<dyn NostrDatabase>,
-    #[doc(hidden)]
-    pub __signer: Option<Arc<dyn NostrSigner>>,
 }
 
 impl Default for RelayPoolBuilder {
@@ -38,10 +39,10 @@ impl Default for RelayPoolBuilder {
         Self {
             websocket_transport: Arc::new(DefaultWebsocketTransport),
             admit_policy: None,
+            auth_middleware: None,
             monitor: None,
             opts: RelayPoolOptions::default(),
             __database: Arc::new(MemoryDatabase::default()),
-            __signer: None,
         }
     }
 }

--- a/crates/nostr-relay-pool/src/pool/inner.rs
+++ b/crates/nostr-relay-pool/src/pool/inner.rs
@@ -52,8 +52,8 @@ impl InnerRelayPool {
             state: SharedState::new(
                 builder.__database,
                 builder.websocket_transport,
-                builder.__signer,
                 builder.admit_policy,
+                builder.auth_middleware,
                 builder.opts.nip42_auto_authentication,
                 builder.monitor,
             ),

--- a/crates/nostr-relay-pool/src/relay/error.rs
+++ b/crates/nostr-relay-pool/src/relay/error.rs
@@ -114,6 +114,8 @@ pub enum Error {
     },
     /// Auth failed
     AuthenticationFailed,
+    /// Authentication middleware not set
+    AuthMiddlewareNotSet,
     /// Premature exit
     PrematureExit,
 }
@@ -178,6 +180,7 @@ impl fmt::Display for Error {
                 current.as_millis()
             ),
             Self::AuthenticationFailed => write!(f, "authentication failed"),
+            Self::AuthMiddlewareNotSet => write!(f, "authentication middleware not set"),
             Self::PrematureExit => write!(f, "premature exit"),
         }
     }

--- a/crates/nostr-sdk/src/client/error.rs
+++ b/crates/nostr-sdk/src/client/error.rs
@@ -36,6 +36,8 @@ pub enum Error {
     ImpossibleToZap(String),
     /// Broken down filters for gossip are empty
     GossipFiltersEmpty,
+    /// Signer not configured
+    SignerNotConfigured,
     /// Private message (NIP17) relays not found
     PrivateMsgRelaysNotFound,
 }
@@ -63,6 +65,7 @@ impl fmt::Display for Error {
             Self::GossipFiltersEmpty => {
                 write!(f, "gossip broken down filters are empty")
             }
+            Self::SignerNotConfigured => write!(f, "signer not configured"),
             Self::PrivateMsgRelaysNotFound => write!(f, "Private message relays not found. The user is not ready to receive private messages."),
         }
     }

--- a/crates/nostr-sdk/src/client/middleware.rs
+++ b/crates/nostr-sdk/src/client/middleware.rs
@@ -1,0 +1,33 @@
+use std::sync::Arc;
+
+use nostr::prelude::BoxedFuture;
+use nostr::{Event, EventBuilder, NostrSigner, RelayUrl};
+use nostr_relay_pool::policy::{AuthenticationMiddleware, PolicyError};
+use tokio::sync::RwLock;
+
+use super::error::Error;
+
+#[derive(Debug)]
+pub(crate) struct DefaultAuthMiddleware {
+    pub(crate) signer: Arc<RwLock<Option<Arc<dyn NostrSigner>>>>,
+}
+
+impl AuthenticationMiddleware for DefaultAuthMiddleware {
+    fn is_ready(&self) -> BoxedFuture<'_, bool> {
+        Box::pin(async move { self.signer.read().await.is_some() })
+    }
+
+    fn authenticate<'a>(
+        &'a self,
+        _relay_url: &'a RelayUrl,
+        builder: EventBuilder,
+    ) -> BoxedFuture<'a, Result<Event, PolicyError>> {
+        Box::pin(async move {
+            let signer = self.signer.read().await;
+            let signer: &Arc<dyn NostrSigner> = signer
+                .as_ref()
+                .ok_or(PolicyError::backend(Error::SignerNotConfigured))?;
+            builder.sign(signer).await.map_err(PolicyError::backend)
+        })
+    }
+}

--- a/crates/nostr-sdk/src/client/mod.rs
+++ b/crates/nostr-sdk/src/client/mod.rs
@@ -13,14 +13,16 @@ use std::time::Duration;
 use nostr::prelude::*;
 use nostr_database::prelude::*;
 use nostr_relay_pool::prelude::*;
-use tokio::sync::broadcast;
+use tokio::sync::{broadcast, RwLock};
 
 pub mod builder;
 mod error;
+mod middleware;
 pub mod options;
 
 pub use self::builder::ClientBuilder;
 pub use self::error::Error;
+use self::middleware::DefaultAuthMiddleware;
 pub use self::options::Options;
 #[cfg(not(target_arch = "wasm32"))]
 pub use self::options::{Connection, ConnectionTarget};
@@ -31,6 +33,7 @@ use crate::gossip::{BrokenDownFilters, Gossip};
 pub struct Client {
     pool: RelayPool,
     gossip: Gossip,
+    signer: Arc<RwLock<Option<Arc<dyn NostrSigner>>>>,
     opts: Options,
 }
 
@@ -79,20 +82,35 @@ impl Client {
     }
 
     fn from_builder(builder: ClientBuilder) -> Self {
+        // Wrap signer
+        let signer: Arc<RwLock<Option<Arc<dyn NostrSigner>>>> =
+            Arc::new(RwLock::new(builder.signer));
+
+        // Construct authentication middleware
+        let auth_middleware = Arc::new(DefaultAuthMiddleware {
+            // Clone the signer Arc!
+            //
+            // All changes done in the `Arc<RwLock<T>>`
+            // in the client will be reflected also in the middleware,
+            // since it's wrapped in an `Arc`.
+            signer: signer.clone(),
+        });
+
         // Construct relay pool builder
         let pool_builder: RelayPoolBuilder = RelayPoolBuilder {
             websocket_transport: builder.websocket_transport,
             admit_policy: builder.admit_policy,
+            auth_middleware: Some(auth_middleware),
             monitor: builder.monitor,
             opts: builder.opts.pool,
             __database: builder.database,
-            __signer: builder.signer,
         };
 
         // Construct client
         Self {
             pool: pool_builder.build(),
             gossip: Gossip::new(),
+            signer,
             opts: builder.opts,
         }
     }
@@ -117,7 +135,8 @@ impl Client {
     /// Check if signer is configured
     #[inline]
     pub async fn has_signer(&self) -> bool {
-        self.pool.state().has_signer().await
+        let signer = self.signer.read().await;
+        signer.is_some()
     }
 
     /// Get current nostr signer
@@ -127,7 +146,8 @@ impl Client {
     /// Returns an error if the signer isn't set.
     #[inline]
     pub async fn signer(&self) -> Result<Arc<dyn NostrSigner>, Error> {
-        Ok(self.pool.state().signer().await?)
+        let signer = self.signer.read().await;
+        signer.clone().ok_or(Error::SignerNotConfigured)
     }
 
     /// Set nostr signer
@@ -136,13 +156,15 @@ impl Client {
     where
         T: IntoNostrSigner,
     {
-        self.pool.state().set_signer(signer).await;
+        let mut s = self.signer.write().await;
+        *s = Some(signer.into_nostr_signer());
     }
 
     /// Unset nostr signer
     #[inline]
     pub async fn unset_signer(&self) {
-        self.pool.state().unset_signer().await;
+        let mut s = self.signer.write().await;
+        *s = None;
     }
 
     /// Get [`RelayPool`]


### PR DESCRIPTION
- Add `AuthenticationMiddleware` trait
- Move signer from `SharedState` to `Client`

Closes https://github.com/rust-nostr/nostr/issues/739
