### PR TITLE
refactor: convert NIP05, NIP11, NIP96 to I/O-free

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2694,16 +2694,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "mime_guess"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
-dependencies = [
- "mime",
- "unicase",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2781,7 +2771,6 @@ dependencies = [
  "instant",
  "js-sys",
  "nostr-ots",
- "reqwest",
  "scrypt",
  "secp256k1",
  "serde",
@@ -3957,7 +3946,6 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
- "mime_guess",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -3971,7 +3959,6 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
- "tokio-socks",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -6157,15 +6144,6 @@ name = "uncased"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
-dependencies = [
- "version_check",
-]
-
-[[package]]
-name = "unicase"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
 dependencies = [
  "version_check",
 ]

--- a/crates/nostr/Cargo.toml
+++ b/crates/nostr/Cargo.toml
@@ -48,17 +48,17 @@ alloc = [
 all-nips = ["nip04", "nip05", "nip06", "nip07", "nip11", "nip44", "nip46", "nip47", "nip49", "nip57", "nip59", "nip96", "nip98"]
 nip03 = ["dep:nostr-ots"]
 nip04 = ["dep:aes", "dep:base64", "dep:cbc"]
-nip05 = ["dep:reqwest"]
+nip05 = []
 nip06 = ["dep:bip39"]
 nip07 = ["dep:js-sys", "dep:wasm-bindgen", "dep:wasm-bindgen-futures", "dep:web-sys"]
-nip11 = ["dep:reqwest"]
+nip11 = []
 nip44 = ["dep:base64", "dep:chacha20"]
 nip46 = ["nip04", "nip44"]
 nip47 = ["nip04"]
 nip49 = ["dep:chacha20poly1305", "dep:scrypt", "dep:unicode-normalization"]
 nip57 = ["dep:aes", "dep:cbc"]
 nip59 = ["nip44"]
-nip96 = ["dep:reqwest", "nip98", "reqwest?/multipart"]
+nip96 = ["nip98"]
 nip98 = ["dep:base64"]
 
 [dependencies]
@@ -71,7 +71,6 @@ cbc = { version = "0.1", optional = true }
 chacha20 = { version = "0.9", optional = true }
 chacha20poly1305 = { version = "0.10", default-features = false, features = ["getrandom"], optional = true }
 nostr-ots = { version = "0.2", optional = true }
-reqwest = { workspace = true, features = ["json", "rustls-tls", "socks"], optional = true }
 scrypt = { version = "0.11", default-features = false, optional = true }
 secp256k1 = { version = "0.29", default-features = false, features = ["rand", "serde"] }
 serde = { workspace = true, default-features = false, features = ["derive"] }

--- a/crates/nostr/examples/nip05.rs
+++ b/crates/nostr/examples/nip05.rs
@@ -8,17 +8,36 @@ use nostr::prelude::*;
 async fn main() -> Result<()> {
     let public_key =
         PublicKey::parse("b2d670de53b27691c0c3400225b65c35a26d06093bcc41f48ffc71e0907f9d4a")?;
-
+    // 1. Create a request
+    let request = nip05::Nip05Request::new("0xtr@oxtr.dev")?;
+    // 2. Use reqwest (or any HTTP client) to fetch the data
+    let client = reqwest::Client::new();
+    let response = client.get(request.url()).send().await?.text().await?;
+    // 3. Verify
     if nip05::verify(&public_key, "0xtr@oxtr.dev", None).await? {
         println!("NIP05 verified");
     } else {
         println!("NIP05 NOT verified");
     }
 
-    let profile: Nip05Profile = nip05::profile("_@fiatjaf.com", None).await?;
+    let profile_request = nip05::Nip05Request::new("_@fiatjaf.com")?;
+    let profile_response = client
+        .get(profile_request.url())
+        .send()
+        .await?
+        .text()
+        .await?;
+    let profile: Nip05Profile = nip05::profile_from_response(&profile_response, &profile_request)?;
+
     println!("Public key: {}", profile.public_key);
     println!("Relays: {:?}", profile.relays);
     println!("Relays (NIP46): {:?}", profile.nip46);
+
+    // using the simple URL function
+    println!("\n--- Alternative approach using get_nip05_url ---");
+    let url = nip05::get_nip05_url("test@example.com")?;
+    println!("Would fetch from: {}", url);
+    // You can now use any HTTP client to fetch from this URL
 
     Ok(())
 }

--- a/crates/nostr/examples/nip11.rs
+++ b/crates/nostr/examples/nip11.rs
@@ -8,9 +8,32 @@ use nostr::prelude::*;
 async fn main() -> Result<()> {
     let relay_url = Url::parse("wss://relay.damus.io")?;
 
-    let info = RelayInformationDocument::get(relay_url, Nip11GetOptions::default()).await?;
+    // 1. Create the request
+    let request = nip11::Nip11Request::new(relay_url)?;
+
+    // 2. Use reqwest (or any HTTP client) to fetchdata
+    let client = reqwest::Client::new();
+    let mut req_builder = client.get(request.url());
+
+    // 3. Add the required headers
+    for (name, value) in request.headers() {
+        req_builder = req_builder.header(name, value);
+    }
+
+    // 4. Send the request and get the response
+    let response = req_builder.send().await?.text().await?;
+
+    // 5. Parse the relay information document
+    let info = RelayInformationDocument::from_response(&response)?;
 
     println!("{:#?}", info);
+
+    // Example showing flexibility - using the simple URL function
+    println!("\n--- Alternative approach using get_relay_info_url ---");
+    let relay_url2 = Url::parse("wss://relay.snort.social")?;
+    let info_url = nip11::get_relay_info_url(relay_url2)?;
+    println!("Would fetch relay info from: {}", info_url);
+    println!("Remember to include Accept: application/nostr+json header");
 
     Ok(())
 }

--- a/crates/nostr/examples/nip96.rs
+++ b/crates/nostr/examples/nip96.rs
@@ -2,6 +2,7 @@
 // Copyright (c) 2023-2025 Rust Nostr Developers
 // Distributed under the MIT software license
 
+use nostr::nips::nip96::{HttpClient, IoError};
 use nostr::prelude::*;
 
 const FILE: &[u8] = &[
@@ -15,16 +16,63 @@ const FILE: &[u8] = &[
 #[tokio::main]
 async fn main() -> Result<()> {
     let keys = Keys::parse("nsec1j4c6269y9w0q2er2xjw8sv2ehyrtfxq3jwgdlxj6qfn8z4gjsq5qfvfk99")?;
-
     let server_url: Url = Url::parse("https://NostrMedia.com")?;
 
-    let config: ServerConfig = nip96::get_server_config(server_url, None).await?;
+    // Step 1: Get server configuration
+    let config_request = nip96::ServerConfigRequest::new(server_url)?;
 
-    let file_data: Vec<u8> = FILE.to_vec();
+    let client = reqwest::Client::new();
+    let config_response = client
+        .get(config_request.url())
+        .send()
+        .await?
+        .text()
+        .await?;
+    let config: ServerConfig = nip96::server_config_from_response(&config_response)?;
 
-    // Upload
-    let url: Url = nip96::upload_data(&keys, &config, file_data, None, None).await?;
-    println!("File uploaded: {url}");
+    println!("Server config loaded from: {}", config_request.url());
+    println!("Upload endpoint: {}", config.api_url);
+
+    // Step 2: Prepare file upload
+    let file_data: &[u8] = FILE;
+
+    // Create upload request
+    let upload_request = nip96::UploadRequest::new(&keys, &config, file_data).await?;
+
+    // Step 3: Create multipart form (users handle this with their preferred method)
+    let form_file_part = reqwest::multipart::Part::bytes(file_data.to_vec())
+        .file_name("test.png")
+        .mime_str("image/png")?;
+
+    let form = reqwest::multipart::Form::new().part("file", form_file_part);
+
+    // Step 4: Upload file using reqwest
+    let upload_response = client
+        .post(upload_request.url())
+        .header("Authorization", upload_request.authorization())
+        .multipart(form)
+        .send()
+        .await?
+        .text()
+        .await?;
+
+    // Step 5: Parse response and extract URL
+    match nip96::upload_response_to_url(&upload_response) {
+        Ok(url) => println!("File uploaded successfully: {url}"),
+        Err(e) => println!("Upload failed: {e}"),
+    }
+
+    // Example showing flexibility - you can use any HTTP client
+    println!("\n--- This approach works with any HTTP client! ---");
+    println!(
+        "1. Get config URL: {}",
+        nip96::get_server_config_url(&server_url)?
+    );
+    println!("2. Fetch config with your HTTP client");
+    println!("3. Parse with nip96::server_config_from_response()");
+    println!("4. Create upload request with UploadRequest::new()");
+    println!("5. Upload with your HTTP client + multipart form");
+    println!("6. Parse response with nip96::upload_response_to_url()");
 
     Ok(())
 }

--- a/crates/nostr/src/nips/nip05.rs
+++ b/crates/nostr/src/nips/nip05.rs
@@ -9,20 +9,12 @@
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
-use std::net::SocketAddr;
-
-#[cfg(not(target_arch = "wasm32"))]
-use reqwest::Proxy;
-use reqwest::{Client, Response};
 use serde_json::Value;
-
 use crate::{key, PublicKey, RelayUrl};
 
 /// `NIP05` error
 #[derive(Debug)]
 pub enum Error {
-    /// Reqwest error
-    Reqwest(reqwest::Error),
     /// Error deserializing JSON data
     Json(serde_json::Error),
     /// Keys error
@@ -39,18 +31,11 @@ impl std::error::Error for Error {}
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Reqwest(e) => write!(f, "{e}"),
             Self::Json(e) => write!(f, "impossible to deserialize NIP05 data: {e}"),
             Self::Keys(e) => write!(f, "{e}"),
             Self::InvalidFormat => write!(f, "invalid format"),
             Self::ImpossibleToVerify => write!(f, "impossible to verify"),
         }
-    }
-}
-
-impl From<reqwest::Error> for Error {
-    fn from(e: reqwest::Error) -> Self {
-        Self::Reqwest(e)
     }
 }
 
@@ -81,6 +66,53 @@ pub struct Nip05Profile {
     ///
     /// <https://github.com/nostr-protocol/nips/blob/master/46.md>
     pub nip46: Vec<RelayUrl>,
+}
+
+/// NIP05 request information
+///
+/// Contains the URL and name needed to verify a NIP05 identifier
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Nip05Request {
+    /// The URL to fetch
+    pub url: String,
+    /// The name to verify
+    pub name: String,
+}
+
+impl Nip05Request {
+    /// Create a new NIP05 request from identifier
+    pub fn new<S>(nip05: S) -> Result<Self, Error>
+    where
+        S: AsRef<str>,
+    {
+        let (url, name) = compose_url(nip05.as_ref())?;
+        Ok(Self {
+            url,
+            name: name.to_string(),
+        })
+    }
+
+    /// Get the URL to fetch
+    pub fn url(&self) -> &str {
+        &self.url
+    }
+
+    /// Get the name to verify
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+/// Get the NIP05 URL for a given identifier
+/// (just an option if you do not want to use the full verification logic)
+///
+/// Returns the URL that should be fetched for NIP05 verification
+pub fn get_nip05_url<S>(nip05: S) -> Result<String, Error>
+where
+    S: AsRef<str>,
+{
+    let (url, _) = compose_url(nip05.as_ref())?;
+    Ok(url)
 }
 
 fn compose_url(nip05: &str) -> Result<(String, &str), Error> {
@@ -126,57 +158,41 @@ fn verify_from_json(public_key: &PublicKey, json: &Value, name: &str) -> bool {
     false
 }
 
-async fn make_req(nip05: &str, _proxy: Option<SocketAddr>) -> Result<(Value, &str), Error> {
-    let (url, name) = compose_url(nip05)?;
+/// Parse JSON data and extract name for NIP05 operations
+// fn parse_json_data(data: &[u8], nip05: &str) -> Result<(Value, &str), Error> {
+//     let (_url, name) = compose_url(nip05)?;
+//     let json: Value = serde_json::from_slice(data)?;
+//     Ok((json, name))
+// }
 
-    #[cfg(not(target_arch = "wasm32"))]
-    let client: Client = {
-        let mut builder = Client::builder();
-        if let Some(proxy) = _proxy {
-            let proxy = format!("socks5h://{proxy}");
-            builder = builder.proxy(Proxy::all(proxy)?);
-        }
-        builder.build()?
-    };
-
-    #[cfg(target_arch = "wasm32")]
-    let client: Client = Client::new();
-
-    let res: Response = client.get(url).send().await?;
-    let json: Value = res.json().await?;
-
-    Ok((json, name))
-}
-
-/// Verify NIP05
+/// Verify NIP05 using pre-fetched JSON data
 ///
-/// **Proxy is ignored for WASM targets!**
-///
+/// Takes the JSON response from the .well-known/nostr.json endpoint
+/// and verifies if public key matches the NIP05 identifier.
+/// 
 /// <https://github.com/nostr-protocol/nips/blob/master/05.md>
-pub async fn verify<S>(
+pub fn verify_from_response(
     public_key: &PublicKey,
-    nip05: S,
-    _proxy: Option<SocketAddr>,
-) -> Result<bool, Error>
-where
-    S: AsRef<str>,
-{
-    let (json, name) = make_req(nip05.as_ref(), _proxy).await?;
-    Ok(verify_from_json(public_key, &json, name))
+    json_response: &str,
+    request: &Nip05Request,
+) -> Result<bool, Error> {
+    let json: Value = serde_json::from_str(json_response)?;
+    Ok(verify_from_json(public_key, &json, &request.name))
 }
 
-/// Get NIP05 profile
+/// Get NIP05 profile using pre-fetched JSON data (I/O free)
 ///
-/// **Proxy is ignored for WASM targets!**
-///
+/// Takes the JSON response from the .well-known/nostr.json endpoint 
+/// and extracts profile information
+/// 
 /// <https://github.com/nostr-protocol/nips/blob/master/05.md>
-pub async fn profile<S>(nip05: S, _proxy: Option<SocketAddr>) -> Result<Nip05Profile, Error>
-where
-    S: AsRef<str>,
-{
-    let (json, name) = make_req(nip05.as_ref(), _proxy).await?;
+pub fn profile_from_response(
+    json_response: &str,
+    request: &Nip05Request,
+) -> Result<Nip05Profile, Error> {
+    let json: Value = serde_json::from_str(json_response)?;
 
-    let public_key: PublicKey = get_key_from_json(&json, name).ok_or(Error::ImpossibleToVerify)?;
+    let public_key: PublicKey = get_key_from_json(&json, &request.name).ok_or(Error::ImpossibleToVerify)?;
     let relays: Vec<RelayUrl> = get_relays_from_json(&json, &public_key);
     let nip46: Vec<RelayUrl> = get_nip46_relays_from_json(&json, &public_key);
 
@@ -190,7 +206,44 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    
+    #[test]
+    fn test_nip05_request() {
+        let request = Nip05Request::new("_@yukikishimoto.com").unwrap();
+        assert_eq!(
+            request.url(),
+            "https://yukikishimoto.com/.well-known/nostr.json?name=_"
+        );
+        assert_eq!(request.name(), "_");
 
+        // Test invalid format
+        assert!(Nip05Request::new("invalid").is_err());
+    }
+
+    #[test]
+    fn test_verify_from_response() {
+        let json_response = r#"{
+            "names": {
+              "yuki": "68d81165918100b7da43fc28f7d1fc12554466e1115886b9e7bb326f65ec4272",
+              "_": "68d81165918100b7da43fc28f7d1fc12554466e1115886b9e7bb326f65ec4272"
+            }
+          }"#;
+
+        let request = Nip05Request::new("_@yukikishimoto.com").unwrap();
+        let public_key =
+            PublicKey::from_hex("68d81165918100b7da43fc28f7d1fc12554466e1115886b9e7bb326f65ec4272")
+                .unwrap();
+        
+        assert!(verify_from_response(&public_key, json_response, &request).unwrap());
+
+        let yuki_request = Nip05Request::new("yuki@yukikishimoto.com").unwrap();
+        assert!(verify_from_response(&public_key, json_response, &yuki_request).unwrap());
+
+        let wrong_key =
+            PublicKey::from_hex("b2d670de53b27691c0c3400225b65c35a26d06093bcc41f48ffc71e0907f9d4a")
+                .unwrap();
+        assert!(!verify_from_response(&wrong_key, json_response, &yuki_request).unwrap());
+    }
     #[test]
     fn test_verify_nip05() {
         // nostr.json

--- a/crates/nostr/src/nips/nip11.rs
+++ b/crates/nostr/src/nips/nip11.rs
@@ -7,30 +7,22 @@
 //!
 //! <https://github.com/nostr-protocol/nips/blob/master/11.md>
 
+use crate::{Timestamp, Url};
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
-use core::time::Duration;
-#[cfg(not(target_arch = "wasm32"))]
-use std::net::SocketAddr;
-
-use reqwest::Client;
-#[cfg(not(target_arch = "wasm32"))]
-use reqwest::Proxy;
-
-use crate::{Timestamp, Url};
 
 /// `NIP11` error
 #[derive(Debug)]
 pub enum Error {
-    /// Reqwest error
-    Reqwest(reqwest::Error),
     /// The relay information document is invalid
     InvalidInformationDocument,
     /// The relay information document is not accessible
     InaccessibleInformationDocument,
     /// Provided URL scheme is not valid
     InvalidScheme,
+    /// JSON parsing error
+    Json(serde_json::Error),
 }
 
 impl std::error::Error for Error {}
@@ -38,7 +30,6 @@ impl std::error::Error for Error {}
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Reqwest(e) => write!(f, "{e}"),
             Self::InvalidInformationDocument => {
                 write!(f, "The relay information document is invalid")
             }
@@ -46,59 +37,69 @@ impl fmt::Display for Error {
                 write!(f, "The relay information document is not accessible")
             }
             Self::InvalidScheme => write!(f, "Provided URL scheme is not valid"),
+            Self::Json(e) => write!(f, "JSON error: {e}"),
         }
     }
 }
 
-impl From<reqwest::Error> for Error {
-    fn from(e: reqwest::Error) -> Self {
-        Self::Reqwest(e)
+// JSON error conversion
+impl From<serde_json::Error> for Error {
+    fn from(e: serde_json::Error) -> Self {
+        Self::Json(e)
     }
 }
 
-/// NIP11 get options
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Nip11GetOptions {
-    /// Proxy
-    #[cfg(not(target_arch = "wasm32"))]
-    pub proxy: Option<SocketAddr>,
-    /// Timeout
-    pub timeout: Duration,
+/// NIP11 request information
+///
+/// Contains the URL and headers needed for fetching relay information
+/// (allowing you to use your preferred https clients)
+///
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Nip11Request {
+    /// The URL to fetch (converted to HTTP/HTTPS if needed)
+    pub url: String,
+    /// Headers to include in the request
+    pub headers: Vec<(String, String)>,
 }
 
-impl Default for Nip11GetOptions {
-    fn default() -> Self {
-        Self {
-            proxy: None,
-            timeout: Duration::from_secs(60),
-        }
+impl Nip11Request {
+    /// Create a new NIP11 request from a relay URL
+    pub fn new(relay_url: Url) -> Result<Self, Error> {
+        let url = get_relay_info_url(relay_url)?;
+        let headers = vec![("Accept".to_string(), "application/nostr+json".to_string())];
+
+        Ok(Self { url, headers })
+    }
+
+    /// Get the URL to fetch
+    pub fn url(&self) -> &str {
+        &self.url
+    }
+
+    /// Get the headers for the request
+    pub fn headers(&self) -> &[(String, String)] {
+        &self.headers
     }
 }
 
-impl Nip11GetOptions {
-    /// New default options
-    #[inline]
-    #[must_use]
-    pub fn new() -> Self {
-        Self::default()
-    }
+/// Get NIP11 for a given relay URL
+///
+/// Returns the HTTP(s) URL that should be fetched for relay information
+pub fn get_relay_info_url(relay_url: Url) -> Result<String, Error> {
+    let mut url = relay_url;
+    with_http_scheme(&mut url)?;
+    Ok(url.to_string())
+}
 
-    /// Set proxy
-    #[inline]
-    #[must_use]
-    #[cfg(not(target_arch = "wasm32"))]
-    pub fn proxy(mut self, proxy: SocketAddr) -> Self {
-        self.proxy = Some(proxy);
-        self
+/// Returns a new URL with scheme substituted to HTTP(S) if WS(S) was provided,
+/// other schemes leaves untouched.
+fn with_http_scheme(url: &mut Url) -> Result<(), Error> {
+    match url.scheme() {
+        "wss" => url.set_scheme("https").map_err(|_| Error::InvalidScheme)?,
+        "ws" => url.set_scheme("http").map_err(|_| Error::InvalidScheme)?,
+        _ => {}
     }
-
-    /// Set timeout
-    #[inline]
-    #[must_use]
-    pub fn timeout(mut self, timeout: Duration) -> Self {
-        self.timeout = timeout;
-        self
-    }
+    Ok(())
 }
 
 /// Relay information document
@@ -233,52 +234,66 @@ impl RelayInformationDocument {
         Self::default()
     }
 
-    /// Get Relay Information Document
-    pub async fn get(mut url: Url, opts: Nip11GetOptions) -> Result<Self, Error> {
-        let mut builder = Client::builder();
-
-        // Set proxy
-        #[cfg(not(target_arch = "wasm32"))]
-        if let Some(proxy) = opts.proxy {
-            let proxy = format!("socks5h://{proxy}");
-            builder = builder.proxy(Proxy::all(proxy)?);
-        }
-
-        // Set timeout
-        builder = builder.timeout(opts.timeout);
-
-        // Build client
-        let client: Client = builder.build()?;
-
-        let url: &str = Self::with_http_scheme(&mut url)?;
-        let req = client.get(url).header("Accept", "application/nostr+json");
-        match req.send().await {
-            Ok(response) => {
-                let json: String = response.text().await?;
-                match serde_json::from_slice(json.as_bytes()) {
-                    Ok(json) => Ok(json),
-                    Err(_) => Err(Error::InvalidInformationDocument),
-                }
-            }
-            Err(_) => Err(Error::InaccessibleInformationDocument),
-        }
-    }
-
-    /// Returns new URL with scheme substituted to HTTP(S) if WS(S) was provided,
-    /// other schemes leaves untouched.
-    fn with_http_scheme(url: &mut Url) -> Result<&str, Error> {
-        match url.scheme() {
-            "wss" => url.set_scheme("https").map_err(|_| Error::InvalidScheme)?,
-            "ws" => url.set_scheme("http").map_err(|_| Error::InvalidScheme)?,
-            _ => {}
-        }
-        Ok(url.as_str())
+    /// Parse relay information document from JSON response
+    ///
+    /// Allows you to parse relay information without any HTTP dependencies.
+    /// Fetch the JSON data using your preferred HTTP client and pass it here.
+    ///
+    pub fn from_response(json_response: &str) -> Result<Self, Error> {
+        serde_json::from_str(json_response).map_err(|_| Error::InvalidInformationDocument)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_nip11_request() {
+        let relay_url = Url::parse("wss://relay.damus.io").unwrap();
+        let request = Nip11Request::new(relay_url).unwrap();
+
+        assert_eq!(request.url(), "https://relay.damus.io/");
+        assert_eq!(request.headers().len(), 1);
+        assert_eq!(request.headers()[0].0, "Accept");
+        assert_eq!(request.headers()[0].1, "application/nostr+json");
+    }
+
+    #[test]
+    fn test_get_relay_info_url() {
+        // Test WS to HTTP conversion
+        let relay_url = Url::parse("ws://relay.example.com").unwrap();
+        let info_url = get_relay_info_url(relay_url).unwrap();
+        assert_eq!(info_url, "http://relay.example.com/");
+
+        // Test WSS to HTTPS conversion
+        let relay_url = Url::parse("wss://relay.damus.io").unwrap();
+        let info_url = get_relay_info_url(relay_url).unwrap();
+        assert_eq!(info_url, "https://relay.damus.io/");
+
+        // Test HTTPS URL (should remain unchanged)
+        let relay_url = Url::parse("https://relay.example.com").unwrap();
+        let info_url = get_relay_info_url(relay_url).unwrap();
+        assert_eq!(info_url, "https://relay.example.com/");
+    }
+
+    #[test]
+    fn test_from_response() {
+        let json_response = r#"{
+            "name": "Test Relay",
+            "description": "A test relay",
+            "supported_nips": [1, 2, 11]
+        }"#;
+
+        let doc = RelayInformationDocument::from_response(json_response).unwrap();
+        assert_eq!(doc.name, Some("Test Relay".to_string()));
+        assert_eq!(doc.description, Some("A test relay".to_string()));
+        assert_eq!(doc.supported_nips, Some(vec![1, 2, 11]));
+
+        // Test invalid JSON
+        let invalid_json = "not json";
+        assert!(RelayInformationDocument::from_response(invalid_json).is_err());
+    }
 
     #[test]
     fn correctly_serializes_retention_kind() {


### PR DESCRIPTION
Removed reqwest dependency from the core library and added I/O-free functions for all three NIPs. Intention here being to allow users to have more choice on client to use 

close #930

