### PR TITLE
Add Monitor to NostrWalletConnectOptions

### DIFF
--- a/crates/nwc/CHANGELOG.md
+++ b/crates/nwc/CHANGELOG.md
@@ -28,6 +28,7 @@
 ### Added
 
 - Add notification support for real-time payment updates (https://github.com/rust-nostr/nostr/pull/953)
+- Add Monitor to NostrWalletConnectOptions (https://github.com/rust-nostr/nostr/pull/989)
 
 ## v0.42.0 - 2025/05/20
 

--- a/crates/nwc/src/lib.rs
+++ b/crates/nwc/src/lib.rs
@@ -53,9 +53,14 @@ impl NWC {
 
     /// New `NWC` client with custom [`NostrWalletConnectOptions`].
     pub fn with_opts(uri: NostrWalletConnectURI, opts: NostrWalletConnectOptions) -> Self {
+        let pool = match opts.monitor.as_ref() {
+            Some(monitor) => RelayPool::builder().monitor(monitor.clone()).build(),
+            None => RelayPool::default(),
+        };
+
         Self {
             uri,
-            pool: RelayPool::default(),
+            pool,
             opts,
             bootstrapped: Arc::new(AtomicBool::new(false)),
             notifications_subscribed: Arc::new(AtomicBool::new(false)),

--- a/crates/nwc/src/options.rs
+++ b/crates/nwc/src/options.rs
@@ -6,6 +6,7 @@
 
 use std::time::Duration;
 
+use nostr_relay_pool::monitor::Monitor;
 use nostr_relay_pool::{ConnectionMode, RelayOptions};
 
 /// Default timeout
@@ -16,6 +17,7 @@ pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(60);
 pub struct NostrWalletConnectOptions {
     pub(super) relay: RelayOptions,
     pub(super) timeout: Duration,
+    pub(super) monitor: Option<Monitor>,
 }
 
 impl Default for NostrWalletConnectOptions {
@@ -23,6 +25,7 @@ impl Default for NostrWalletConnectOptions {
         Self {
             relay: RelayOptions::default(),
             timeout: DEFAULT_TIMEOUT,
+            monitor: None,
         }
     }
 }
@@ -46,6 +49,13 @@ impl NostrWalletConnectOptions {
     #[inline]
     pub fn timeout(mut self, timeout: Duration) -> Self {
         self.timeout = timeout;
+        self
+    }
+
+    /// Set Relay Pool monitor
+    #[inline]
+    pub fn monitor(mut self, monitor: Monitor) -> Self {
+        self.monitor = Some(monitor);
         self
     }
 }


### PR DESCRIPTION
### Description
The only way to get the status of the relays in the `NWC` is the `status` function. With the recent addition of `Monitor` it would be convenient to add it (I thought in `NostrWalletConnectOptions`).
### Notes to the reviewers
### Checklist

* [x] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [x] I ran `just precommit` or `just check` before committing
* [x] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
