### PR TITLE
nwc: Add `NWC::reconnect_relay`

### DIFF
--- a/crates/nwc/CHANGELOG.md
+++ b/crates/nwc/CHANGELOG.md
@@ -23,6 +23,12 @@
 
 -->
 
+## Unreleased
+
+### Added
+
+- Add `NWC::reconnect_relay` (https://github.com/rust-nostr/nostr/pull/1020)
+
 ## v0.43.0 - 2025/07/28
 
 ### Added

--- a/crates/nwc/src/lib.rs
+++ b/crates/nwc/src/lib.rs
@@ -312,6 +312,24 @@ impl NWC {
         Ok(())
     }
 
+    /// Manually reconnect to a specific relay
+    ///
+    /// This function can be used to force a reconnection to a relay when automatic reconnection
+    /// is disabled via [`RelayOptions::reconnect`].
+    ///
+    /// If the client is not bootstrapped, it will do nothing.
+    pub async fn reconnect_relay<U>(&self, url: U) -> Result<(), Error>
+    where
+        U: TryIntoUrl,
+        pool::Error: From<<U as TryIntoUrl>::Err>,
+    {
+        if !self.bootstrapped.load(Ordering::SeqCst) {
+            return Ok(());
+        }
+
+        Ok(self.pool.connect_relay(url).await?)
+    }
+
     /// Completely shutdown [NWC] client
     #[inline]
     pub async fn shutdown(self) {


### PR DESCRIPTION
### Description

This function can be used to force a reconnection to a relay when automatic reconnection is disabled via `RelayOptions::reconnect`.

### Notes to the reviewers

### Checklist

* [x] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [x] I ran `just precommit` or `just check` before committing
* [x] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
