### PR TITLE
nostr: Fix recursion with loop in iterator

### DIFF
--- a/crates/nostr/src/parser.rs
+++ b/crates/nostr/src/parser.rs
@@ -480,61 +480,59 @@ impl Iterator for FindMatches<'_> {
     type Item = Match;
 
     fn next(&mut self) -> Option<Self::Item> {
-        // Iterator ended
-        if self.pos >= self.bytes.len() {
-            return None;
-        }
-
-        // Check if text parsing is enabled
-        if self.opts.text {
-            // Check for line break
-            if let Some(mat) = self.try_parse_line_break() {
-                self.pos = mat.end;
-                return Some(mat);
+        // Loop through the texts till a match is found
+        while self.pos < self.bytes.len() {
+            // Check if text parsing is enabled
+            if self.opts.text {
+                // Check for line break
+                if let Some(mat) = self.try_parse_line_break() {
+                    self.pos = mat.end;
+                    return Some(mat);
+                }
             }
-        }
 
-        // Check if hashtags parsing is enabled
-        if self.opts.hashtags {
-            // Check for hashtag
-            if let Some(mat) = self.try_parse_hashtag() {
-                self.pos = mat.end;
-                return Some(mat);
+            // Check if hashtags parsing is enabled
+            if self.opts.hashtags {
+                // Check for hashtag
+                if let Some(mat) = self.try_parse_hashtag() {
+                    self.pos = mat.end;
+                    return Some(mat);
+                }
             }
-        }
 
-        // Check if nostr URIs parsing is enabled
-        if self.opts.nostr_uris {
-            // Check for nostr URI
-            if let Some(mat) = self.try_parse_nostr_uri() {
-                self.pos = mat.end;
-                return Some(mat);
+            // Check if nostr URIs parsing is enabled
+            if self.opts.nostr_uris {
+                // Check for nostr URI
+                if let Some(mat) = self.try_parse_nostr_uri() {
+                    self.pos = mat.end;
+                    return Some(mat);
+                }
             }
-        }
 
-        // Check if URLs parsing is enabled
-        if self.opts.urls {
-            // Check for URL
-            if let Some(mat) = self.try_parse_url() {
-                self.pos = mat.end;
-                return Some(mat);
+            // Check if URLs parsing is enabled
+            if self.opts.urls {
+                // Check for URL
+                if let Some(mat) = self.try_parse_url() {
+                    self.pos = mat.end;
+                    return Some(mat);
+                }
             }
+
+            // Move to the next character (handle UTF-8)
+            self.pos += if self.bytes[self.pos].is_ascii() {
+                1
+            } else {
+                // For non-ASCII, we need to skip the full UTF-8 sequence
+                self.text[self.pos..]
+                    .chars()
+                    .next()
+                    .map(|c| c.len_utf8())
+                    .unwrap_or(1)
+            };
         }
 
-        // Move to the next character (handle UTF-8)
-        self.pos += if self.bytes[self.pos].is_ascii() {
-            1
-        } else {
-            // For non-ASCII, we need to skip the full UTF-8 sequence
-            self.text[self.pos..]
-                .chars()
-                .next()
-                .map(|c| c.len_utf8())
-                .unwrap_or(1)
-        };
-
-        // Recursion
-        self.next()
+        // No match is found
+        None
     }
 }
 


### PR DESCRIPTION
The `Iterator` implementation of `FindMatches` used recursion. That was causing stack overflow when parsing text of length greater than 5723 without any matches.

Replacing the recursion with while loop allows iterator to work with larger texts and much more efficient, as rust does not optimize tail recursion.

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Checklist

* [x] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [ ] I ran `just precommit` or `just check` before committing
* [ ] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
