### PR TITLE
browser-signer-proxy: Options for `BrowserSignerProxy`

### DIFF
--- a/signer/nostr-browser-signer-proxy/examples/browser-signer-proxy.rs
+++ b/signer/nostr-browser-signer-proxy/examples/browser-signer-proxy.rs
@@ -9,7 +9,7 @@ use tokio::{signal, time};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let proxy = BrowserSignerProxy::new(8080);
+    let proxy = BrowserSignerProxy::new(BrowserSignerProxyOptions::default());
 
     proxy.start().await?;
 


### PR DESCRIPTION
### Description

Resolve a `TODO` comment. Adding some simple options for `BrowserSignerProxy`

### Note

I added `serde::Serialize` and `serde::Deserialize`. So if the clients want to store the options in a file.

### Checklist

* [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [X] I ran `just precommit` or `just check` before committing
* [ ] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
