### PR TITLE
pool: allow putting relays to sleep when idle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - nostr: add NIP-88 support (https://github.com/rust-nostr/nostr/pull/892)
 - nostr: add `Nip11GetOptions` (https://github.com/rust-nostr/nostr/pull/913)
 - nostr: add `RelayUrl::domain` method (https://github.com/rust-nostr/nostr/pull/914)
+- pool: allow putting relays to sleep when idle (https://github.com/rust-nostr/nostr/pull/926)
 
 ### Fixed
 

--- a/crates/nostr-relay-pool/src/relay/constants.rs
+++ b/crates/nostr-relay-pool/src/relay/constants.rs
@@ -37,6 +37,13 @@ pub(super) const MIN_SUCCESS_RATE: f64 = 0.90;
 
 pub(super) const PING_INTERVAL: Duration = Duration::from_secs(55); // Used also for latency calculation
 
+/// Sleep interval
+#[cfg(not(test))]
+pub(super) const SLEEP_INTERVAL: Duration = Duration::from_secs(60);
+/// Sleep interval for tests
+#[cfg(test)]
+pub(super) const SLEEP_INTERVAL: Duration = Duration::from_secs(1);
+
 pub(super) const WEBSOCKET_TX_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/nostr-relay-pool/src/relay/error.rs
+++ b/crates/nostr-relay-pool/src/relay/error.rs
@@ -57,6 +57,8 @@ pub enum Error {
     NotReady,
     /// Relay not connected
     NotConnected,
+    /// Relay is sleeping
+    Sleeping,
     /// Relay banned
     Banned,
     /// Connection rejected
@@ -144,6 +146,7 @@ impl fmt::Display for Error {
             }
             Self::NotReady => write!(f, "relay is initialized but not ready"),
             Self::NotConnected => write!(f, "relay not connected"),
+            Self::Sleeping => write!(f, "relay is sleeping"),
             Self::Banned => write!(f, "relay banned"),
             Self::ConnectionRejected { reason } => {
                 let reason: &str = reason.as_deref().unwrap_or("unknown");

--- a/crates/nostr-relay-pool/src/relay/options.rs
+++ b/crates/nostr-relay-pool/src/relay/options.rs
@@ -19,6 +19,8 @@ pub struct RelayOptions {
     pub(super) connection_mode: ConnectionMode,
     pub(super) flags: RelayServiceFlags,
     pub(super) reconnect: bool,
+    pub(super) sleep_when_idle: bool,
+    pub(super) idle_timeout: Duration,
     pub(super) retry_interval: Duration,
     pub(super) adjust_retry_interval: bool,
     pub(super) limits: RelayLimits,
@@ -32,6 +34,8 @@ impl Default for RelayOptions {
             connection_mode: ConnectionMode::default(),
             flags: RelayServiceFlags::default(),
             reconnect: true,
+            sleep_when_idle: false,
+            idle_timeout: Duration::from_secs(300),
             retry_interval: DEFAULT_RETRY_INTERVAL,
             adjust_retry_interval: true,
             limits: RelayLimits::default(),
@@ -128,6 +132,20 @@ impl RelayOptions {
     #[inline]
     pub fn notification_channel_size(mut self, size: usize) -> Self {
         self.notification_channel_size = size;
+        self
+    }
+
+    /// Sleep when idle (default: false)
+    #[inline]
+    pub fn sleep_when_idle(mut self, enable: bool) -> Self {
+        self.sleep_when_idle = enable;
+        self
+    }
+
+    /// Set idle timeout for on-demand connections (default: 5 minutes)
+    #[inline]
+    pub fn idle_timeout(mut self, timeout: Duration) -> Self {
+        self.idle_timeout = timeout;
         self
     }
 }

--- a/crates/nostr-relay-pool/src/relay/status.rs
+++ b/crates/nostr-relay-pool/src/relay/status.rs
@@ -41,6 +41,7 @@ impl AtomicRelayStatus {
             4 => RelayStatus::Disconnected,
             5 => RelayStatus::Terminated,
             6 => RelayStatus::Banned,
+            7 => RelayStatus::Sleeping,
             _ => unreachable!(),
         }
     }
@@ -63,6 +64,8 @@ pub enum RelayStatus {
     Terminated = 5,
     /// The relay has been banned.
     Banned = 6,
+    /// Relay is sleeping
+    Sleeping = 7,
 }
 
 impl fmt::Display for RelayStatus {
@@ -75,6 +78,7 @@ impl fmt::Display for RelayStatus {
             Self::Disconnected => write!(f, "Disconnected"),
             Self::Terminated => write!(f, "Terminated"),
             Self::Banned => write!(f, "Banned"),
+            Self::Sleeping => write!(f, "Sleeping"),
         }
     }
 }
@@ -106,10 +110,15 @@ impl RelayStatus {
         matches!(self, Self::Banned)
     }
 
+    /// Check if is [`RelayStatus::Sleeping`]
+    pub(crate) fn is_sleeping(&self) -> bool {
+        matches!(self, Self::Sleeping)
+    }
+
     /// Check if relay can start a connection (status is `initialized` or `terminated`)
     #[inline]
     pub(crate) fn can_connect(&self) -> bool {
-        matches!(self, Self::Initialized | Self::Terminated)
+        matches!(self, Self::Initialized | Self::Terminated | Self::Sleeping)
     }
 }
 
@@ -213,5 +222,17 @@ mod tests {
         assert!(!status.can_connect());
         let relay = AtomicRelayStatus::new(status);
         assert_eq!(relay.load(), RelayStatus::Banned);
+    }
+
+    #[test]
+    fn test_status_sleeping() {
+        let status = RelayStatus::Sleeping;
+        assert!(!status.is_initialized());
+        assert!(!status.is_connected());
+        assert!(!status.is_disconnected());
+        assert!(!status.is_terminated());
+        assert!(!status.is_banned());
+        assert!(status.is_sleeping());
+        assert!(status.can_connect());
     }
 }


### PR DESCRIPTION
Allow to put on sleep the relays when inactive for some time. Currently this option is disabled by default and must be enabled in the `RelayOptions`. In future PRs will be possible to enable it from the client options (for all relays or just the gossip ones).

- Sleep after configurable timeout (default: 5 min) if conditions are met (i.e., no long-lived subscription active)
- Wake up (reconnect automatically) when interacting with it (send/fetch events, subscribe)

Replaces https://github.com/rust-nostr/nostr/pull/924
Closes https://github.com/rust-nostr/nostr/issues/730