### PR TITLE
doc(database): Fix `Events::is_empty` doc

### DIFF
--- a/crates/nostr-database/src/collections/events.rs
+++ b/crates/nostr-database/src/collections/events.rs
@@ -55,7 +55,7 @@ impl Events {
         self.set.len()
     }
 
-    /// Returns the number of events in the collection.
+    /// Checks if there are no events.
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.set.is_empty()


### PR DESCRIPTION
### Description

from "Returns the number of events in the collection." to "Checks if there are no events."


### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Checklist

* [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [X] I ran `just precommit` or `just check` before committing
* [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
