### PR TITLE
nostr-blossom: Fix url serialization for blossom client

### DIFF
--- a/rfs/nostr-blossom/src/client.rs
+++ b/rfs/nostr-blossom/src/client.rs
@@ -59,7 +59,7 @@ impl BlossomClient {
     where
         T: NostrSigner,
     {
-        let url = format!("{}/upload", self.base_url);
+        let url = format!("{}upload", self.base_url);
 
         let hash: Sha256Hash = Sha256Hash::hash(&data);
         let file_hashes: Vec<Sha256Hash> = vec![hash];
@@ -111,7 +111,7 @@ impl BlossomClient {
     where
         T: NostrSigner,
     {
-        let mut url = format!("{}/list/{}", self.base_url, pubkey.to_hex());
+        let mut url = format!("{}list/{}", self.base_url, pubkey.to_hex());
 
         let mut query_params = Vec::new();
 
@@ -169,7 +169,7 @@ impl BlossomClient {
     where
         T: NostrSigner,
     {
-        let url = format!("{}/{}", self.base_url, sha256);
+        let url = format!("{}{}", self.base_url, sha256);
         let mut request = self.client.get(url);
         let mut headers = HeaderMap::new();
 
@@ -224,7 +224,7 @@ impl BlossomClient {
     where
         T: NostrSigner,
     {
-        let url = format!("{}/{}", self.base_url, sha256);
+        let url = format!("{}{}", self.base_url, sha256);
 
         let mut request = self.client.head(url);
 
@@ -267,7 +267,7 @@ impl BlossomClient {
     where
         T: NostrSigner,
     {
-        let url = format!("{}/{}", self.base_url, sha256);
+        let url = format!("{}{}", self.base_url, sha256);
 
         let mut headers = HeaderMap::new();
         let default_auth = self.default_auth(


### PR DESCRIPTION
* The `Url` type automatically adds trailing '/' as shown [here](https://github.com/delcin-raj/url_example)

* This was identified when working with whitenoise [pr](https://github.com/parres-hq/whitenoise/pull/237)

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Checklist

* [ ] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [ ] I ran `just precommit` or `just check` before committing
* [ ] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
