### PR TITLE
relay-pool: don't send ws close msg if the stream has been terminated

### DIFF
--- a/crates/nostr-relay-pool/src/transport/error.rs
+++ b/crates/nostr-relay-pool/src/transport/error.rs
@@ -11,6 +11,10 @@ use core::fmt;
 pub enum TransportError {
     /// An error happened in the underlying backend.
     Backend(Box<dyn std::error::Error + Send + Sync>),
+    /// Sink error
+    Sink(Box<dyn std::error::Error + Send + Sync>),
+    /// Stream error
+    Stream(Box<dyn std::error::Error + Send + Sync>),
 }
 
 impl std::error::Error for TransportError {}
@@ -19,6 +23,8 @@ impl fmt::Display for TransportError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Backend(e) => write!(f, "{e}"),
+            Self::Sink(e) => write!(f, "{e}"),
+            Self::Stream(e) => write!(f, "{e}"),
         }
     }
 }
@@ -33,5 +39,27 @@ impl TransportError {
         E: std::error::Error + Send + Sync + 'static,
     {
         Self::Backend(Box::new(error))
+    }
+
+    /// Create a new sink error
+    ///
+    /// Shorthand for `Error::Sink(Box::new(error))`.
+    #[inline]
+    pub fn sink<E>(error: E) -> Self
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        Self::Sink(Box::new(error))
+    }
+
+    /// Create a new stream error
+    ///
+    /// Shorthand for `Error::Stream(Box::new(error))`.
+    #[inline]
+    pub fn stream<E>(error: E) -> Self
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        Self::Stream(Box::new(error))
     }
 }

--- a/crates/nostr-relay-pool/src/transport/websocket.rs
+++ b/crates/nostr-relay-pool/src/transport/websocket.rs
@@ -94,8 +94,8 @@ impl WebSocketTransport for DefaultWebsocketTransport {
 
             // Split sink and stream
             let (tx, rx) = socket.split();
-            let sink: BoxSink = Box::new(tx.sink_map_err(TransportError::backend)) as BoxSink;
-            let stream: BoxStream = Box::new(rx.map_err(TransportError::backend)) as BoxStream;
+            let sink: BoxSink = Box::new(tx.sink_map_err(TransportError::sink)) as BoxSink;
+            let stream: BoxStream = Box::new(rx.map_err(TransportError::stream)) as BoxStream;
             Ok((sink, stream))
         })
     }


### PR DESCRIPTION
Fixes https://github.com/rust-nostr/nostr/issues/984

