### PR TITLE
Fix simple warning lints

### DIFF
--- a/crates/nostr-relay-pool/src/relay/inner.rs
+++ b/crates/nostr-relay-pool/src/relay/inner.rs
@@ -430,7 +430,7 @@ impl InnerRelay {
         let subscriptions = self.atomic.subscriptions.read().await;
 
         // No sleep if there are active subscriptions
-        if subscriptions.len() > 0 {
+        if !subscriptions.is_empty() {
             return false;
         }
 

--- a/crates/nostr-relay-pool/src/relay/options.rs
+++ b/crates/nostr-relay-pool/src/relay/options.rs
@@ -359,16 +359,17 @@ mod tests {
     #[test]
     fn test_close() {
         let opts = SubscribeOptions::default();
-        assert_eq!(opts.is_auto_closing(), false);
+        assert!(!opts.is_auto_closing());
         let opts = SubscribeOptions::default().close_on(Some(SubscribeAutoCloseOptions::default()));
-        assert_eq!(opts.is_auto_closing(), true);
+        assert!(opts.is_auto_closing());
     }
 
     #[test]
     fn test_sync_progress_percentage() {
-        let mut sp = SyncProgress::default();
-        sp.total = 5;
-        sp.current = 2;
+        let sp = SyncProgress {
+            total: 5,
+            current: 2,
+        };
         assert_eq!(sp.percentage(), 2f64 / 5f64);
         let sp_zero = SyncProgress::default();
         assert_eq!(sp_zero.percentage(), 0.0);

--- a/crates/nostr/src/event/mod.rs
+++ b/crates/nostr/src/event/mod.rs
@@ -339,7 +339,7 @@ struct EventIntermediate<'a> {
     pub created_at: Cow<'a, Timestamp>,
     pub kind: Cow<'a, Kind>,
     pub tags: Cow<'a, Tags>,
-    pub content: Cow<'a, String>,
+    pub content: Cow<'a, str>,
     pub sig: Cow<'a, Signature>,
 }
 

--- a/crates/nostr/src/nips/nip06/bip32.rs
+++ b/crates/nostr/src/nips/nip06/bip32.rs
@@ -27,11 +27,9 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::Secp256k1(ref e) => write!(f, "{e}"),
-            Self::InvalidChildNumber(ref n) => write!(
-                f,
-                "child number {} is invalid (not within [0, 2^31 - 1])",
-                n
-            ),
+            Self::InvalidChildNumber(ref n) => {
+                write!(f, "child number {n} is invalid (not within [0, 2^31 - 1])")
+            }
         }
     }
 }

--- a/crates/nostr/src/nips/nip44/v2.rs
+++ b/crates/nostr/src/nips/nip44/v2.rs
@@ -384,7 +384,7 @@ mod tests {
         for i in (0..len).step_by(2) {
             let high = val(hex[i], i);
             let low = val(hex[i + 1], i + 1);
-            bytes.push(high << 4 | low);
+            bytes.push((high << 4) | low);
         }
 
         bytes

--- a/crates/nostr/src/util/hex.rs
+++ b/crates/nostr/src/util/hex.rs
@@ -31,7 +31,7 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::InvalidHexCharacter { c, index } => {
-                write!(f, "Invalid character {} at position {}", c, index)
+                write!(f, "Invalid character {c} at position {index}")
             }
             Self::OddLength => write!(f, "Odd number of digits"),
             Self::InvalidLength => write!(f, "Invalid length"),


### PR DESCRIPTION
### Description  

Ran `cargo +stable clippy` and addressed its warnings.  

### Notes for Reviewers  

One lint remains unresolved regarding boxing the `RelayMessage` variant in `RelayNotification::Message`, as it exceeds 248 bytes in size. Refer to the [Clippy documentation](https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant) for details. Let me know if this should be fixed, as it would introduce a breaking change.

### Checklist

* [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [X] I ran `just precommit` or `just check` before committing
* [ ] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
