### PR TITLE
browser-signer-proxy: `Drop` and `AtomicDestroyer` for `BrowserSignerProxy`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2886,6 +2886,7 @@ dependencies = [
 name = "nostr-browser-signer-proxy"
 version = "0.1.0"
 dependencies = [
+ "atomic-destructor",
  "bytes",
  "http-body-util",
  "hyper",

--- a/signer/nostr-browser-signer-proxy/Cargo.toml
+++ b/signer/nostr-browser-signer-proxy/Cargo.toml
@@ -12,6 +12,7 @@ rust-version.workspace = true
 keywords = ["nostr", "nip07", "browser", "signer", "proxy"]
 
 [dependencies]
+atomic-destructor.workspace = true
 bytes = "1.10"
 http-body-util = "0.1"
 hyper = { version = "1.6", features = ["server", "http1"] }
@@ -19,7 +20,14 @@ hyper-util = { version = "0.1", features = ["tokio"] }
 nostr = { workspace = true, features = ["std"] }
 serde = { workspace = true, features = ["std", "derive"] }
 serde_json = { workspace = true, features = ["std"] }
-tokio = { workspace = true, features = ["macros", "net", "rt", "rt-multi-thread", "sync", "time"] }
+tokio = { workspace = true, features = [
+  "macros",
+  "net",
+  "rt",
+  "rt-multi-thread",
+  "sync",
+  "time",
+] }
 tracing = { workspace = true, features = ["std"] }
 uuid = { version = "1.17", features = ["serde", "v4"] }
 


### PR DESCRIPTION
### Description

Once the proxy is dropped, it will no longer accept new connections and all existing connections will be terminated.

### Notes to the reviewers

I'm uncertain whether `AtomicDestroyer` correctly implements the functionality needed to address the `TODO` I removed.

### Checklist

* [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [X] I ran `just precommit` or `just check` before committing
* [ ] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
