### PR TITLE
fix(nostr): index out of bounds in `Tags::dedup()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 ### Fixed
 
 - keyring: fix keys persistence between OS restarts on Linux (https://github.com/rust-nostr/nostr/pull/942)
+- nostr: index out of bounds in `Tags::dedup()`. (https://github.com/rust-nostr/nostr/pull/949)
 
 ### Removed
 

--- a/crates/nostr/src/event/tag/list.rs
+++ b/crates/nostr/src/event/tag/list.rs
@@ -381,7 +381,7 @@ impl Tags {
         }
 
         // Build a new list, placing the best duplicate at the earliest index
-        let mut new_list: Vec<Option<Tag>> = vec![None; map.len()];
+        let mut new_list: Vec<Option<Tag>> = vec![None; self.list.len()];
         for DedupVal {
             first_idx,
             best_idx,


### PR DESCRIPTION
fix #948

### Description

This fixes a panic in `Tags::dedup()` by resizing `new_list` to `self.list.len()` instead of `map.len()`, ensuring `first_idx` stays in bounds when deduplicating tags.

### Checklist

* [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [X] I ran `just precommit` or `just check` before committing
* [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
