### PR TITLE
nostr: synchronize nip47 fields with current spec

### DIFF
--- a/crates/nostr/CHANGELOG.md
+++ b/crates/nostr/CHANGELOG.md
@@ -23,6 +23,14 @@
 
 -->
 
+## Unreleased
+
+### Added
+- Add ``nip47`` ``state`` field for transactions
+
+### Changed
+- ``nip47`` fields synchronized with current spec
+
 ## v0.43.0 - 2025/07/28
 
 ### Breaking changes

--- a/crates/nostr/src/nips/nip47.rs
+++ b/crates/nostr/src/nips/nip47.rs
@@ -357,6 +357,23 @@ pub enum TransactionType {
     Outgoing,
 }
 
+/// Transaction State
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum TransactionState {
+    /// Pending
+    #[serde(rename = "pending")]
+    Pending,
+    /// Settled
+    #[serde(rename = "settled")]
+    Settled,
+    /// Expired (for invoices)
+    #[serde(rename = "expired")]
+    Expired,
+    /// Failed (for payments)
+    #[serde(rename = "failed")]
+    Failed,
+}
+
 /// List Transactions Request
 #[derive(Debug, Clone, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ListTransactionsRequest {
@@ -546,6 +563,7 @@ pub struct PayInvoiceResponse {
     /// Response preimage
     pub preimage: String,
     /// Fees paid
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub fees_paid: Option<u64>,
 }
 
@@ -554,15 +572,45 @@ pub struct PayInvoiceResponse {
 pub struct PayKeysendResponse {
     /// Response preimage
     pub preimage: String,
+    /// Fees paid
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fees_paid: Option<u64>,
 }
 
 /// Make Invoice Response
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct MakeInvoiceResponse {
-    /// Bolt 11 invoice
+    /// Transaction type
+    #[serde(rename = "type")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transaction_type: Option<TransactionType>,
+    /// Transaction state
+    pub state: TransactionState,
+    /// Bolt11 invoice
     pub invoice: String,
+    /// Invoice's description
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Invoice's description hash
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description_hash: Option<String>,
+    /// Payment preimage
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub preimage: Option<String>,
     /// Invoice's payment hash
     pub payment_hash: String,
+    /// Amount in millisatoshis
+    pub amount: u64,
+    /// Fees paid in millisatoshis
+    pub fees_paid: u64,
+    /// Creation timestamp in seconds since epoch
+    pub created_at: Timestamp,
+    /// Expiration timestamp in seconds since epoch
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<Timestamp>,
+    /// Optional metadata about the payment
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Value>,
 }
 
 /// Lookup Invoice Response
@@ -572,6 +620,8 @@ pub struct LookupInvoiceResponse {
     #[serde(rename = "type")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub transaction_type: Option<TransactionType>,
+    /// Transaction state
+    pub state: TransactionState,
     /// Bolt11 invoice
     #[serde(skip_serializing_if = "Option::is_none")]
     pub invoice: Option<String>,
@@ -1170,6 +1220,8 @@ pub struct PaymentNotification {
     #[serde(rename = "type")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub transaction_type: Option<TransactionType>,
+    /// Transaction state
+    pub state: TransactionState,
     /// Bolt11 invoice
     pub invoice: String,
     /// Invoice's description
@@ -1309,6 +1361,7 @@ mod tests {
             result: Some(ResponseResult::ListTransactions(vec![
                 LookupInvoiceResponse {
                     transaction_type: Some(TransactionType::Incoming),
+                    state: TransactionState::Expired,
                     invoice: Some(String::from("abcd")),
                     description: Some(String::from("string")),
                     amount: 123,
@@ -1339,6 +1392,7 @@ mod tests {
                 "transactions": [
                     {
                        "type": "incoming",
+                       "state": "expired",
                        "invoice": "abcd",
                        "description": "string",
                        "payment_hash": "",
@@ -1358,6 +1412,7 @@ mod tests {
             Some(ResponseResult::ListTransactions(vec![
                 LookupInvoiceResponse {
                     transaction_type: Some(TransactionType::Incoming),
+                    state: TransactionState::Expired,
                     invoice: Some(String::from("abcd")),
                     description: Some(String::from("string")),
                     amount: 123,
@@ -1380,6 +1435,7 @@ mod tests {
             "notification_type": "payment_received",
             "notification": {
                 "type": "incoming",
+                "state": "settled",
                 "invoice": "abcd",
                 "description": "string1",
                 "description_hash": "string2",
@@ -1400,6 +1456,7 @@ mod tests {
         );
         let notification_result = NotificationResult::PaymentReceived(PaymentNotification {
             transaction_type: Some(TransactionType::Incoming),
+            state: TransactionState::Settled,
             invoice: String::from("abcd"),
             description: Some(String::from("string1")),
             description_hash: Some(String::from("string2")),


### PR DESCRIPTION


### Description

notably adding state field for transactions : https://github.com/nostr-protocol/nips/pull/1933



### Checklist

* [x] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [x] I ran `just precommit` or `just check` before committing
* [x] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
