### PR TITLE
relay-pool: add TransportSink for WebSocket

### DIFF
--- a/crates/nostr-relay-pool/CHANGELOG.md
+++ b/crates/nostr-relay-pool/CHANGELOG.md
@@ -44,6 +44,10 @@
 - An option to ban relays that send events which don't match the subscription filter (https://github.com/rust-nostr/nostr/pull/981)
 - Add `RelayOptions::verify_subscriptions` option (https://github.com/rust-nostr/nostr/pull/997)
 
+### Fixed
+
+- Fix panic after a broken pipe error in the relay connection (https://github.com/rust-nostr/nostr/pull/1007)
+
 ## v0.42.0 - 2025/05/20
 
 ### Breaking changes


### PR DESCRIPTION
Add the `TransportSink` struct as a replacement for the `sink_map_err` method that was causing panics in case of connection interruption (i.e., broken pipe error).

Fixes https://github.com/rust-nostr/nostr/issues/984

Replaces #987