### PR TITLE
nostr: remove `Market::Mention` (NIP-10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 ### Breaking changes
 
 - nostr: remove `NostrConnectMethod::GetRelays`, `NostrConnectRequest::GetRelays` and `ResponseResult::GetRelays` ([Yuki Kishimoto] at https://github.com/rust-nostr/nostr/pull/894)
+- nostr: remove `Market::Mention` (NIP-10) ([Yuki Kishimoto] at https://github.com/rust-nostr/nostr/pull/895)
 - connect: remove `NostrConnect::get_relays` ([Yuki Kishimoto] at https://github.com/rust-nostr/nostr/pull/894)
 
 ### Changed

--- a/crates/nostr/src/nips/nip10.rs
+++ b/crates/nostr/src/nips/nip10.rs
@@ -36,8 +36,6 @@ pub enum Marker {
     Root,
     /// Reply
     Reply,
-    /// Mention
-    Mention,
 }
 
 impl fmt::Display for Marker {
@@ -45,7 +43,6 @@ impl fmt::Display for Marker {
         match self {
             Self::Root => write!(f, "root"),
             Self::Reply => write!(f, "reply"),
-            Self::Mention => write!(f, "mention"),
         }
     }
 }
@@ -57,7 +54,6 @@ impl FromStr for Marker {
         match marker {
             "root" => Ok(Self::Root),
             "reply" => Ok(Self::Reply),
-            "mention" => Ok(Self::Mention),
             _ => Err(Error::InvalidMarker),
         }
     }


### PR DESCRIPTION
Remove the `Marker::Mention` variant from NIP-10, according to https://github.com/nostr-protocol/nips/commit/0023ca81 revision.