### PR TITLE
relay-pool: Prevent sending event notifications for non-existing subscriptions

### DIFF
--- a/crates/nostr-relay-pool/CHANGELOG.md
+++ b/crates/nostr-relay-pool/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Refine notification sending depending on event database saving status (https://github.com/rust-nostr/nostr/pull/911)
 - Simplify received message logging (https://github.com/rust-nostr/nostr/pull/945)
 - Trim incoming relay messages before processing
+- Prevent sending event notifications when no subscriptions are present for it (https://github.com/rust-nostr/nostr/pull/979)
 
 ### Added
 

--- a/crates/nostr-relay-pool/src/relay/error.rs
+++ b/crates/nostr-relay-pool/src/relay/error.rs
@@ -59,6 +59,8 @@ pub enum Error {
     NotConnected,
     /// Relay is sleeping
     Sleeping,
+    /// Relay subscription id not exist
+    SubscriptionNotFound,
     /// Relay banned
     Banned,
     /// Connection rejected
@@ -146,6 +148,7 @@ impl fmt::Display for Error {
             }
             Self::NotReady => write!(f, "relay is initialized but not ready"),
             Self::NotConnected => write!(f, "relay not connected"),
+            Self::SubscriptionNotFound => write!(f, "relay subscription id not exist"),
             Self::Sleeping => write!(f, "relay is sleeping"),
             Self::Banned => write!(f, "relay banned"),
             Self::ConnectionRejected { reason } => {


### PR DESCRIPTION
This change ensures that event notifications are not sent for subscriptions that no longer exist. The pool now checks the validity of the subscription before triggering any notifications.

Additionally, we now store the auto-closing subscription ID.

Discussed in https://github.com/rust-nostr/nostr/discussions/975

### Checklist

* [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [X] I ran `just precommit` or `just check` before committing
* [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
