### PR TITLE
nostr: fix `nip22::extract_root` to handle uppercase tags when `is_root` is true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 ### Fixed
 
 - nostr: handle `A` and `E` standard tags ([awiteb] at https://github.com/rust-nostr/nostr/pull/870)
+- nostr: fix `nip22::extract_root` to handle uppercase tags when `is_root` is true ([awiteb] at https://github.com/rust-nostr/nostr/pull/876)
 
 ### Deprecated
 

--- a/crates/nostr/src/nips/nip22.rs
+++ b/crates/nostr/src/nips/nip22.rs
@@ -8,7 +8,7 @@
 
 use crate::nips::nip01::Coordinate;
 use crate::nips::nip73::ExternalContentId;
-use crate::{Event, EventId, Kind, PublicKey, RelayUrl, TagKind, TagStandard, Url};
+use crate::{Alphabet, Event, EventId, Kind, PublicKey, RelayUrl, TagKind, TagStandard, Url};
 
 /// Borrowed comment extracted data
 pub enum Comment<'a> {
@@ -98,7 +98,7 @@ fn check_return<T>(val: T, is_root: bool, uppercase: bool) -> Option<T> {
 fn extract_kind(event: &Event, is_root: bool) -> Option<&Kind> {
     event
         .tags
-        .filter_standardized(TagKind::k())
+        .filter_standardized(TagKind::single_letter(Alphabet::K, is_root))
         .find_map(|tag| match tag {
             TagStandard::Kind { kind, uppercase } => check_return(kind, is_root, *uppercase),
             _ => None,
@@ -116,7 +116,7 @@ fn extract_event(
 ) -> Option<(&EventId, Option<&RelayUrl>, Option<&PublicKey>)> {
     event
         .tags
-        .filter_standardized(TagKind::e())
+        .filter_standardized(TagKind::single_letter(Alphabet::E, is_root))
         .find_map(|tag| match tag {
             TagStandard::Event {
                 event_id,
@@ -141,7 +141,7 @@ fn extract_event(
 fn extract_coordinate(event: &Event, is_root: bool) -> Option<(&Coordinate, Option<&RelayUrl>)> {
     event
         .tags
-        .filter_standardized(TagKind::a())
+        .filter_standardized(TagKind::single_letter(Alphabet::A, is_root))
         .find_map(|tag| match tag {
             TagStandard::Coordinate {
                 coordinate,
@@ -161,7 +161,7 @@ fn extract_coordinate(event: &Event, is_root: bool) -> Option<(&Coordinate, Opti
 fn extract_external(event: &Event, is_root: bool) -> Option<(&ExternalContentId, Option<&Url>)> {
     event
         .tags
-        .filter_standardized(TagKind::i())
+        .filter_standardized(TagKind::single_letter(Alphabet::I, is_root))
         .find_map(|tag| match tag {
             TagStandard::ExternalContent {
                 content,


### PR DESCRIPTION
### Description

Fixes the `nip22::extract_root` function by ensuring it properly handles uppercase and
lowercase tags (`k`,`e`,`a`,`i`) when `is_root` is `true`. The issue occurred because `nip22::extract_{kind,event,coordinate,external}` enforced lowercase kinds even for root cases.

### Notes to the reviewers

N/A

### Checklist

* [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [X] I ran `just precommit` or `just check` before committing
* [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
