### PR TITLE
Add add_members method to groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 
 ### Added
 
+- nostr-mls: Add `add_memebers` method for adding members to an existing group (https://github.com/rust-nostr/nostr/pull/931)
 - nostr: add NIP-88 support (https://github.com/rust-nostr/nostr/pull/892)
 - nostr: add `Nip11GetOptions` (https://github.com/rust-nostr/nostr/pull/913)
 - nostr: add `RelayUrl::domain` method (https://github.com/rust-nostr/nostr/pull/914)


### PR DESCRIPTION
This adds a single method to nostr_mls to allow for adding new members to an existing group. 
