### PR TITLE
pool: fix wrong conversion from u8 to RelayStatus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 
 - nostr: handle `A` and `E` standard tags ([awiteb] at https://github.com/rust-nostr/nostr/pull/870)
 - nostr: fix `nip22::extract_root` to handle uppercase tags when `is_root` is true ([awiteb] at https://github.com/rust-nostr/nostr/pull/876)
+- pool: fix wrong conversion from u8 to RelayStatus ([Yuki Kishimoto] at https://github.com/rust-nostr/nostr/pull/878)
 
 ### Deprecated
 

--- a/crates/nostr-relay-pool/src/relay/status.rs
+++ b/crates/nostr-relay-pool/src/relay/status.rs
@@ -35,7 +35,7 @@ impl AtomicRelayStatus {
         let val: u8 = self.value.load(Ordering::SeqCst);
         match val {
             0 => RelayStatus::Initialized,
-            1 => RelayStatus::Connecting,
+            1 => RelayStatus::Pending,
             2 => RelayStatus::Connecting,
             3 => RelayStatus::Connected,
             4 => RelayStatus::Disconnected,


### PR DESCRIPTION
Fixes https://github.com/rust-nostr/nostr/issues/877