### PR TITLE
lmdb: add max_readers and additional_dbs fields to NostrLmdbBuilder

### DIFF
--- a/database/nostr-lmdb/CHANGELOG.md
+++ b/database/nostr-lmdb/CHANGELOG.md
@@ -32,6 +32,7 @@
 ### Added
 
 - Add NostrLmdbBuilder and allow setting a custom map size (https://github.com/rust-nostr/nostr/pull/970)
+- Add `max_readers` and `additional_dbs` fields to `NostrLmdbBuilder`
 
 ## v0.42.0 - 2025/05/20
 

--- a/database/nostr-lmdb/src/store/lmdb/mod.rs
+++ b/database/nostr-lmdb/src/store/lmdb/mod.rs
@@ -48,7 +48,12 @@ pub(crate) struct Lmdb {
 }
 
 impl Lmdb {
-    pub(super) fn new<P>(path: P, map_size: usize) -> Result<Self, Error>
+    pub(super) fn new<P>(
+        path: P,
+        map_size: usize,
+        max_readers: u32,
+        additional_dbs: u32,
+    ) -> Result<Self, Error>
     where
         P: AsRef<Path>,
     {
@@ -56,7 +61,8 @@ impl Lmdb {
         let env: Env = unsafe {
             EnvOpenOptions::new()
                 .flags(EnvFlags::NO_TLS)
-                .max_dbs(9)
+                .max_dbs(9 + additional_dbs)
+                .max_readers(max_readers)
                 .map_size(map_size)
                 .open(path)?
         };

--- a/database/nostr-lmdb/src/store/mod.rs
+++ b/database/nostr-lmdb/src/store/mod.rs
@@ -27,7 +27,12 @@ pub struct Store {
 }
 
 impl Store {
-    pub(super) fn open<P>(path: P, map_size: usize) -> Result<Store, Error>
+    pub(super) fn open<P>(
+        path: P,
+        map_size: usize,
+        max_readers: u32,
+        additional_dbs: u32,
+    ) -> Result<Store, Error>
     where
         P: AsRef<Path>,
     {
@@ -36,7 +41,7 @@ impl Store {
         // Create the directory if it doesn't exist
         fs::create_dir_all(path)?;
 
-        let db: Lmdb = Lmdb::new(path, map_size)?;
+        let db: Lmdb = Lmdb::new(path, map_size, max_readers, additional_dbs)?;
         let ingester: Sender<IngesterItem> = Ingester::run(db.clone());
 
         Ok(Self { db, ingester })


### PR DESCRIPTION
### Description

Add max_readers and additional_dbs configuration options to NostrLmdbBuilder to allow fine-tuning of LMDB environment settings.

- **max_readers**: Controls the maximum number of reader threads (defaults to 126)
- **additional_dbs**: Specifies additional database slots beyond the 9 internal ones (defaults to 0)

This addresses part of the feedback from PR #992 where the reviewer suggested changing the parameter name to `additional_dbs` since 9 databases are already defined internally.

### Notes to the reviewers

- Following the same pattern as the existing `map_size` field
- All parameters cascade through: NostrLmdbBuilder → Store → Lmdb
- Uses sensible defaults (126 for max_readers, 0 for additional_dbs)
- No breaking changes - all existing code continues to work

### Checklist

* [x] I followed the contribution guidelines
* [x] I ran `just precommit` before committing  
* [x] I updated the CHANGELOG