### PR TITLE
pool: refine notification sending depending on event database saving status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 ### Changed
 
 - nostr: rework `NostrParser` ([Yuki Kishimoto] at https://github.com/rust-nostr/nostr/pull/899)
+- pool: refine notification sending depending on event database saving status ([Yuki Kishimoto] at https://github.com/rust-nostr/nostr/pull/911)
 
 ### Added
 


### PR DESCRIPTION
Send the event notification depending on the `SaveEventStatus` output.

Ref https://github.com/rust-nostr/nostr/issues/909#issuecomment-2938648893