### PR TITLE
ci: fix logic for skipping incompatible crates for wasm32-unknown-unknown target in CI script

### DIFF
--- a/contrib/scripts/check-crates.sh
+++ b/contrib/scripts/check-crates.sh
@@ -97,14 +97,12 @@ do
         echo  "Checking '$arg' [$version]"
     fi
 
-    cargo $version check $arg
-
     if [[ $arg != *"--target wasm32-unknown-unknown"* ]];
     then
+        cargo $version check $arg
         cargo $version test $arg
+        cargo $version clippy $arg -- -D warnings
     fi
-
-    cargo $version clippy $arg -- -D warnings
 
     # If CI, clean every time to avoid to go out of space (GitHub Actions issue)
     if [ "$is_ci" == true ]; then


### PR DESCRIPTION
Closes #884 

### Description

This patch introduces a fix for one of the `precommit` scripts in `contrib/scripts/check-crates.sh` to skip running cargo check, cargo test, and cargo clippy for any crate that targets wasm32-unknown-unknown, which was causing the `just precommit` CI command to fail.

### Notes to the reviewers

To test:

- Checkout to PR
- run `just precommit`

### Checklist

* [x] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [x] I ran `just precommit` or `just check` before committing
* [ ] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
