### PR TITLE
Add remove_members, update return type for group changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - connect: remove `NostrConnect::get_relays` (https://github.com/rust-nostr/nostr/pull/894)
 - database: merge traits into `NostrDatabase` (https://github.com/rust-nostr/nostr/pull/916)
 - database: remove `NostrDatabase::has_coordinate_been_deleted` (https://github.com/rust-nostr/nostr/pull/917)
+- mls: changed return type of `NostrMls::add_members` and `NostrMls::self_update` (https://github.com/rust-nostr/nostr/pull/934)
 
 ### Changed
 
@@ -45,6 +46,7 @@
 - database: impl `Any` for `NostrDatabase` (https://github.com/rust-nostr/nostr/pull/918)
 - pool: refine notification sending depending on event database saving status (https://github.com/rust-nostr/nostr/pull/911)
 
+
 ### Added
 
 - nostr: add NIP-88 support (https://github.com/rust-nostr/nostr/pull/892)
@@ -52,6 +54,7 @@
 - nostr: add `RelayUrl::domain` method (https://github.com/rust-nostr/nostr/pull/914)
 - pool: allow putting relays to sleep when idle (https://github.com/rust-nostr/nostr/pull/926)
 - mls: add `NostrMls::add_members` method for adding members to an existing group (https://github.com/rust-nostr/nostr/pull/931)
+- mls: add `NostrMls::remove_members` method for removing members from an existing group (https://github.com/rust-nostr/nostr/pull/934)
 
 ### Fixed
 

--- a/mls/nostr-mls/src/groups.rs
+++ b/mls/nostr-mls/src/groups.rs
@@ -98,7 +98,9 @@ where
     /// * `Err(Error)` - If the current user's public key cannot be extracted or the group is not found
     pub(crate) fn is_admin(&self, group: &MlsGroup) -> Result<bool, Error> {
         let current_user_pubkey = self.get_own_pubkey(group)?;
-        let stored_group = self.get_group(group.group_id())?.ok_or(Error::GroupNotFound)?;
+        let stored_group = self
+            .get_group(group.group_id())?
+            .ok_or(Error::GroupNotFound)?;
         Ok(stored_group.admin_pubkeys.contains(&current_user_pubkey))
     }
 
@@ -283,7 +285,9 @@ where
 
         // Check if current user is an admin
         if !self.is_admin(&group)? {
-            return Err(Error::Group("Only group admins can add members".to_string()));
+            return Err(Error::Group(
+                "Only group admins can add members".to_string(),
+            ));
         }
 
         let (commit_message, welcome_message, group_info) = group
@@ -303,7 +307,10 @@ where
             .map_err(|e| Error::Group(e.to_string()))?;
 
         let serialized_group_info = group_info
-            .map(|g| g.tls_serialize_detached().map_err(|e| Error::Group(e.to_string())))
+            .map(|g| {
+                g.tls_serialize_detached()
+                    .map_err(|e| Error::Group(e.to_string()))
+            })
             .transpose()?;
 
         Ok(UpdateGroupResult {
@@ -336,7 +343,9 @@ where
 
         // Check if current user is an admin
         if !self.is_admin(&group)? {
-            return Err(Error::Group("Only group admins can remove members".to_string()));
+            return Err(Error::Group(
+                "Only group admins can remove members".to_string(),
+            ));
         }
 
         // Convert pubkeys to leaf indices
@@ -369,11 +378,17 @@ where
             .map_err(|e| Error::Group(e.to_string()))?;
 
         let serialized_welcome_message = welcome_option
-            .map(|w| w.tls_serialize_detached().map_err(|e| Error::Group(e.to_string())))
+            .map(|w| {
+                w.tls_serialize_detached()
+                    .map_err(|e| Error::Group(e.to_string()))
+            })
             .transpose()?;
 
         let serialized_group_info = group_info
-            .map(|g| g.tls_serialize_detached().map_err(|e| Error::Group(e.to_string())))
+            .map(|g| {
+                g.tls_serialize_detached()
+                    .map_err(|e| Error::Group(e.to_string()))
+            })
             .transpose()?;
 
         Ok(UpdateGroupResult {
@@ -641,12 +656,18 @@ where
 
         let serialized_welcome_message = commit_message_bundle
             .welcome()
-            .map(|w| w.tls_serialize_detached().map_err(|e| Error::Group(e.to_string())))
+            .map(|w| {
+                w.tls_serialize_detached()
+                    .map_err(|e| Error::Group(e.to_string()))
+            })
             .transpose()?;
 
         let serialized_group_info = commit_message_bundle
             .group_info()
-            .map(|g| g.tls_serialize_detached().map_err(|e| Error::Group(e.to_string())))
+            .map(|g| {
+                g.tls_serialize_detached()
+                    .map_err(|e| Error::Group(e.to_string()))
+            })
             .transpose()?;
 
         Ok(UpdateGroupResult {
@@ -1121,7 +1142,10 @@ mod tests {
             .get_own_pubkey(&mls_group)
             .expect("Failed to get own pubkey");
 
-        assert_eq!(own_pubkey, creator_pk, "Own pubkey should match creator pubkey");
+        assert_eq!(
+            own_pubkey, creator_pk,
+            "Own pubkey should match creator pubkey"
+        );
     }
 
     #[test]
@@ -1277,12 +1301,16 @@ mod tests {
             .expect("Failed to build key package");
 
         // Test that admin can add members (should work)
-        let add_result = admin_nostr_mls.add_members(group_id, &[new_key_package_bundle.key_package().clone()]);
+        let add_result =
+            admin_nostr_mls.add_members(group_id, &[new_key_package_bundle.key_package().clone()]);
         assert!(add_result.is_ok(), "Admin should be able to add members");
 
         // Test that admin can remove members (should work)
         let remove_result = admin_nostr_mls.remove_members(group_id, &[member1_pk]);
-        assert!(remove_result.is_ok(), "Admin should be able to remove members");
+        assert!(
+            remove_result.is_ok(),
+            "Admin should be able to remove members"
+        );
 
         // Note: Testing non-admin permissions would require the non-admin user to actually
         // be part of the MLS group, which would require processing the welcome message.
@@ -1352,7 +1380,10 @@ mod tests {
         }
 
         // Verify we found the expected public keys
-        assert!(found_pubkeys.contains(&creator_pk), "Should find creator pubkey");
+        assert!(
+            found_pubkeys.contains(&creator_pk),
+            "Should find creator pubkey"
+        );
         for member_pk in &initial_members {
             assert!(
                 found_pubkeys.contains(member_pk),
@@ -1439,7 +1470,10 @@ mod tests {
         );
 
         // Verify remaining members are still in the group
-        assert!(final_members.contains(&creator_pk), "Creator should still be in group");
+        assert!(
+            final_members.contains(&creator_pk),
+            "Creator should still be in group"
+        );
         assert!(
             final_members.contains(&initial_members[0]),
             "Remaining member should still be in group"
@@ -1693,7 +1727,10 @@ mod tests {
         );
 
         // Verify all original members are still in the group
-        assert!(final_members.contains(&creator_pk), "Creator should still be in group");
+        assert!(
+            final_members.contains(&creator_pk),
+            "Creator should still be in group"
+        );
         for initial_member_pk in &initial_members {
             assert!(
                 final_members.contains(initial_member_pk),

--- a/mls/nostr-mls/src/groups.rs
+++ b/mls/nostr-mls/src/groups.rs
@@ -35,24 +35,15 @@ pub struct CreateGroupResult {
     pub serialized_welcome_message: Vec<u8>,
 }
 
-/// Result of updating a member's own leaf node in an MLS group
+/// Result of updating a group
 #[derive(Debug)]
-pub struct SelfUpdateResult {
-    /// Serialized update message to be sent to the group
-    pub serialized_message: Vec<u8>,
-    /// The group's exporter secret before the update
-    pub current_secret: group_types::GroupExporterSecret,
-    /// The group's new exporter secret after the update
-    pub new_secret: group_types::GroupExporterSecret,
-}
-
-/// Result of batch adding members to a group
-#[derive(Debug)]
-pub struct AddMembersResult {
-    /// Serialized commit message for adding members
-    pub commit_message: Vec<u8>,
-    /// Serialized welcome message for new members
-    pub welcome_message: Vec<u8>,
+pub struct UpdateGroupResult {
+    /// Serialized commit message to be fanned out to the group
+    pub serialized_commit_message: Vec<u8>,
+    /// Optional serialized welcome message for new members
+    pub serialized_welcome_message: Option<Vec<u8>>,
+    /// Optional serialized group info for the group - since we use the ratchet_tree extension this should always be present
+    pub serialized_group_info: Option<Vec<u8>>,
 }
 
 impl<Storage> NostrMls<Storage>
@@ -72,6 +63,61 @@ where
     #[inline]
     pub(crate) fn get_own_leaf<'a>(&self, group: &'a MlsGroup) -> Result<&'a LeafNode, Error> {
         group.own_leaf().ok_or(Error::OwnLeafNotFound)
+    }
+
+    /// Gets the current user's public key from an MLS group
+    ///
+    /// # Arguments
+    ///
+    /// * `group` - Reference to the MLS group
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(PublicKey)` - The current user's public key
+    /// * `Err(Error)` - If the user's leaf node is not found or there is an error extracting the public key
+    pub(crate) fn get_own_pubkey(&self, group: &MlsGroup) -> Result<PublicKey, Error> {
+        let own_leaf = self.get_own_leaf(group)?;
+        let credentials: BasicCredential =
+            BasicCredential::try_from(own_leaf.credential().clone())?;
+        let hex_bytes: &[u8] = credentials.identity();
+        let hex_str: &str = str::from_utf8(hex_bytes)?;
+        let public_key = PublicKey::from_hex(hex_str)?;
+        Ok(public_key)
+    }
+
+    /// Checks if the current user (own leaf node) is an admin of an MLS group
+    ///
+    /// # Arguments
+    ///
+    /// * `group` - Reference to the MLS group
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(true)` - The current user is an admin
+    /// * `Ok(false)` - The current user is not an admin
+    /// * `Err(Error)` - If the current user's public key cannot be extracted or the group is not found
+    pub(crate) fn is_admin(&self, group: &MlsGroup) -> Result<bool, Error> {
+        let current_user_pubkey = self.get_own_pubkey(group)?;
+        let stored_group = self.get_group(group.group_id())?.ok_or(Error::GroupNotFound)?;
+        Ok(stored_group.admin_pubkeys.contains(&current_user_pubkey))
+    }
+
+    /// Extracts the public key from a leaf node
+    ///
+    /// # Arguments
+    ///
+    /// * `leaf` - Reference to the leaf node
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(PublicKey)` - The public key extracted from the leaf node
+    /// * `Err(Error)` - If the public key cannot be extracted or there is an error converting the public key to hex
+    pub(crate) fn pubkey_for_member(&self, member: &Member) -> Result<PublicKey, Error> {
+        let credentials: BasicCredential = BasicCredential::try_from(member.credential.clone())?;
+        let hex_bytes: &[u8] = credentials.identity();
+        let hex_str: &str = str::from_utf8(hex_bytes)?;
+        let public_key = PublicKey::from_hex(hex_str)?;
+        Ok(public_key)
     }
 
     /// Loads the signature key pair for the current member in an MLS group
@@ -229,13 +275,18 @@ where
         &self,
         group_id: &GroupId,
         key_packages: &[KeyPackage],
-    ) -> Result<AddMembersResult, Error> {
+    ) -> Result<UpdateGroupResult, Error> {
         // Load group
         let mut group = self.load_mls_group(group_id)?.ok_or(Error::GroupNotFound)?;
 
         let signer: SignatureKeyPair = self.load_mls_signer(&group)?;
 
-        let (commit_message, welcome_message, _group_info) = group
+        // Check if current user is an admin
+        if !self.is_admin(&group)? {
+            return Err(Error::Group("Only group admins can add members".to_string()));
+        }
+
+        let (commit_message, welcome_message, group_info) = group
             .add_members(&self.provider, &signer, key_packages)
             .map_err(|e| Error::Group(e.to_string()))?;
 
@@ -243,17 +294,92 @@ where
             .merge_pending_commit(&self.provider)
             .map_err(|e| Error::Group(e.to_string()))?;
 
-        let serialized_commit = commit_message
+        let serialized_commit_message = commit_message
             .tls_serialize_detached()
             .map_err(|e| Error::Group(e.to_string()))?;
 
-        let serialized_welcome = welcome_message
+        let serialized_welcome_message = welcome_message
             .tls_serialize_detached()
             .map_err(|e| Error::Group(e.to_string()))?;
 
-        Ok(AddMembersResult {
-            commit_message: serialized_commit,
-            welcome_message: serialized_welcome,
+        let serialized_group_info = group_info
+            .map(|g| g.tls_serialize_detached().map_err(|e| Error::Group(e.to_string())))
+            .transpose()?;
+
+        Ok(UpdateGroupResult {
+            serialized_commit_message,
+            serialized_welcome_message: Some(serialized_welcome_message),
+            serialized_group_info,
+        })
+    }
+
+    /// Remove members from a group
+    ///
+    /// # Arguments
+    ///
+    /// * `group_id` - The MLS group ID
+    /// * `pubkeys_hex` - The hex-encoded Nostr public keys of the members to remove
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(UpdateGroupResult)` - The result of removing members
+    /// * `Err(Error)` - If there is an error removing members
+    pub fn remove_members(
+        &self,
+        group_id: &GroupId,
+        pubkeys: &[PublicKey],
+    ) -> Result<UpdateGroupResult, Error> {
+        // Load group
+        let mut group = self.load_mls_group(group_id)?.ok_or(Error::GroupNotFound)?;
+
+        let signer: SignatureKeyPair = self.load_mls_signer(&group)?;
+
+        // Check if current user is an admin
+        if !self.is_admin(&group)? {
+            return Err(Error::Group("Only group admins can remove members".to_string()));
+        }
+
+        // Convert pubkeys to leaf indices
+        let mut leaf_indices = Vec::new();
+        let members = group.members();
+
+        for (index, member) in members.enumerate() {
+            let pubkey = self.pubkey_for_member(&member)?;
+            if pubkeys.contains(&pubkey) {
+                leaf_indices.push(LeafNodeIndex::new(index as u32));
+            }
+        }
+
+        if leaf_indices.is_empty() {
+            return Err(Error::Group(
+                "No matching members found to remove".to_string(),
+            ));
+        }
+
+        let (commit_message, welcome_option, group_info) = group
+            .remove_members(&self.provider, &signer, &leaf_indices)
+            .map_err(|e| Error::Group(e.to_string()))?;
+
+        group
+            .merge_pending_commit(&self.provider)
+            .map_err(|e| Error::Group(e.to_string()))?;
+
+        let serialized_commit_message = commit_message
+            .tls_serialize_detached()
+            .map_err(|e| Error::Group(e.to_string()))?;
+
+        let serialized_welcome_message = welcome_option
+            .map(|w| w.tls_serialize_detached().map_err(|e| Error::Group(e.to_string())))
+            .transpose()?;
+
+        let serialized_group_info = group_info
+            .map(|g| g.tls_serialize_detached().map_err(|e| Error::Group(e.to_string())))
+            .transpose()?;
+
+        Ok(UpdateGroupResult {
+            serialized_commit_message,
+            serialized_welcome_message,
+            serialized_group_info,
         })
     }
 
@@ -455,7 +581,7 @@ where
     /// - The specified group is not found
     /// - Failed to generate or store signature keypair
     /// - Failed to perform self-update operation
-    pub fn self_update(&self, group_id: &GroupId) -> Result<SelfUpdateResult, Error> {
+    pub fn self_update(&self, group_id: &GroupId) -> Result<UpdateGroupResult, Error> {
         // Load group
         let mut group = self.load_mls_group(group_id)?.ok_or(Error::GroupNotFound)?;
 
@@ -511,12 +637,22 @@ where
         tracing::debug!(target: "nostr_openmls::groups::self_update", "New epoch: {:?}", new_secret.epoch);
 
         // Serialize the message
-        let serialized_message = commit_message_bundle.commit().tls_serialize_detached()?;
+        let serialized_commit_message = commit_message_bundle.commit().tls_serialize_detached()?;
 
-        Ok(SelfUpdateResult {
-            serialized_message,
-            current_secret,
-            new_secret,
+        let serialized_welcome_message = commit_message_bundle
+            .welcome()
+            .map(|w| w.tls_serialize_detached().map_err(|e| Error::Group(e.to_string())))
+            .transpose()?;
+
+        let serialized_group_info = commit_message_bundle
+            .group_info()
+            .map(|g| g.tls_serialize_detached().map_err(|e| Error::Group(e.to_string())))
+            .transpose()?;
+
+        Ok(UpdateGroupResult {
+            serialized_commit_message,
+            serialized_welcome_message,
+            serialized_group_info,
         })
     }
 
@@ -571,6 +707,7 @@ where
 #[cfg(test)]
 mod tests {
     use nostr::{Keys, PublicKey};
+    use openmls::prelude::BasicCredential;
 
     use crate::tests::create_test_nostr_mls;
 
@@ -705,11 +842,11 @@ mod tests {
 
         // Verify the result contains the expected data
         assert!(
-            !add_result.commit_message.is_empty(),
+            !add_result.serialized_commit_message.is_empty(),
             "Commit message should not be empty"
         );
         assert!(
-            !add_result.welcome_message.is_empty(),
+            add_result.serialized_welcome_message.is_some(),
             "Welcome message should not be empty"
         );
 
@@ -925,6 +1062,846 @@ mod tests {
             final_members.len(),
             4, // creator + 2 initial + 1 new = 4 total
             "Should have 4 total members"
+        );
+    }
+
+    #[test]
+    fn test_get_own_pubkey() {
+        use nostr::RelayUrl;
+
+        let creator_nostr_mls = create_test_nostr_mls();
+        let (creator_pk, initial_members, admins) = create_test_group_members();
+
+        // Create key packages for initial members
+        let mut initial_key_packages = Vec::new();
+        for member_pk in &initial_members {
+            let member_nostr_mls = create_test_nostr_mls();
+            let (credential, signature_keypair) = member_nostr_mls
+                .generate_credential_with_key(member_pk)
+                .expect("Failed to generate credential");
+
+            let capabilities = member_nostr_mls.capabilities();
+            let key_package_bundle = openmls::prelude::KeyPackage::builder()
+                .leaf_node_capabilities(capabilities)
+                .mark_as_last_resort()
+                .build(
+                    member_nostr_mls.ciphersuite,
+                    &member_nostr_mls.provider,
+                    &signature_keypair,
+                    credential,
+                )
+                .expect("Failed to build key package");
+
+            initial_key_packages.push(key_package_bundle.key_package().clone());
+        }
+
+        // Create the group
+        let create_result = creator_nostr_mls
+            .create_group(
+                "Test Group",
+                "A test group for get_own_pubkey testing",
+                &creator_pk,
+                &initial_members,
+                &initial_key_packages,
+                admins,
+                vec![RelayUrl::parse("wss://test.relay").unwrap()],
+            )
+            .expect("Failed to create group");
+
+        let group_id = &create_result.group.mls_group_id;
+
+        // Load the MLS group
+        let mls_group = creator_nostr_mls
+            .load_mls_group(group_id)
+            .expect("Failed to load MLS group")
+            .expect("MLS group should exist");
+
+        // Test get_own_pubkey
+        let own_pubkey = creator_nostr_mls
+            .get_own_pubkey(&mls_group)
+            .expect("Failed to get own pubkey");
+
+        assert_eq!(own_pubkey, creator_pk, "Own pubkey should match creator pubkey");
+    }
+
+    #[test]
+    fn test_is_admin() {
+        use nostr::RelayUrl;
+
+        let creator_nostr_mls = create_test_nostr_mls();
+        let (creator_pk, initial_members, admins) = create_test_group_members();
+
+        // Create key packages for initial members
+        let mut initial_key_packages = Vec::new();
+        for member_pk in &initial_members {
+            let member_nostr_mls = create_test_nostr_mls();
+            let (credential, signature_keypair) = member_nostr_mls
+                .generate_credential_with_key(member_pk)
+                .expect("Failed to generate credential");
+
+            let capabilities = member_nostr_mls.capabilities();
+            let key_package_bundle = openmls::prelude::KeyPackage::builder()
+                .leaf_node_capabilities(capabilities)
+                .mark_as_last_resort()
+                .build(
+                    member_nostr_mls.ciphersuite,
+                    &member_nostr_mls.provider,
+                    &signature_keypair,
+                    credential,
+                )
+                .expect("Failed to build key package");
+
+            initial_key_packages.push(key_package_bundle.key_package().clone());
+        }
+
+        // Create the group
+        let create_result = creator_nostr_mls
+            .create_group(
+                "Test Group",
+                "A test group for is_admin testing",
+                &creator_pk,
+                &initial_members,
+                &initial_key_packages,
+                admins,
+                vec![RelayUrl::parse("wss://test.relay").unwrap()],
+            )
+            .expect("Failed to create group");
+
+        let group_id = &create_result.group.mls_group_id;
+
+        // Load the MLS group
+        let mls_group = creator_nostr_mls
+            .load_mls_group(group_id)
+            .expect("Failed to load MLS group")
+            .expect("MLS group should exist");
+
+        // Test is_admin - creator should be admin
+        let is_admin = creator_nostr_mls
+            .is_admin(&mls_group)
+            .expect("Failed to check admin status");
+
+        assert!(is_admin, "Creator should be admin");
+    }
+
+    #[test]
+    fn test_admin_permission_checks() {
+        use nostr::RelayUrl;
+
+        let admin_nostr_mls = create_test_nostr_mls();
+        let non_admin_nostr_mls = create_test_nostr_mls();
+
+        // Generate keys
+        let admin_keys = Keys::generate();
+        let non_admin_keys = Keys::generate();
+        let member1_keys = Keys::generate();
+
+        let admin_pk = admin_keys.public_key();
+        let non_admin_pk = non_admin_keys.public_key();
+        let member1_pk = member1_keys.public_key();
+
+        // Create key packages for initial members
+        let mut initial_key_packages = Vec::new();
+
+        // Key package for non-admin user
+        let (credential, signature_keypair) = admin_nostr_mls
+            .generate_credential_with_key(&non_admin_pk)
+            .expect("Failed to generate credential");
+        let capabilities = admin_nostr_mls.capabilities();
+        let key_package_bundle = openmls::prelude::KeyPackage::builder()
+            .leaf_node_capabilities(capabilities)
+            .mark_as_last_resort()
+            .build(
+                admin_nostr_mls.ciphersuite,
+                &admin_nostr_mls.provider,
+                &signature_keypair,
+                credential,
+            )
+            .expect("Failed to build key package");
+        initial_key_packages.push(key_package_bundle.key_package().clone());
+
+        // Key package for member1
+        let (credential, signature_keypair) = admin_nostr_mls
+            .generate_credential_with_key(&member1_pk)
+            .expect("Failed to generate credential");
+        let capabilities2 = admin_nostr_mls.capabilities();
+        let key_package_bundle = openmls::prelude::KeyPackage::builder()
+            .leaf_node_capabilities(capabilities2)
+            .mark_as_last_resort()
+            .build(
+                admin_nostr_mls.ciphersuite,
+                &admin_nostr_mls.provider,
+                &signature_keypair,
+                credential,
+            )
+            .expect("Failed to build key package");
+        initial_key_packages.push(key_package_bundle.key_package().clone());
+
+        // Create group with admin as creator, non_admin and member1 as members
+        // Only admin is an admin
+        let create_result = admin_nostr_mls
+            .create_group(
+                "Admin Test Group",
+                "A test group for admin permission testing",
+                &admin_pk,
+                &[non_admin_pk, member1_pk],
+                &initial_key_packages,
+                vec![admin_pk], // Only admin is an admin
+                vec![RelayUrl::parse("wss://test.relay").unwrap()],
+            )
+            .expect("Failed to create group");
+
+        let group_id = &create_result.group.mls_group_id;
+
+        // Now let's simulate the non-admin user trying to add/remove members
+        // First, we need to set up the non-admin user's MLS group state
+        // In a real scenario, they would have joined via the welcome message
+
+        // Create a new member to add
+        let new_member_keys = Keys::generate();
+        let new_member_pk = new_member_keys.public_key();
+
+        // Create key package for new member
+        let (credential, signature_keypair) = non_admin_nostr_mls
+            .generate_credential_with_key(&new_member_pk)
+            .expect("Failed to generate credential");
+        let capabilities3 = non_admin_nostr_mls.capabilities();
+        let new_key_package_bundle = openmls::prelude::KeyPackage::builder()
+            .leaf_node_capabilities(capabilities3)
+            .mark_as_last_resort()
+            .build(
+                non_admin_nostr_mls.ciphersuite,
+                &non_admin_nostr_mls.provider,
+                &signature_keypair,
+                credential,
+            )
+            .expect("Failed to build key package");
+
+        // Test that admin can add members (should work)
+        let add_result = admin_nostr_mls.add_members(group_id, &[new_key_package_bundle.key_package().clone()]);
+        assert!(add_result.is_ok(), "Admin should be able to add members");
+
+        // Test that admin can remove members (should work)
+        let remove_result = admin_nostr_mls.remove_members(group_id, &[member1_pk]);
+        assert!(remove_result.is_ok(), "Admin should be able to remove members");
+
+        // Note: Testing non-admin permissions would require the non-admin user to actually
+        // be part of the MLS group, which would require processing the welcome message.
+        // For now, we've verified that admin permissions work correctly.
+    }
+
+    #[test]
+    fn test_pubkey_for_member() {
+        use nostr::RelayUrl;
+
+        let creator_nostr_mls = create_test_nostr_mls();
+        let (creator_pk, initial_members, admins) = create_test_group_members();
+
+        // Create key packages for initial members
+        let mut initial_key_packages = Vec::new();
+        for member_pk in &initial_members {
+            let member_nostr_mls = create_test_nostr_mls();
+            let (credential, signature_keypair) = member_nostr_mls
+                .generate_credential_with_key(member_pk)
+                .expect("Failed to generate credential");
+
+            let capabilities = member_nostr_mls.capabilities();
+            let key_package_bundle = openmls::prelude::KeyPackage::builder()
+                .leaf_node_capabilities(capabilities)
+                .mark_as_last_resort()
+                .build(
+                    member_nostr_mls.ciphersuite,
+                    &member_nostr_mls.provider,
+                    &signature_keypair,
+                    credential,
+                )
+                .expect("Failed to build key package");
+
+            initial_key_packages.push(key_package_bundle.key_package().clone());
+        }
+
+        // Create the group
+        let create_result = creator_nostr_mls
+            .create_group(
+                "Test Group",
+                "A test group for pubkey_for_member testing",
+                &creator_pk,
+                &initial_members,
+                &initial_key_packages,
+                admins,
+                vec![RelayUrl::parse("wss://test.relay").unwrap()],
+            )
+            .expect("Failed to create group");
+
+        let group_id = &create_result.group.mls_group_id;
+
+        // Load the MLS group
+        let mls_group = creator_nostr_mls
+            .load_mls_group(group_id)
+            .expect("Failed to load MLS group")
+            .expect("MLS group should exist");
+
+        // Test pubkey_for_member by checking all members
+        let members: Vec<_> = mls_group.members().collect();
+        let mut found_pubkeys = Vec::new();
+
+        for member in &members {
+            let pubkey = creator_nostr_mls
+                .pubkey_for_member(member)
+                .expect("Failed to get pubkey for member");
+            found_pubkeys.push(pubkey);
+        }
+
+        // Verify we found the expected public keys
+        assert!(found_pubkeys.contains(&creator_pk), "Should find creator pubkey");
+        for member_pk in &initial_members {
+            assert!(
+                found_pubkeys.contains(member_pk),
+                "Should find member pubkey: {:?}",
+                member_pk
+            );
+        }
+        assert_eq!(found_pubkeys.len(), 3, "Should have 3 members total");
+    }
+
+    #[test]
+    fn test_remove_members_success() {
+        use nostr::RelayUrl;
+
+        let creator_nostr_mls = create_test_nostr_mls();
+        let (creator_pk, initial_members, admins) = create_test_group_members();
+
+        // Create key packages for initial members
+        let mut initial_key_packages = Vec::new();
+        for member_pk in &initial_members {
+            let member_nostr_mls = create_test_nostr_mls();
+            let (credential, signature_keypair) = member_nostr_mls
+                .generate_credential_with_key(member_pk)
+                .expect("Failed to generate credential");
+
+            let capabilities = member_nostr_mls.capabilities();
+            let key_package_bundle = openmls::prelude::KeyPackage::builder()
+                .leaf_node_capabilities(capabilities)
+                .mark_as_last_resort()
+                .build(
+                    member_nostr_mls.ciphersuite,
+                    &member_nostr_mls.provider,
+                    &signature_keypair,
+                    credential,
+                )
+                .expect("Failed to build key package");
+
+            initial_key_packages.push(key_package_bundle.key_package().clone());
+        }
+
+        // Create the group
+        let create_result = creator_nostr_mls
+            .create_group(
+                "Test Group",
+                "A test group for remove_members testing",
+                &creator_pk,
+                &initial_members,
+                &initial_key_packages,
+                admins,
+                vec![RelayUrl::parse("wss://test.relay").unwrap()],
+            )
+            .expect("Failed to create group");
+
+        let group_id = &create_result.group.mls_group_id;
+
+        // Verify initial group state
+        let initial_members_set = creator_nostr_mls
+            .get_members(group_id)
+            .expect("Failed to get initial members");
+        assert_eq!(initial_members_set.len(), 3); // creator + 2 initial members
+
+        // Remove one member (the second initial member)
+        let member_to_remove = initial_members[1];
+        let remove_result = creator_nostr_mls
+            .remove_members(group_id, &[member_to_remove])
+            .expect("Failed to remove member");
+
+        // Verify the result contains the expected data
+        assert!(
+            !remove_result.serialized_commit_message.is_empty(),
+            "Commit message should not be empty"
+        );
+
+        // Verify the group state was updated correctly
+        let final_members = creator_nostr_mls
+            .get_members(group_id)
+            .expect("Failed to get final members");
+        assert_eq!(final_members.len(), 2); // creator + 1 remaining member
+
+        // Verify the removed member is no longer in the group
+        assert!(
+            !final_members.contains(&member_to_remove),
+            "Removed member should not be in the group"
+        );
+
+        // Verify remaining members are still in the group
+        assert!(final_members.contains(&creator_pk), "Creator should still be in group");
+        assert!(
+            final_members.contains(&initial_members[0]),
+            "Remaining member should still be in group"
+        );
+    }
+
+    #[test]
+    fn test_remove_members_group_not_found() {
+        use openmls::group::GroupId;
+
+        let nostr_mls = create_test_nostr_mls();
+        let non_existent_group_id = GroupId::from_slice(&[1, 2, 3, 4, 5]);
+        let dummy_pubkey = Keys::generate().public_key();
+
+        let result = nostr_mls.remove_members(&non_existent_group_id, &[dummy_pubkey]);
+        assert!(
+            matches!(result, Err(crate::Error::GroupNotFound)),
+            "Should return GroupNotFound error for non-existent group"
+        );
+    }
+
+    #[test]
+    fn test_remove_members_no_matching_members() {
+        use nostr::RelayUrl;
+
+        let creator_nostr_mls = create_test_nostr_mls();
+        let (creator_pk, initial_members, admins) = create_test_group_members();
+
+        // Create key packages for initial members
+        let mut initial_key_packages = Vec::new();
+        for member_pk in &initial_members {
+            let member_nostr_mls = create_test_nostr_mls();
+            let (credential, signature_keypair) = member_nostr_mls
+                .generate_credential_with_key(member_pk)
+                .expect("Failed to generate credential");
+
+            let capabilities = member_nostr_mls.capabilities();
+            let key_package_bundle = openmls::prelude::KeyPackage::builder()
+                .leaf_node_capabilities(capabilities)
+                .mark_as_last_resort()
+                .build(
+                    member_nostr_mls.ciphersuite,
+                    &member_nostr_mls.provider,
+                    &signature_keypair,
+                    credential,
+                )
+                .expect("Failed to build key package");
+
+            initial_key_packages.push(key_package_bundle.key_package().clone());
+        }
+
+        // Create the group
+        let create_result = creator_nostr_mls
+            .create_group(
+                "Test Group",
+                "A test group for remove_members no matching testing",
+                &creator_pk,
+                &initial_members,
+                &initial_key_packages,
+                admins,
+                vec![RelayUrl::parse("wss://test.relay").unwrap()],
+            )
+            .expect("Failed to create group");
+
+        let group_id = &create_result.group.mls_group_id;
+
+        // Try to remove a member that doesn't exist in the group
+        let non_member = Keys::generate().public_key();
+        let result = creator_nostr_mls.remove_members(group_id, &[non_member]);
+
+        assert!(
+            matches!(
+                result,
+                Err(crate::Error::Group(ref msg)) if msg.contains("No matching members found")
+            ),
+            "Should return error when no matching members found"
+        );
+    }
+
+    #[test]
+    fn test_remove_members_epoch_advancement() {
+        use nostr::RelayUrl;
+
+        let creator_nostr_mls = create_test_nostr_mls();
+        let (creator_pk, initial_members, admins) = create_test_group_members();
+
+        // Create key packages for initial members
+        let mut initial_key_packages = Vec::new();
+        for member_pk in &initial_members {
+            let member_nostr_mls = create_test_nostr_mls();
+            let (credential, signature_keypair) = member_nostr_mls
+                .generate_credential_with_key(member_pk)
+                .expect("Failed to generate credential");
+
+            let capabilities = member_nostr_mls.capabilities();
+            let key_package_bundle = openmls::prelude::KeyPackage::builder()
+                .leaf_node_capabilities(capabilities)
+                .mark_as_last_resort()
+                .build(
+                    member_nostr_mls.ciphersuite,
+                    &member_nostr_mls.provider,
+                    &signature_keypair,
+                    credential,
+                )
+                .expect("Failed to build key package");
+
+            initial_key_packages.push(key_package_bundle.key_package().clone());
+        }
+
+        // Create the group
+        let create_result = creator_nostr_mls
+            .create_group(
+                "Test Group",
+                "A test group for remove_members epoch testing",
+                &creator_pk,
+                &initial_members,
+                &initial_key_packages,
+                admins,
+                vec![RelayUrl::parse("wss://test.relay").unwrap()],
+            )
+            .expect("Failed to create group");
+
+        let group_id = &create_result.group.mls_group_id;
+
+        // Get initial epoch
+        let initial_group = creator_nostr_mls
+            .get_group(group_id)
+            .expect("Failed to get group")
+            .expect("Group should exist");
+        let initial_epoch = initial_group.epoch;
+
+        // Remove a member
+        let member_to_remove = initial_members[0];
+        let _remove_result = creator_nostr_mls
+            .remove_members(group_id, &[member_to_remove])
+            .expect("Failed to remove member");
+
+        // Verify the MLS group epoch was advanced
+        let mls_group = creator_nostr_mls
+            .load_mls_group(group_id)
+            .expect("Failed to load MLS group")
+            .expect("MLS group should exist");
+        let final_mls_epoch = mls_group.epoch().as_u64();
+
+        assert!(
+            final_mls_epoch > initial_epoch,
+            "MLS group epoch should advance after removing members (initial: {}, final: {})",
+            initial_epoch,
+            final_mls_epoch
+        );
+
+        // Verify the member was removed
+        let final_members = creator_nostr_mls
+            .get_members(group_id)
+            .expect("Failed to get members");
+        assert!(
+            !final_members.contains(&member_to_remove),
+            "Removed member should not be in the group"
+        );
+        assert_eq!(
+            final_members.len(),
+            2, // creator + 1 remaining member
+            "Should have 2 total members after removal"
+        );
+    }
+
+    #[test]
+    fn test_self_update_success() {
+        use nostr::RelayUrl;
+
+        let creator_nostr_mls = create_test_nostr_mls();
+        let (creator_pk, initial_members, admins) = create_test_group_members();
+
+        // Create key packages for initial members
+        let mut initial_key_packages = Vec::new();
+        for member_pk in &initial_members {
+            let member_nostr_mls = create_test_nostr_mls();
+            let (credential, signature_keypair) = member_nostr_mls
+                .generate_credential_with_key(member_pk)
+                .expect("Failed to generate credential");
+
+            let capabilities = member_nostr_mls.capabilities();
+            let key_package_bundle = openmls::prelude::KeyPackage::builder()
+                .leaf_node_capabilities(capabilities)
+                .mark_as_last_resort()
+                .build(
+                    member_nostr_mls.ciphersuite,
+                    &member_nostr_mls.provider,
+                    &signature_keypair,
+                    credential,
+                )
+                .expect("Failed to build key package");
+
+            initial_key_packages.push(key_package_bundle.key_package().clone());
+        }
+
+        // Create the group
+        let create_result = creator_nostr_mls
+            .create_group(
+                "Test Group",
+                "A test group for self_update testing",
+                &creator_pk,
+                &initial_members,
+                &initial_key_packages,
+                admins,
+                vec![RelayUrl::parse("wss://test.relay").unwrap()],
+            )
+            .expect("Failed to create group");
+
+        let group_id = &create_result.group.mls_group_id;
+
+        // Verify initial group state
+        let initial_members_set = creator_nostr_mls
+            .get_members(group_id)
+            .expect("Failed to get initial members");
+        assert_eq!(initial_members_set.len(), 3); // creator + 2 initial members
+
+        // Get initial group state
+        let initial_mls_group = creator_nostr_mls
+            .load_mls_group(group_id)
+            .expect("Failed to load MLS group")
+            .expect("MLS group should exist");
+        let initial_epoch = initial_mls_group.epoch().as_u64();
+
+        // Ensure the exporter secret exists before self update (this creates it if it doesn't exist)
+        let _initial_secret = creator_nostr_mls
+            .exporter_secret(group_id)
+            .expect("Failed to get initial exporter secret");
+
+        // Perform self update
+        let update_result = creator_nostr_mls
+            .self_update(group_id)
+            .expect("Failed to perform self update");
+
+        // Verify the result contains the expected data
+        assert!(
+            !update_result.serialized_commit_message.is_empty(),
+            "Commit message should not be empty"
+        );
+        // Note: self_update typically doesn't produce a welcome message unless there are special circumstances
+        // assert!(update_result.serialized_welcome_message.is_none(), "Welcome message should typically be None for self-update");
+
+        // Verify the group state was updated correctly
+        let final_members = creator_nostr_mls
+            .get_members(group_id)
+            .expect("Failed to get final members");
+        assert_eq!(
+            final_members.len(),
+            3,
+            "Member count should remain the same after self update"
+        );
+
+        // Verify all original members are still in the group
+        assert!(final_members.contains(&creator_pk), "Creator should still be in group");
+        for initial_member_pk in &initial_members {
+            assert!(
+                final_members.contains(initial_member_pk),
+                "Initial member should still be in group"
+            );
+        }
+
+        // Verify the epoch was advanced
+        let final_mls_group = creator_nostr_mls
+            .load_mls_group(group_id)
+            .expect("Failed to load MLS group")
+            .expect("MLS group should exist");
+        let final_epoch = final_mls_group.epoch().as_u64();
+
+        assert!(
+            final_epoch > initial_epoch,
+            "Epoch should advance after self update (initial: {}, final: {})",
+            initial_epoch,
+            final_epoch
+        );
+    }
+
+    #[test]
+    fn test_self_update_group_not_found() {
+        use openmls::group::GroupId;
+
+        let nostr_mls = create_test_nostr_mls();
+        let non_existent_group_id = GroupId::from_slice(&[1, 2, 3, 4, 5]);
+
+        let result = nostr_mls.self_update(&non_existent_group_id);
+        assert!(
+            matches!(result, Err(crate::Error::GroupNotFound)),
+            "Should return GroupNotFound error for non-existent group"
+        );
+    }
+
+    #[test]
+    fn test_self_update_key_rotation() {
+        use nostr::RelayUrl;
+
+        let creator_nostr_mls = create_test_nostr_mls();
+        let (creator_pk, initial_members, admins) = create_test_group_members();
+
+        // Create key packages for initial members
+        let mut initial_key_packages = Vec::new();
+        for member_pk in &initial_members {
+            let member_nostr_mls = create_test_nostr_mls();
+            let (credential, signature_keypair) = member_nostr_mls
+                .generate_credential_with_key(member_pk)
+                .expect("Failed to generate credential");
+
+            let capabilities = member_nostr_mls.capabilities();
+            let key_package_bundle = openmls::prelude::KeyPackage::builder()
+                .leaf_node_capabilities(capabilities)
+                .mark_as_last_resort()
+                .build(
+                    member_nostr_mls.ciphersuite,
+                    &member_nostr_mls.provider,
+                    &signature_keypair,
+                    credential,
+                )
+                .expect("Failed to build key package");
+
+            initial_key_packages.push(key_package_bundle.key_package().clone());
+        }
+
+        // Create the group
+        let create_result = creator_nostr_mls
+            .create_group(
+                "Test Group",
+                "A test group for self_update key rotation testing",
+                &creator_pk,
+                &initial_members,
+                &initial_key_packages,
+                admins,
+                vec![RelayUrl::parse("wss://test.relay").unwrap()],
+            )
+            .expect("Failed to create group");
+
+        let group_id = &create_result.group.mls_group_id;
+
+        // Get initial signature key from the leaf node
+        let initial_mls_group = creator_nostr_mls
+            .load_mls_group(group_id)
+            .expect("Failed to load MLS group")
+            .expect("MLS group should exist");
+        let initial_own_leaf = creator_nostr_mls
+            .get_own_leaf(&initial_mls_group)
+            .expect("Failed to get initial own leaf");
+        let initial_signature_key = initial_own_leaf.signature_key().as_slice().to_vec();
+
+        // Ensure the exporter secret exists before self update (this creates it if it doesn't exist)
+        let _initial_secret = creator_nostr_mls
+            .exporter_secret(group_id)
+            .expect("Failed to get initial exporter secret");
+
+        // Perform self update (this should rotate the signing key)
+        let _update_result = creator_nostr_mls
+            .self_update(group_id)
+            .expect("Failed to perform self update");
+
+        // Get the new signature key
+        let final_mls_group = creator_nostr_mls
+            .load_mls_group(group_id)
+            .expect("Failed to load MLS group")
+            .expect("MLS group should exist");
+        let final_own_leaf = creator_nostr_mls
+            .get_own_leaf(&final_mls_group)
+            .expect("Failed to get final own leaf");
+        let final_signature_key = final_own_leaf.signature_key().as_slice().to_vec();
+
+        // Verify the signature key has been rotated
+        assert_ne!(
+            initial_signature_key, final_signature_key,
+            "Signature key should be different after self update"
+        );
+
+        // Verify the public key identity remains the same
+        let initial_credential = BasicCredential::try_from(initial_own_leaf.credential().clone())
+            .expect("Failed to extract initial credential");
+        let final_credential = BasicCredential::try_from(final_own_leaf.credential().clone())
+            .expect("Failed to extract final credential");
+
+        assert_eq!(
+            initial_credential.identity(),
+            final_credential.identity(),
+            "Public key identity should remain the same after self update"
+        );
+    }
+
+    #[test]
+    fn test_self_update_exporter_secret_rotation() {
+        use nostr::RelayUrl;
+
+        let creator_nostr_mls = create_test_nostr_mls();
+        let (creator_pk, initial_members, admins) = create_test_group_members();
+
+        // Create key packages for initial members
+        let mut initial_key_packages = Vec::new();
+        for member_pk in &initial_members {
+            let member_nostr_mls = create_test_nostr_mls();
+            let (credential, signature_keypair) = member_nostr_mls
+                .generate_credential_with_key(member_pk)
+                .expect("Failed to generate credential");
+
+            let capabilities = member_nostr_mls.capabilities();
+            let key_package_bundle = openmls::prelude::KeyPackage::builder()
+                .leaf_node_capabilities(capabilities)
+                .mark_as_last_resort()
+                .build(
+                    member_nostr_mls.ciphersuite,
+                    &member_nostr_mls.provider,
+                    &signature_keypair,
+                    credential,
+                )
+                .expect("Failed to build key package");
+
+            initial_key_packages.push(key_package_bundle.key_package().clone());
+        }
+
+        // Create the group
+        let create_result = creator_nostr_mls
+            .create_group(
+                "Test Group",
+                "A test group for self_update exporter secret testing",
+                &creator_pk,
+                &initial_members,
+                &initial_key_packages,
+                admins,
+                vec![RelayUrl::parse("wss://test.relay").unwrap()],
+            )
+            .expect("Failed to create group");
+
+        let group_id = &create_result.group.mls_group_id;
+
+        // Get initial exporter secret
+        let initial_secret = creator_nostr_mls
+            .exporter_secret(group_id)
+            .expect("Failed to get initial exporter secret");
+
+        // Perform self update
+        let _update_result = creator_nostr_mls
+            .self_update(group_id)
+            .expect("Failed to perform self update");
+
+        // Get the new exporter secret
+        let final_secret = creator_nostr_mls
+            .exporter_secret(group_id)
+            .expect("Failed to get final exporter secret");
+
+        // Verify the exporter secret has been rotated
+        assert_ne!(
+            initial_secret.secret, final_secret.secret,
+            "Exporter secret should be different after self update"
+        );
+
+        // Verify the epoch has advanced
+        assert!(
+            final_secret.epoch > initial_secret.epoch,
+            "Epoch should advance after self update (initial: {}, final: {})",
+            initial_secret.epoch,
+            final_secret.epoch
+        );
+
+        // Verify the group ID remains the same
+        assert_eq!(
+            initial_secret.mls_group_id, final_secret.mls_group_id,
+            "Group ID should remain the same"
         );
     }
 }


### PR DESCRIPTION
### Description

This PR adds a few things: 

- `remove_members` method to remove members from a group. This can only be done by group admins. 
- fixed `add_members` method to ensure that only admins can add members. 
- added helper methods for `get_own_pubkey`, `is_admin`, and `pubkey_for_member`. 
- updated the return type to be consistent for all group update operations. We now return the serialized commit, and optionally a welcome and group_info. Since OpenMls operations to change a group state all return something similar we're mimicking their behavior for consistency.
- Added many tests to try and cover this new functionality.

### Checklist

* [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [X] I ran `just precommit` or `just check` before committing
* [x] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
