### PR TITLE
Remove protected tag temporarily

### DIFF
--- a/crates/nostr-mls/src/key_packages.rs
+++ b/crates/nostr-mls/src/key_packages.rs
@@ -37,7 +37,7 @@ where
         &self,
         public_key: &PublicKey,
         relays: I,
-    ) -> Result<(String, [Tag; 5]), Error>
+    ) -> Result<(String, [Tag; 4]), Error>
     where
         I: IntoIterator<Item = RelayUrl>,
     {
@@ -65,7 +65,6 @@ where
             ),
             Tag::custom(TagKind::MlsExtensions, [self.extensions_value()]),
             Tag::relays(relays),
-            Tag::protected(),
         ];
 
         Ok((hex::encode(key_package_serialized), tags))
@@ -206,12 +205,11 @@ mod tests {
         // Verify the key package has the expected properties
         assert_eq!(key_package.ciphersuite(), DEFAULT_CIPHERSUITE);
 
-        assert_eq!(tags.len(), 5);
+        assert_eq!(tags.len(), 4);
         assert_eq!(tags[0].kind(), TagKind::MlsProtocolVersion);
         assert_eq!(tags[1].kind(), TagKind::MlsCiphersuite);
         assert_eq!(tags[2].kind(), TagKind::MlsExtensions);
         assert_eq!(tags[3].kind(), TagKind::Relays);
-        assert_eq!(tags[4].kind(), TagKind::Protected);
 
         assert_eq!(
             tags[3].content().unwrap(),


### PR DESCRIPTION
### Description

This removes the protected tag from key package events. It was causing problems with realize accepting it without authentication. The plan is to come back and add this back in the future, once we figure out what's going on with the authentication.

### Checklist

* [x] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [x] I ran `just precommit` or `just check` before committing
* [x] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
