### PR TITLE
keyring: Re-export `keyring::Entry` and `keyring::Error`

### DIFF
--- a/crates/nostr-keyring/CHANGELOG.md
+++ b/crates/nostr-keyring/CHANGELOG.md
@@ -23,6 +23,12 @@
 
 -->
 
+## Unreleased
+
+### Changed
+
+- Re-export `keyring::Entry` and `keyring::Error` (https://github.com/rust-nostr/nostr/pull/974)
+
 ## v0.42.1 - 2025/06/28
 
 - Fix keys persistence between OS restarts on Linux (https://github.com/rust-nostr/nostr/pull/942)

--- a/crates/nostr-keyring/src/lib.rs
+++ b/crates/nostr-keyring/src/lib.rs
@@ -15,7 +15,7 @@ use std::fmt;
 
 #[cfg(feature = "async")]
 use async_utility::{task, tokio};
-use keyring::Entry;
+pub use keyring::{Entry, Error as KeyringError};
 use nostr::{key, Keys, SecretKey};
 
 pub mod prelude;
@@ -27,7 +27,7 @@ pub enum Error {
     #[cfg(feature = "async")]
     Join(tokio::task::JoinError),
     /// Keyring error
-    Keyring(keyring::Error),
+    Keyring(KeyringError),
     /// Nostr keys error
     Keys(key::Error),
 }
@@ -52,8 +52,8 @@ impl From<tokio::task::JoinError> for Error {
     }
 }
 
-impl From<keyring::Error> for Error {
-    fn from(e: keyring::Error) -> Self {
+impl From<KeyringError> for Error {
+    fn from(e: KeyringError) -> Self {
         Self::Keyring(e)
     }
 }


### PR DESCRIPTION
### Description

Allows crate users to utilize the `Entry` and `Error` types returned by `nostr-keyring` without needing to explicitly add `keyring` as a dependency in `Cargo.toml`

### Checklist

* [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [ ] I ran `just precommit` or `just check` before committing (No need)
* [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
