### PR TITLE
pool: update `RelayPool::subscriptions` and `RelayPool::subscription` outputs

### DIFF
--- a/crates/nostr-relay-pool/CHANGELOG.md
+++ b/crates/nostr-relay-pool/CHANGELOG.md
@@ -28,6 +28,7 @@
 ### Breaking changes
 
 - Drop NIP-11 support (https://github.com/rust-nostr/nostr/pull/950)
+- Update `RelayPool::subscriptions` and `RelayPool::subscription` outputs (https://github.com/rust-nostr/nostr/pull/980)
 
 ### Changed
 

--- a/crates/nostr-relay-pool/src/pool/inner.rs
+++ b/crates/nostr-relay-pool/src/pool/inner.rs
@@ -25,7 +25,8 @@ pub(super) type Relays = HashMap<RelayUrl, Relay>;
 #[derive(Debug)]
 pub(super) struct AtomicPrivateData {
     pub(super) relays: RwLock<Relays>,
-    pub(super) subscriptions: RwLock<HashMap<SubscriptionId, Filter>>,
+    /// Map of subscriptions that will be inherited by new added relays.
+    pub(super) inherit_subscriptions: RwLock<HashMap<SubscriptionId, Filter>>,
     pub(super) shutdown: AtomicBool,
 }
 
@@ -59,7 +60,7 @@ impl InnerRelayPool {
             ),
             atomic: Arc::new(AtomicPrivateData {
                 relays: RwLock::new(HashMap::new()),
-                subscriptions: RwLock::new(HashMap::new()),
+                inherit_subscriptions: RwLock::new(HashMap::new()),
                 shutdown: AtomicBool::new(false),
             }),
             notification_sender,

--- a/crates/nostr-sdk/CHANGELOG.md
+++ b/crates/nostr-sdk/CHANGELOG.md
@@ -25,6 +25,10 @@
 
 ## Unreleased
 
+### Breaking changes
+
+- Update `Client::subscriptions` and `Client::subscription` outputs (https://github.com/rust-nostr/nostr/pull/980)
+
 ### Changed
 
 - Extract at max 3 relays per NIP65 marker (https://github.com/rust-nostr/nostr/pull/951)

--- a/crates/nostr-sdk/src/client/mod.rs
+++ b/crates/nostr-sdk/src/client/mod.rs
@@ -507,22 +507,22 @@ impl Client {
         self.pool.disconnect().await
     }
 
-    /// Get pool subscriptions
+    /// Get subscriptions
     #[inline]
-    pub async fn subscriptions(&self) -> HashMap<SubscriptionId, Filter> {
+    pub async fn subscriptions(&self) -> HashMap<SubscriptionId, HashMap<RelayUrl, Filter>> {
         self.pool.subscriptions().await
     }
 
-    /// Get pool subscription
+    /// Get subscription
     #[inline]
-    pub async fn subscription(&self, id: &SubscriptionId) -> Option<Filter> {
+    pub async fn subscription(&self, id: &SubscriptionId) -> HashMap<RelayUrl, Filter> {
         self.pool.subscription(id).await
     }
 
     /// Subscribe to filters
     ///
     /// This method create a new subscription. None of the previous subscriptions will be edited/closed when you call this!
-    /// So remember to unsubscribe when you no longer need it. You can get all your active **pool** (non-auto-closing) subscriptions
+    /// So remember to unsubscribe when you no longer need it. You can get all your active (non-auto-closing) subscriptions
     /// by calling `client.subscriptions().await`.
     ///
     /// If `gossip` is enabled (see [`Options::gossip`]) the events will be requested also to
@@ -530,7 +530,7 @@ impl Client {
     ///
     /// # Auto-closing subscription
     ///
-    /// It's possible to automatically close a subscription by configuring the [SubscribeAutoCloseOptions].
+    /// It's possible to automatically close a subscription by configuring the [`SubscribeAutoCloseOptions`].
     ///
     /// Note: auto-closing subscriptions aren't saved in subscriptions map!
     ///


### PR DESCRIPTION
- Update `RelayPool::subscriptions` and `Client::subscriptions` output from `HashMap<SubscriptionId, Filter>` to `HashMap<SubscriptionId, HashMap<RelayUrl, Filter>>`
- Update `RelayPool::subscription` and `Client::subscription` output from `Option<Filter>` to `HashMap<RelayUrl, Filter>`

Previously, only the REQs sent with `Client::subscribe` or `RelayPool::subscribe` (which are sent to ALL relays) were included in the output. This change allows to get all the long-lived subscriptions, including the ones sent only to specific relays (like the gossip ones).

Closes https://github.com/rust-nostr/nostr/issues/814