### PR TITLE
nostr: flexible filtering with `MatchEventOptions`

### DIFF
--- a/crates/nostr-relay-builder/src/local/inner.rs
+++ b/crates/nostr-relay-builder/src/local/inner.rs
@@ -265,7 +265,7 @@ impl InnerLocalRelay {
                     if let Ok(event) = event {
                          // Iter subscriptions
                         for (subscription_id, filter) in session.subscriptions.iter() {
-                            if filter.match_event(&event) {
+                            if filter.match_event(&event, MatchEventOptions::new()) {
                                 send_msg(&mut tx, RelayMessage::Event{
                                     subscription_id: Cow::Borrowed(subscription_id),
                                     event: Cow::Borrowed(&event)

--- a/crates/nostr/CHANGELOG.md
+++ b/crates/nostr/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Convert `nip05` module to be I/O-free (https://github.com/rust-nostr/nostr/pull/936)
 - Convert `nip11` module to be I/O-free (https://github.com/rust-nostr/nostr/pull/950)
 - Convert `nip96` module to be I/O-free (https://github.com/rust-nostr/nostr/pull/935)
+- Add `MatchEventOptions` as a parameter to `Filter::match_event` function (https://github.com/rust-nostr/nostr/pull/976)
 
 ### Changed
 

--- a/database/nostr-database/src/helper.rs
+++ b/database/nostr-database/src/helper.rs
@@ -11,6 +11,7 @@ use std::iter;
 use std::ops::Deref;
 use std::sync::Arc;
 
+use nostr::filter::MatchEventOptions;
 use nostr::nips::nip01::{Coordinate, CoordinateBorrow};
 use nostr::{Alphabet, Event, EventId, Filter, Kind, PublicKey, SingleLetterTag, Timestamp};
 use tokio::sync::{OwnedRwLockReadGuard, RwLock};
@@ -537,9 +538,10 @@ impl InternalDatabaseHelper {
     /// Generic query
     #[inline]
     fn internal_generic_query(&self, filter: Filter) -> impl Iterator<Item = &DatabaseEvent> {
-        self.events
-            .iter()
-            .filter(move |event| !self.deleted_ids.contains(&event.id) && filter.match_event(event))
+        self.events.iter().filter(move |event| {
+            !self.deleted_ids.contains(&event.id)
+                && filter.match_event(event, MatchEventOptions::new())
+        })
     }
 
     fn internal_query(&self, filter: Filter) -> InternalQueryResult {


### PR DESCRIPTION
### Description

Add new `MatchEventOptions` struct to control which fields are checked
when matching events against a filter. Modify `Filter::match_event` to
respect these options, skipping checks for disabled fields and enforcing
conditions for enabled ones.

This provides more flexible event matching behavior, allowing callers to
selectively enable/disable specific filter checks as needed.

> Discussed in https://github.com/rust-nostr/nostr/discussions/975

### Checklist

* [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [X] I ran `just precommit` or `just check` before committing
* [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
