### PR TITLE
sdk: extract at max 3 relays per NIP65 marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,6 @@
 - pool: refine notification sending depending on event database saving status (https://github.com/rust-nostr/nostr/pull/911)
 - pool: simplify received message logging (https://github.com/rust-nostr/nostr/pull/945)
 - pool: trim incoming relay messages before processing
-- sdk: take only the first 3 relays from NIP65 list for gossip
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 - pool: refine notification sending depending on event database saving status (https://github.com/rust-nostr/nostr/pull/911)
 - pool: simplify received message logging (https://github.com/rust-nostr/nostr/pull/945)
 - pool: trim incoming relay messages before processing
+- sdk: extract at max 3 relays per NIP65 marker (https://github.com/rust-nostr/nostr/pull/951)
 
 ### Added
 

--- a/crates/nostr-sdk/src/gossip/constant.rs
+++ b/crates/nostr-sdk/src/gossip/constant.rs
@@ -5,6 +5,6 @@
 use std::time::Duration;
 
 /// Max number of relays allowed in NIP17/NIP65 lists
-pub const MAX_RELAYS_LIST: usize = 3;
+pub const MAX_RELAYS_LIST: usize = 5;
 pub const PUBKEY_METADATA_OUTDATED_AFTER: Duration = Duration::from_secs(60 * 60); // 60 min
 pub const CHECK_OUTDATED_INTERVAL: Duration = Duration::from_secs(60 * 5); // 5 min

--- a/crates/nostr-sdk/src/gossip/constant.rs
+++ b/crates/nostr-sdk/src/gossip/constant.rs
@@ -4,7 +4,11 @@
 
 use std::time::Duration;
 
-/// Max number of relays allowed in NIP17/NIP65 lists
-pub const MAX_RELAYS_LIST: usize = 5;
+/// Take at max N relays per NIP-65 marker.
+pub(super) const MAX_RELAYS_PER_NIP65_MARKER: usize = 3;
+pub(super) const MAX_NIP17_RELAYS: usize = 3;
+/// Used as a kind of protection if someone inserts too many relays in the NIP65 list.
+/// Only the first 10 relays are extracted from the NIP65 list and then handled.
+pub(super) const MAX_RELAYS_ALLOWED_IN_NIP65: usize = 10;
 pub const PUBKEY_METADATA_OUTDATED_AFTER: Duration = Duration::from_secs(60 * 60); // 60 min
 pub const CHECK_OUTDATED_INTERVAL: Duration = Duration::from_secs(60 * 5); // 5 min

--- a/crates/nostr-sdk/src/gossip/mod.rs
+++ b/crates/nostr-sdk/src/gossip/mod.rs
@@ -583,7 +583,7 @@ mod tests {
             BrokenDownFilters::Filters(map) => {
                 assert_eq!(map.get(&damus_url).unwrap(), &p_tag_filter);
                 assert_eq!(map.get(&nostr_bg_url).unwrap(), &p_tag_filter);
-                //assert_eq!(map.get(&nostr_mom_url).unwrap(), &p_tag_filter);
+                assert_eq!(map.get(&nostr_mom_url).unwrap(), &p_tag_filter);
                 assert!(!map.contains_key(&nos_lol_url));
                 assert!(!map.contains_key(&nostr_info_url));
                 assert!(!map.contains_key(&relay_rip_url));
@@ -601,10 +601,10 @@ mod tests {
                 assert_eq!(map.get(&damus_url).unwrap(), &filter);
                 assert_eq!(map.get(&nostr_bg_url).unwrap(), &filter);
                 assert_eq!(map.get(&nos_lol_url).unwrap(), &filter);
-                //assert_eq!(map.get(&nostr_mom_url).unwrap(), &filter);
+                assert_eq!(map.get(&nostr_mom_url).unwrap(), &filter);
                 assert_eq!(map.get(&nostr_info_url).unwrap(), &filter);
                 assert_eq!(map.get(&relay_rip_url).unwrap(), &filter);
-                //assert_eq!(map.get(&snort_url).unwrap(), &filter);
+                assert_eq!(map.get(&snort_url).unwrap(), &filter);
             }
             _ => panic!("Expected filters"),
         }


### PR DESCRIPTION
Rework the gossip (NIP-65) relays extraction: extract at max 3 relays per marker (`write`/`read`) from the NIP-65 lists.

It's given the priority to the relays that are both `read` and `write`.

@dluvian 