### PR TITLE
nostr: rework `NostrParser`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,15 +29,20 @@
 
 - nostr: remove `NostrConnectMethod::GetRelays`, `NostrConnectRequest::GetRelays` and `ResponseResult::GetRelays` ([Yuki Kishimoto] at https://github.com/rust-nostr/nostr/pull/894)
 - nostr: remove `Market::Mention` (NIP-10) ([Yuki Kishimoto] at https://github.com/rust-nostr/nostr/pull/895)
+- nostr: remove `parser` feature ([Yuki Kishimoto] at https://github.com/rust-nostr/nostr/pull/899)
 - connect: remove `NostrConnect::get_relays` ([Yuki Kishimoto] at https://github.com/rust-nostr/nostr/pull/894)
 
 ### Changed
+
+- nostr: rework `NostrParser` ([Yuki Kishimoto] at https://github.com/rust-nostr/nostr/pull/899)
 
 ### Added
 
 ### Fixed
 
 ### Removed
+
+- nostr: remove regex dep ([Yuki Kishimoto] at https://github.com/rust-nostr/nostr/pull/899)
 
 ### Deprecated
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2780,7 +2780,6 @@ dependencies = [
  "instant",
  "js-sys",
  "nostr-ots",
- "regex",
  "reqwest",
  "scrypt",
  "secp256k1",

--- a/contrib/scripts/check-crates.sh
+++ b/contrib/scripts/check-crates.sh
@@ -36,8 +36,6 @@ buildargs=(
     "-p nostr --features all-nips"                                # std + all-nips
     "-p nostr --no-default-features --features alloc"             # Only alloc feature
     "-p nostr --no-default-features --features alloc,all-nips"    # alloc + all-nips
-    "-p nostr --features parser"                                  # std + parser
-    "-p nostr --no-default-features --features alloc,parser"      # alloc + parser
     "-p nostr --all-features"                                     # All features
     "-p nostr-database"
     "-p nostr-lmdb"

--- a/crates/nostr/Cargo.toml
+++ b/crates/nostr/Cargo.toml
@@ -26,7 +26,6 @@ std = [
     "cbc?/std",
     "chacha20?/std",
     "chacha20poly1305?/std",
-    "regex?/std",
     "scrypt?/std",
     "secp256k1/std",
     "secp256k1/rand-std",
@@ -46,7 +45,6 @@ alloc = [
     "serde/alloc",
     "serde_json/alloc",
 ]
-parser = ["dep:regex"]
 all-nips = ["nip04", "nip05", "nip06", "nip07", "nip11", "nip44", "nip46", "nip47", "nip49", "nip57", "nip59", "nip96", "nip98"]
 nip03 = ["dep:nostr-ots"]
 nip04 = ["dep:aes", "dep:base64", "dep:cbc"]
@@ -73,7 +71,6 @@ cbc = { version = "0.1", optional = true }
 chacha20 = { version = "0.9", optional = true }
 chacha20poly1305 = { version = "0.10", default-features = false, features = ["getrandom"], optional = true }
 nostr-ots = { version = "0.2", optional = true }
-regex = { version = "1.11", default-features = false, features = ["perf", "unicode"], optional = true }
 reqwest = { workspace = true, features = ["json", "rustls-tls", "socks"], optional = true }
 scrypt = { version = "0.11", default-features = false, optional = true }
 secp256k1 = { version = "0.29", default-features = false, features = ["rand", "serde"] }
@@ -140,7 +137,7 @@ required-features = ["std", "nip98"]
 
 [[example]]
 name = "parser"
-required-features = ["std", "parser"]
+required-features = ["std"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(bench)'] }

--- a/crates/nostr/README.md
+++ b/crates/nostr/README.md
@@ -87,7 +87,6 @@ The following crate feature flags are available:
 |------------|:-------:|----------------------------------------------------------------------------------------------|
 | `std`      |   Yes   | Enable `std` library                                                                         |
 | `alloc`    |   No    | Needed to use this library in `no_std` context                                               |
-| `parser`   |   No    | Enable the `NostrParser`                                                                     |
 | `all-nips` |   No    | Enable all NIPs                                                                              |
 | `nip03`    |   No    | Enable NIP-03: OpenTimestamps Attestations for Events                                        |
 | `nip04`    |   No    | Enable NIP-04: Encrypted Direct Message                                                      |

--- a/crates/nostr/src/lib.rs
+++ b/crates/nostr/src/lib.rs
@@ -47,7 +47,6 @@ pub mod filter;
 pub mod key;
 pub mod message;
 pub mod nips;
-#[cfg(feature = "parser")]
 pub mod parser;
 pub mod prelude;
 pub mod signer;

--- a/crates/nostr/src/nips/nip19.rs
+++ b/crates/nostr/src/nips/nip19.rs
@@ -146,7 +146,7 @@ impl From<nip49::Error> for Error {
 }
 
 /// To ensure total matching on prefixes when decoding a [`Nip19`] object
-pub(super) enum Nip19Prefix {
+pub(crate) enum Nip19Prefix {
     /// Secret Key
     NSec,
     /// Encrypted Secret Key

--- a/crates/nostr/src/prelude.rs
+++ b/crates/nostr/src/prelude.rs
@@ -81,7 +81,6 @@ pub use crate::nips::nip96::{self, *};
 #[cfg(feature = "nip98")]
 pub use crate::nips::nip98::{self, *};
 pub use crate::nips::nipc0::{self, *};
-#[cfg(feature = "parser")]
 pub use crate::parser::{self, *};
 pub use crate::signer::{self, *};
 pub use crate::types::*;


### PR DESCRIPTION
Main changes:
- Remove regex dependency
- Remove `parser` feature
- Implement a built-in pattern finder

These changes increase the parsing performance of ~2x and reduce the binary size of (~1.1MB on `x86_64-unknown-linux-gnu` target).

Another advantage is the reduction of the "features" matrix: since the `NostrParser` no longer requires the regex dependency, the `parser` feature is no longer needed.