### PR TITLE
Add browser signer (NIP-07) proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,9 +617,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "caret"
@@ -2155,12 +2155,12 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
- "futures-util",
+ "futures-core",
  "http",
  "http-body",
  "pin-project-lite",
@@ -2234,9 +2234,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.13"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c293b6b3d21eca78250dc7dbebd6b9210ec5530e038cbfe0661b5c47ab06e8"
+checksum = "7f66d5bd4c6f02bf0542fad85d626775bab9258cf795a4256dcaf3161114d1df"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2394,6 +2394,17 @@ name = "inventory"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f958d3d68f4167080a18141e10381e7634563984a537f2a49a30fd8e53ac5767"
+
+[[package]]
+name = "io-uring"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
+dependencies = [
+ "bitflags 2.9.0",
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "ipnet"
@@ -2869,6 +2880,22 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "nostr-browser-signer-proxy"
+version = "0.1.0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "nostr",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -4477,9 +4504,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
 dependencies = [
  "itoa",
  "memchr",
@@ -5009,17 +5036,19 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
+ "slab",
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",
@@ -6422,11 +6451,13 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.10.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.3.1",
+ "js-sys",
+ "serde",
  "wasm-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
 
     # Signers
     "signer/nostr-browser-signer",
+    "signer/nostr-browser-signer-proxy",
     "signer/nostr-connect",
 ]
 default-members = ["crates/*"]

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The project is split up into several crates in the `crates/` directory:
     * [**nostr**](./crates/nostr): Rust implementation of Nostr protocol
     * Signers
         * [**nostr-browser-signer**](./signer/nostr-browser-signer): Nostr Browser signer implementation (NIP-07)
+        * [**nostr-browser-signer-proxy**](./signer/nostr-browser-signer-proxy): Proxy for using the Nostr Browser signer (NIP-07) in native applications
         * [**nostr-connect**](./signer/nostr-connect): Nostr Connect (NIP-46) 
     * [**nostr-database**](./database/nostr-database): Events database abstraction and in-memory implementation
         * [**nostr-lmdb**](./database/nostr-lmdb): LMDB storage backend

--- a/contrib/scripts/check-crates.sh
+++ b/contrib/scripts/check-crates.sh
@@ -37,6 +37,7 @@ buildargs=(
     "-p nostr --no-default-features --features alloc"             # Only alloc feature
     "-p nostr --no-default-features --features alloc,all-nips"    # alloc + all-nips
     "-p nostr-browser-signer --target wasm32-unknown-unknown"
+    "-p nostr-browser-signer-proxy"
     "-p nostr-blossom"
     "-p nostr-http-file-storage"
     "-p nostr-database"

--- a/contrib/scripts/release.sh
+++ b/contrib/scripts/release.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 args=(
     "-p nostr"
     "-p nostr-browser-signer"
+    "-p nostr-browser-signer-proxy"
     "-p nostr-database"
     "-p nostr-lmdb"
     "-p nostr-mls-storage"

--- a/signer/nostr-browser-signer-proxy/CHANGELOG.md
+++ b/signer/nostr-browser-signer-proxy/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+<!-- All notable changes to this project will be documented in this file. -->
+
+<!-- The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), -->
+<!-- and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). -->
+
+<!-- Template
+
+## Unreleased
+
+### Breaking changes
+
+### Changed
+
+### Added
+
+### Fixed
+
+### Removed
+
+### Deprecated
+
+-->
+
+## Unreleased
+
+First release.

--- a/signer/nostr-browser-signer-proxy/Cargo.toml
+++ b/signer/nostr-browser-signer-proxy/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "nostr-browser-signer-proxy"
+version = "0.1.0"
+edition = "2021"
+description = "Proxy to use Nostr Browser signer (NIP-07) in native applications."
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+readme = "README.md"
+rust-version.workspace = true
+keywords = ["nostr", "nip07", "browser", "signer", "proxy"]
+
+[dependencies]
+bytes = "1.10"
+http-body-util = "0.1"
+hyper = { version = "1.6", features = ["server", "http1"] }
+hyper-util = { version = "0.1", features = ["tokio"] }
+nostr = { workspace = true, features = ["std"] }
+serde = { workspace = true, features = ["std", "derive"] }
+serde_json = { workspace = true, features = ["std"] }
+tokio = { workspace = true, features = ["macros", "net", "rt", "rt-multi-thread", "sync", "time"] }
+tracing = { workspace = true, features = ["std"] }
+uuid = { version = "1.17", features = ["serde", "v4"] }
+
+[dev-dependencies]
+nostr = { workspace = true, features = ["nip59"] }
+tokio = { workspace = true, features = ["signal"] }

--- a/signer/nostr-browser-signer-proxy/README.md
+++ b/signer/nostr-browser-signer-proxy/README.md
@@ -1,0 +1,21 @@
+# Browser signer proxy (NIP-07)
+
+## Description
+
+Proxy to use Nostr Browser signer ([NIP-07](https://github.com/nostr-protocol/nips/blob/master/07.md)) in native applications.
+
+## Changelog
+
+All notable changes to this library are documented in the [CHANGELOG.md](CHANGELOG.md).
+
+## State
+
+**This library is in an ALPHA state**, things that are implemented generally work but the API will change in breaking ways.
+
+## Donations
+
+`rust-nostr` is free and open-source. This means we do not earn any revenue by selling it. Instead, we rely on your financial support. If you actively use any of the `rust-nostr` libs/software/services, then please [donate](https://rust-nostr.org/donate).
+
+## License
+
+This project is distributed under the MIT software license - see the [LICENSE](../../LICENSE) file for details

--- a/signer/nostr-browser-signer-proxy/examples/browser-signer-proxy.rs
+++ b/signer/nostr-browser-signer-proxy/examples/browser-signer-proxy.rs
@@ -1,0 +1,42 @@
+// Copyright (c) 2022-2023 Yuki Kishimoto
+// Copyright (c) 2023-2025 Rust Nostr Developers
+// Distributed under the MIT software license
+
+use std::time::Duration;
+
+use nostr_browser_signer_proxy::prelude::*;
+use tokio::{signal, time};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let proxy = BrowserSignerProxy::new(8080);
+
+    proxy.start().await?;
+
+    println!("Url: {}", proxy.url());
+
+    // Give time to open the webpage
+    time::sleep(Duration::from_secs(10)).await;
+
+    // Get public key
+    let public_key = proxy.get_public_key().await?;
+    println!("Public key: {}", public_key);
+
+    // Sign event
+    let event = EventBuilder::text_note("Testing browser signer proxy")
+        .sign(&proxy)
+        .await?;
+    println!("Event: {}", event.as_json());
+
+    // Build a gift wrap
+    let receiver =
+        PublicKey::parse("npub1drvpzev3syqt0kjrls50050uzf25gehpz9vgdw08hvex7e0vgfeq0eseet")?;
+    let rumor = EventBuilder::new(Kind::Custom(123), "test").build(public_key);
+    let gift_wrap = EventBuilder::gift_wrap(&proxy, &receiver, rumor, []).await?;
+    println!("Gift wrap: {}", gift_wrap.as_json());
+
+    // Keep up the program
+    signal::ctrl_c().await?;
+
+    Ok(())
+}

--- a/signer/nostr-browser-signer-proxy/index.html
+++ b/signer/nostr-browser-signer-proxy/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <title>NIP-07 Proxy</title>
+        <link rel="stylesheet" href="style.css">
+    </head>
+    <body>
+        <div class="container">
+            <h1>NIP-07 Proxy</h1>
+            <p>This page acts as a proxy between your native application and the NIP-07 browser extension.</p>
+            <div class="status-box">
+                <strong>Status:</strong> <span id="status">Checking...</span>
+            </div>
+            <p><small>Keep this tab open while using your application. The page will automatically poll for requests from your native app.</small></p>
+
+            <h3>Debug Info</h3>
+            <p><small>Check the browser console (F12) for detailed logs.</small></p>
+        </div>
+
+        <script src="proxy.js"></script>
+    </body>
+</html>

--- a/signer/nostr-browser-signer-proxy/proxy.js
+++ b/signer/nostr-browser-signer-proxy/proxy.js
@@ -1,0 +1,153 @@
+let isPolling = false;
+
+async function pollForRequests() {
+    if (isPolling) return;
+    isPolling = true;
+
+    try {
+        const response = await fetch('/api/pending');
+        const data = await response.json();
+
+        console.log('Polled for requests, got:', data);
+
+        // Process any new requests
+        if (data.requests && data.requests.length > 0) {
+            console.log(`Processing ${data.requests.length} requests`);
+            for (const request of data.requests) {
+                await handleNip07Request(request);
+            }
+        }
+    } catch (error) {
+        console.error('Polling error:', error);
+        updateStatus('Error: ' + error.message, 'error');
+    }
+
+    isPolling = false;
+}
+
+async function handleNip07Request(request) {
+    console.log('Handling request:', request);
+
+    try {
+        let result;
+
+        if (!window.nostr) {
+            throw new Error('NIP-07 extension not available');
+        }
+
+        switch (request.method) {
+            case 'get_public_key':
+                console.log('Calling nostr.getPublicKey()');
+                result = await window.nostr.getPublicKey();
+                console.log('Got public key:', result);
+                break;
+
+            case 'sign_event':
+                console.log('Calling nostr.signEvent() with:', request.params);
+                result = await window.nostr.signEvent(request.params);
+                console.log('Got signed event:', result);
+                break;
+
+            case 'nip04_encrypt':
+                console.log('Calling nostr.nip04.encrypt()');
+                result = await window.nostr.nip04.encrypt(
+                    request.params.public_key,
+                    request.params.content
+                );
+                break;
+
+            case 'nip04_decrypt':
+                console.log('Calling nostr.nip04.decrypt()');
+                result = await window.nostr.nip04.decrypt(
+                    request.params.public_key,
+                    request.params.content
+                );
+                break;
+
+            case 'nip44_encrypt':
+                console.log('Calling nostr.nip44.encrypt()');
+                result = await window.nostr.nip44.encrypt(
+                    request.params.public_key,
+                    request.params.content
+                );
+                break;
+
+            case 'nip44_decrypt':
+                console.log('Calling nostr.nip44.decrypt()');
+                result = await window.nostr.nip44.decrypt(
+                    request.params.public_key,
+                    request.params.content
+                );
+                break;
+
+
+            default:
+                throw new Error(`Unknown method: ${request.method}`);
+        }
+
+        // Send response back to server
+        const responsePayload = {
+            id: request.id,
+            result: result,
+            error: null
+        };
+
+        console.log('Sending response:', responsePayload);
+
+        await fetch('/api/response', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(responsePayload)
+        });
+
+        console.log('Response sent successfully');
+        updateStatus('Request processed successfully', 'connected');
+
+    } catch (error) {
+        console.error('Error handling request:', error);
+
+        // Send error response back to server
+        const errorPayload = {
+            id: request.id,
+            result: null,
+            error: error.message
+        };
+
+        console.log('Sending error response:', errorPayload);
+
+        await fetch('/api/response', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(errorPayload)
+        });
+
+        updateStatus('Error: ' + error.message, 'error');
+    }
+}
+
+function updateStatus(message, className) {
+    const statusEl = document.getElementById('status');
+    statusEl.textContent = message;
+    statusEl.className = className;
+}
+
+// Start polling when page loads
+window.addEventListener('load', () => {
+    console.log('NIP-07 Proxy loaded');
+
+    // Check if NIP-07 extension is available
+    if (window.nostr) {
+        console.log('NIP-07 extension detected');
+        updateStatus('Connected to NIP-07 extension - Ready', 'connected');
+    } else {
+        console.log('NIP-07 extension not found');
+        updateStatus('NIP-07 extension not found', 'error');
+    }
+
+    // Start polling every 500 ms
+    setInterval(pollForRequests, 500);
+});

--- a/signer/nostr-browser-signer-proxy/src/error.rs
+++ b/signer/nostr-browser-signer-proxy/src/error.rs
@@ -1,0 +1,76 @@
+// Copyright (c) 2022-2023 Yuki Kishimoto
+// Copyright (c) 2023-2025 Rust Nostr Developers
+// Distributed under the MIT software license
+
+//! Error
+
+use std::{fmt, io};
+
+use hyper::http;
+use nostr::event;
+use tokio::sync::oneshot::error::RecvError;
+
+/// Error
+#[derive(Debug)]
+pub enum Error {
+    /// I/O error
+    Io(io::Error),
+    /// HTTP error
+    Http(http::Error),
+    /// Json error
+    Json(serde_json::Error),
+    /// Event error
+    Event(event::Error),
+    /// Oneshot channel receive error
+    OneShotRecv(RecvError),
+    /// Generic error
+    Generic(String),
+    /// Timeout
+    Timeout,
+}
+
+impl std::error::Error for Error {}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(e) => write!(f, "{e}"),
+            Self::Http(e) => write!(f, "{e}"),
+            Self::Json(e) => write!(f, "{e}"),
+            Self::Event(e) => write!(f, "{e}"),
+            Self::OneShotRecv(e) => write!(f, "{e}"),
+            Self::Generic(e) => write!(f, "{e}"),
+            Self::Timeout => write!(f, "timeout"),
+        }
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(e: io::Error) -> Self {
+        Self::Io(e)
+    }
+}
+
+impl From<http::Error> for Error {
+    fn from(e: http::Error) -> Self {
+        Self::Http(e)
+    }
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(e: serde_json::Error) -> Self {
+        Self::Json(e)
+    }
+}
+
+impl From<event::Error> for Error {
+    fn from(e: event::Error) -> Self {
+        Self::Event(e)
+    }
+}
+
+impl From<RecvError> for Error {
+    fn from(e: RecvError) -> Self {
+        Self::OneShotRecv(e)
+    }
+}

--- a/signer/nostr-browser-signer-proxy/src/lib.rs
+++ b/signer/nostr-browser-signer-proxy/src/lib.rs
@@ -1,0 +1,509 @@
+// Copyright (c) 2022-2023 Yuki Kishimoto
+// Copyright (c) 2023-2025 Rust Nostr Developers
+// Distributed under the MIT software license
+
+//! Proxy to use Nostr Browser signer ([NIP-07](https://github.com/nostr-protocol/nips/blob/master/07.md)) in native applications.
+//!
+//! <https://github.com/nostr-protocol/nips/blob/master/07.md>
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+#![warn(clippy::large_futures)]
+#![warn(rustdoc::bare_urls)]
+
+use std::collections::HashMap;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::Bytes;
+use http_body_util::combinators::BoxBody;
+use http_body_util::{BodyExt, Full};
+use hyper::body::Incoming;
+use hyper::server::conn::http1;
+use hyper::service::service_fn;
+use hyper::{Method, Request, Response, StatusCode};
+use hyper_util::rt::TokioIo;
+use nostr::prelude::{BoxedFuture, SignerBackend};
+use nostr::{Event, NostrSigner, PublicKey, SignerError, UnsignedEvent};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize, Serializer};
+use serde_json::{json, Value};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::oneshot::Sender;
+use tokio::sync::{oneshot, Mutex, Notify, OnceCell};
+use tokio::task::JoinHandle;
+use tokio::time;
+use uuid::Uuid;
+
+mod error;
+pub mod prelude;
+
+pub use self::error::Error;
+
+const HTML: &str = include_str!("../index.html");
+const JS: &str = include_str!("../proxy.js");
+const CSS: &str = include_str!("../style.css");
+const IP_ADDR: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
+const TIMEOUT: Duration = Duration::from_secs(30);
+
+type PendingResponseMap = HashMap<Uuid, Sender<Result<Value, String>>>;
+
+#[derive(Debug, Deserialize)]
+struct Message {
+    id: Uuid,
+    error: Option<String>,
+    result: Option<Value>,
+}
+
+impl Message {
+    fn into_result(self) -> Result<Value, String> {
+        if let Some(error) = self.error {
+            Err(error)
+        } else {
+            Ok(self.result.unwrap_or(Value::Null))
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum RequestMethod {
+    GetPublicKey,
+    SignEvent,
+    Nip04Encrypt,
+    Nip04Decrypt,
+    Nip44Encrypt,
+    Nip44Decrypt,
+}
+
+impl RequestMethod {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::GetPublicKey => "get_public_key",
+            Self::SignEvent => "sign_event",
+            Self::Nip04Encrypt => "nip04_encrypt",
+            Self::Nip04Decrypt => "nip04_decrypt",
+            Self::Nip44Encrypt => "nip44_encrypt",
+            Self::Nip44Decrypt => "nip44_decrypt",
+        }
+    }
+}
+
+impl Serialize for RequestMethod {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct RequestData {
+    id: Uuid,
+    method: RequestMethod,
+    params: Value,
+}
+
+impl RequestData {
+    #[inline]
+    fn new(method: RequestMethod, params: Value) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            method,
+            params,
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct Requests<'a> {
+    requests: &'a [RequestData],
+}
+
+impl<'a> Requests<'a> {
+    #[inline]
+    fn new(requests: &'a [RequestData]) -> Self {
+        Self { requests }
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        self.requests.len()
+    }
+}
+
+/// Params for NIP-04 and NIP-44 encryption/decryption
+#[derive(Serialize)]
+struct CryptoParams<'a> {
+    public_key: &'a PublicKey,
+    content: &'a str,
+}
+
+impl<'a> CryptoParams<'a> {
+    #[inline]
+    fn new(public_key: &'a PublicKey, content: &'a str) -> Self {
+        Self {
+            public_key,
+            content,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ProxyState {
+    // Requests waiting to be picked up by browser
+    pub outgoing_requests: Mutex<Vec<RequestData>>,
+    // Map of request ID to response sender
+    pub pending_responses: Mutex<PendingResponseMap>,
+}
+
+/// Nostr Browser Signer Proxy
+///
+/// Proxy to use Nostr Browser signer (NIP-07) in native applications.
+#[derive(Debug, Clone)]
+pub struct BrowserSignerProxy {
+    port: u16,
+    state: Arc<ProxyState>,
+    handle: OnceCell<Arc<JoinHandle<()>>>,
+    shutdown: Arc<Notify>,
+}
+
+// TODO: use atomic-destructor to automatically shutdown this when all instances are dropped
+
+impl BrowserSignerProxy {
+    // TODO: use a builder instead, to allow to config IP, port, timeout and so on.
+    /// Construct a new browser signer proxy
+    pub fn new(port: u16) -> Self {
+        let state = ProxyState {
+            outgoing_requests: Mutex::new(Vec::new()),
+            pending_responses: Mutex::new(HashMap::new()),
+        };
+
+        Self {
+            port,
+            state: Arc::new(state),
+            handle: OnceCell::new(),
+            shutdown: Arc::new(Notify::new()),
+        }
+    }
+
+    /// Get the signer proxy webpage URL
+    #[inline]
+    pub fn url(&self) -> String {
+        format!("http://{IP_ADDR}:{}", self.port)
+    }
+
+    /// Start the proxy
+    ///
+    /// If this is not called, will be automatically started on the first interaction with the signer.
+    pub async fn start(&self) -> Result<(), Error> {
+        let _handle: &Arc<JoinHandle<()>> = self
+            .handle
+            .get_or_try_init(|| async {
+                let addr: SocketAddr = SocketAddr::new(IP_ADDR, self.port);
+                let listener = TcpListener::bind(addr).await?;
+
+                let state = self.state.clone();
+                let shutdown = self.shutdown.clone();
+
+                let handle: JoinHandle<()> = tokio::spawn(async move {
+                    loop {
+                        tokio::select! {
+                            res = listener.accept() => {
+                                let stream: TcpStream = match res {
+                                    Ok((stream, ..)) => stream,
+                                    Err(e) => {
+                                        tracing::error!("Failed to accept connection: {}", e);
+                                        continue;
+                                    }
+                                };
+
+                                let io: TokioIo<TcpStream> = TokioIo::new(stream);
+                                let state: Arc<ProxyState> = state.clone();
+
+                                tokio::spawn(async move {
+                                    let service = service_fn(move |req| {
+                                        handle_request(req, state.clone())
+                                    });
+
+                                    if let Err(e) = http1::Builder::new()
+                                        .serve_connection(io, service)
+                                        .await
+                                    {
+                                        tracing::error!("Error serving connection: {e}");
+                                    }
+                                });
+                            },
+                            _ = shutdown.notified() => {
+                                break;
+                            }
+                        }
+                    }
+
+                    tracing::info!("Shutting down proxy server.");
+                });
+
+                Ok::<_, Error>(Arc::new(handle))
+            })
+            .await?;
+        Ok(())
+    }
+
+    #[inline]
+    async fn store_pending_response(&self, id: Uuid, tx: Sender<Result<Value, String>>) {
+        let mut pending_responses = self.state.pending_responses.lock().await;
+        pending_responses.insert(id, tx);
+    }
+
+    #[inline]
+    async fn store_outgoing_request(&self, request: RequestData) {
+        let mut outgoing_requests = self.state.outgoing_requests.lock().await;
+        outgoing_requests.push(request);
+    }
+
+    async fn request<T>(&self, method: RequestMethod, params: Value) -> Result<T, Error>
+    where
+        T: DeserializeOwned,
+    {
+        self.start().await?;
+
+        // Construct the request
+        let request: RequestData = RequestData::new(method, params);
+
+        // Create a oneshot channel
+        let (tx, rx) = oneshot::channel();
+
+        // Store the response sender
+        self.store_pending_response(request.id, tx).await;
+
+        // Add to outgoing requests queue
+        self.store_outgoing_request(request).await;
+
+        // Wait for response
+        match time::timeout(TIMEOUT, rx)
+            .await
+            .map_err(|_| Error::Timeout)??
+        {
+            Ok(res) => Ok(serde_json::from_value(res)?),
+            Err(error) => Err(Error::Generic(error)),
+        }
+    }
+
+    #[inline]
+    async fn _get_public_key(&self) -> Result<PublicKey, Error> {
+        self.request(RequestMethod::GetPublicKey, json!({})).await
+    }
+
+    #[inline]
+    async fn _sign_event(&self, event: UnsignedEvent) -> Result<Event, Error> {
+        let event: Event = self
+            .request(RequestMethod::SignEvent, serde_json::to_value(event)?)
+            .await?;
+        event.verify()?;
+        Ok(event)
+    }
+
+    #[inline]
+    async fn _nip04_encrypt(&self, public_key: &PublicKey, content: &str) -> Result<String, Error> {
+        let params = CryptoParams::new(public_key, content);
+        self.request(RequestMethod::Nip04Encrypt, serde_json::to_value(params)?)
+            .await
+    }
+
+    #[inline]
+    async fn _nip04_decrypt(&self, public_key: &PublicKey, content: &str) -> Result<String, Error> {
+        let params = CryptoParams::new(public_key, content);
+        self.request(RequestMethod::Nip04Decrypt, serde_json::to_value(params)?)
+            .await
+    }
+
+    #[inline]
+    async fn _nip44_encrypt(&self, public_key: &PublicKey, content: &str) -> Result<String, Error> {
+        let params = CryptoParams::new(public_key, content);
+        self.request(RequestMethod::Nip44Encrypt, serde_json::to_value(params)?)
+            .await
+    }
+
+    #[inline]
+    async fn _nip44_decrypt(&self, public_key: &PublicKey, content: &str) -> Result<String, Error> {
+        let params = CryptoParams::new(public_key, content);
+        self.request(RequestMethod::Nip44Decrypt, serde_json::to_value(params)?)
+            .await
+    }
+}
+
+impl NostrSigner for BrowserSignerProxy {
+    fn backend(&self) -> SignerBackend {
+        SignerBackend::BrowserExtension
+    }
+
+    #[inline]
+    fn get_public_key(&self) -> BoxedFuture<Result<PublicKey, SignerError>> {
+        Box::pin(async move { self._get_public_key().await.map_err(SignerError::backend) })
+    }
+
+    #[inline]
+    fn sign_event(&self, unsigned: UnsignedEvent) -> BoxedFuture<Result<Event, SignerError>> {
+        Box::pin(async move {
+            self._sign_event(unsigned)
+                .await
+                .map_err(SignerError::backend)
+        })
+    }
+
+    #[inline]
+    fn nip04_encrypt<'a>(
+        &'a self,
+        public_key: &'a PublicKey,
+        content: &'a str,
+    ) -> BoxedFuture<'a, Result<String, SignerError>> {
+        Box::pin(async move {
+            self._nip04_encrypt(public_key, content)
+                .await
+                .map_err(SignerError::backend)
+        })
+    }
+
+    #[inline]
+    fn nip04_decrypt<'a>(
+        &'a self,
+        public_key: &'a PublicKey,
+        encrypted_content: &'a str,
+    ) -> BoxedFuture<'a, Result<String, SignerError>> {
+        Box::pin(async move {
+            self._nip04_decrypt(public_key, encrypted_content)
+                .await
+                .map_err(SignerError::backend)
+        })
+    }
+
+    #[inline]
+    fn nip44_encrypt<'a>(
+        &'a self,
+        public_key: &'a PublicKey,
+        content: &'a str,
+    ) -> BoxedFuture<'a, Result<String, SignerError>> {
+        Box::pin(async move {
+            self._nip44_encrypt(public_key, content)
+                .await
+                .map_err(SignerError::backend)
+        })
+    }
+
+    #[inline]
+    fn nip44_decrypt<'a>(
+        &'a self,
+        public_key: &'a PublicKey,
+        payload: &'a str,
+    ) -> BoxedFuture<'a, Result<String, SignerError>> {
+        Box::pin(async move {
+            self._nip44_decrypt(public_key, payload)
+                .await
+                .map_err(SignerError::backend)
+        })
+    }
+}
+
+async fn handle_request(
+    req: Request<Incoming>,
+    state: Arc<ProxyState>,
+) -> Result<Response<BoxBody<Bytes, Error>>, Error> {
+    match (req.method(), req.uri().path()) {
+        // Serve the HTML proxy page
+        (&Method::GET, "/") => Ok(Response::builder()
+            .header("Content-Type", "text/html")
+            .body(full(HTML))?),
+        // Serve the CSS page style
+        (&Method::GET, "/style.css") => Ok(Response::builder()
+            .header("Content-Type", "text/css")
+            .body(full(CSS))?),
+        // Serve the JS proxy script
+        (&Method::GET, "/proxy.js") => Ok(Response::builder()
+            .header("Content-Type", "application/javascript")
+            .body(full(JS))?),
+        // Browser polls this endpoint to get pending requests
+        (&Method::GET, "/api/pending") => {
+            let mut outgoing = state.outgoing_requests.lock().await;
+
+            let requests: Requests<'_> = Requests::new(&outgoing);
+            let json: String = serde_json::to_string(&requests)?;
+
+            tracing::debug!("Sending {} pending requests to browser", requests.len());
+
+            // Clear the outgoing requests after sending them
+            outgoing.clear();
+
+            Ok(Response::builder()
+                .header("Content-Type", "application/json")
+                .header("Access-Control-Allow-Origin", "*")
+                .body(full(json))?)
+        }
+        // Get response
+        (&Method::POST, "/api/response") => {
+            // Correctly collect the body bytes from the stream
+            let body_bytes: Bytes = match req.into_body().collect().await {
+                Ok(collected) => collected.to_bytes(),
+                Err(e) => {
+                    tracing::error!("Failed to read body: {e}");
+                    let response = Response::builder()
+                        .status(StatusCode::BAD_REQUEST)
+                        .body(full("Failed to read body"))?;
+                    return Ok(response);
+                }
+            };
+
+            // Handle responses from the browser extension
+            let message: Message = match serde_json::from_slice(&body_bytes) {
+                Ok(json) => json,
+                Err(_) => {
+                    let response = Response::builder()
+                        .status(StatusCode::BAD_REQUEST)
+                        .body(full("Invalid JSON"))?;
+                    return Ok(response);
+                }
+            };
+
+            tracing::debug!("Received response from browser: {message:?}");
+
+            let id: Uuid = message.id;
+            let mut pending = state.pending_responses.lock().await;
+
+            match pending.remove(&id) {
+                Some(sender) => {
+                    let _ = sender.send(message.into_result());
+                    tracing::info!("Forwarded response for request {id}");
+                }
+                None => tracing::warn!("No pending request found for {id}"),
+            }
+
+            let response = Response::builder()
+                .header("Access-Control-Allow-Origin", "*")
+                .body(full("OK"))?;
+            Ok(response)
+        }
+        (&Method::OPTIONS, _) => {
+            // Handle CORS preflight requests
+            let response = Response::builder()
+                .header("Access-Control-Allow-Origin", "*")
+                .header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+                .header("Access-Control-Allow-Headers", "Content-Type")
+                .body(full(""))?;
+            Ok(response)
+        }
+        // 404 - not found
+        _ => {
+            let response = Response::builder()
+                .status(StatusCode::NOT_FOUND)
+                .body(full("Not Found"))?;
+            Ok(response)
+        }
+    }
+}
+
+#[inline]
+fn full<T: Into<Bytes>>(chunk: T) -> BoxBody<Bytes, Error> {
+    Full::new(chunk.into())
+        .map_err(|never| match never {})
+        .boxed()
+}

--- a/signer/nostr-browser-signer-proxy/src/prelude.rs
+++ b/signer/nostr-browser-signer-proxy/src/prelude.rs
@@ -1,0 +1,14 @@
+// Copyright (c) 2022-2023 Yuki Kishimoto
+// Copyright (c) 2023-2025 Rust Nostr Developers
+// Distributed under the MIT software license
+
+//! Prelude
+
+#![allow(unknown_lints)]
+#![allow(ambiguous_glob_reexports)]
+#![doc(hidden)]
+
+pub use nostr::prelude::*;
+
+pub use crate::error::*;
+pub use crate::*;

--- a/signer/nostr-browser-signer-proxy/style.css
+++ b/signer/nostr-browser-signer-proxy/style.css
@@ -1,0 +1,28 @@
+body {
+    font-family: Arial, sans-serif;
+    padding: 20px;
+    background-color: #f0f0f0;
+}
+.container {
+    max-width: 600px;
+    margin: 0 auto;
+    background: white;
+    padding: 20px;
+    border-radius: 8px;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+}
+.connected {
+    color: green;
+    font-weight: bold;
+}
+.error {
+    color: red;
+    font-weight: bold;
+}
+.status-box {
+    background: #f9f9f9;
+    padding: 10px;
+    border-radius: 4px;
+    margin: 10px 0;
+    border-left: 4px solid #ccc;
+}


### PR DESCRIPTION
Add `nostr-browser-signer-proxy` crate, to allow using NIP-07 signer in native applications.