### PR TITLE
pool: add an on-demand relay connection

### DIFF
--- a/crates/nostr-relay-pool/src/relay/options.rs
+++ b/crates/nostr-relay-pool/src/relay/options.rs
@@ -19,6 +19,9 @@ pub struct RelayOptions {
     pub(super) connection_mode: ConnectionMode,
     pub(super) flags: RelayServiceFlags,
     pub(super) reconnect: bool,
+    pub(super) enable_on_demand: bool,
+    pub(super) idle_timeout: Duration,
+    pub(super) gossip_only_sleep: bool,
     pub(super) retry_interval: Duration,
     pub(super) adjust_retry_interval: bool,
     pub(super) limits: RelayLimits,
@@ -32,6 +35,9 @@ impl Default for RelayOptions {
             connection_mode: ConnectionMode::default(),
             flags: RelayServiceFlags::default(),
             reconnect: true,
+            enable_on_demand: false,
+            idle_timeout: Duration::from_secs(300),
+            gossip_only_sleep: false,
             retry_interval: DEFAULT_RETRY_INTERVAL,
             adjust_retry_interval: true,
             limits: RelayLimits::default(),
@@ -128,6 +134,27 @@ impl RelayOptions {
     #[inline]
     pub fn notification_channel_size(mut self, size: usize) -> Self {
         self.notification_channel_size = size;
+        self
+    }
+
+    /// Enable on demand connections (default: disabled)
+    #[inline]
+    pub fn enable_on_demand(mut self, enable: bool) -> Self {
+        self.enable_on_demand = enable;
+        self
+    }
+
+    /// Set idle timeout for on-demand connections (default: 5 minutes)
+    #[inline]
+    pub fn idle_timeout(mut self, timeout: Duration) -> Self {
+        self.idle_timeout = timeout;
+        self
+    }
+
+    /// Enable sleeping only for Gossip relays (default: false)
+    #[inline]
+    pub fn gossip_only_sleep(mut self, enable: bool) -> Self {
+        self.gossip_only_sleep = enable;
         self
     }
 }

--- a/crates/nostr-relay-pool/src/relay/status.rs
+++ b/crates/nostr-relay-pool/src/relay/status.rs
@@ -41,6 +41,7 @@ impl AtomicRelayStatus {
             4 => RelayStatus::Disconnected,
             5 => RelayStatus::Terminated,
             6 => RelayStatus::Banned,
+            7 => RelayStatus::Sleeping,
             _ => unreachable!(),
         }
     }
@@ -63,6 +64,8 @@ pub enum RelayStatus {
     Terminated = 5,
     /// The relay has been banned.
     Banned = 6,
+    ///Relay is sleeping (on-demand mode)
+    Sleeping = 7,
 }
 
 impl fmt::Display for RelayStatus {
@@ -75,6 +78,7 @@ impl fmt::Display for RelayStatus {
             Self::Disconnected => write!(f, "Disconnected"),
             Self::Terminated => write!(f, "Terminated"),
             Self::Banned => write!(f, "Banned"),
+            Self::Sleeping => write!(f, "Sleeping"),
         }
     }
 }
@@ -105,11 +109,15 @@ impl RelayStatus {
     pub(crate) fn is_banned(&self) -> bool {
         matches!(self, Self::Banned)
     }
+    /// Check if is [`RelayStatus::Sleeping`]
+    pub(crate) fn is_sleeping(&self) -> bool {
+        matches!(self, Self::Sleeping)
+    }
 
     /// Check if relay can start a connection (status is `initialized` or `terminated`)
     #[inline]
     pub(crate) fn can_connect(&self) -> bool {
-        matches!(self, Self::Initialized | Self::Terminated)
+        matches!(self, Self::Initialized | Self::Terminated | Self::Sleeping)
     }
 }
 
@@ -213,5 +221,17 @@ mod tests {
         assert!(!status.can_connect());
         let relay = AtomicRelayStatus::new(status);
         assert_eq!(relay.load(), RelayStatus::Banned);
+    }
+
+    #[test]
+    fn test_status_sleeping() {
+        let status = RelayStatus::Sleeping;
+        assert!(!status.is_initialized());
+        assert!(!status.is_connected());
+        assert!(!status.is_disconnected());
+        assert!(!status.is_terminated());
+        assert!(!status.is_banned());
+        assert!(status.is_sleeping());
+        assert!(status.can_connect());
     }
 }


### PR DESCRIPTION
The PR implements on-demand relay connections to optimize resource usage, when many relays are configured. 


This PR adds optional automatic sleep/wake for idle relays to optimize resource usage during gossip scenarios. It is disabled by default (backward compatible).

- Sleep after configurable timeout (has a default: 5 min)
- Wake on send and subscribe operations
- Respect for active subscriptions

Close #730