### PR TITLE
relay-pool: fix `ban_relay_on_mismatch` requiring `verify_subscriptions` in `RelayOptions`

### DIFF
--- a/crates/nostr-relay-pool/CHANGELOG.md
+++ b/crates/nostr-relay-pool/CHANGELOG.md
@@ -23,6 +23,12 @@
 
 -->
 
+## Unreleased
+
+### Fixed
+
+- `ban_relay_on_mismatch` no longer requires `verify_subscriptions` to be enabled.
+
 ## v0.43.0 - 2025/07/28
 
 ### Breaking changes

--- a/crates/nostr-relay-pool/src/relay/inner.rs
+++ b/crates/nostr-relay-pool/src/relay/inner.rs
@@ -1117,7 +1117,7 @@ impl InnerRelay {
         }
 
         // Check if subscription must be verified
-        if self.opts.verify_subscriptions {
+        if self.opts.verify_subscriptions || self.opts.ban_relay_on_mismatch {
             // NOTE: here we don't use the `self.subscription(id)` to avoid an unnecessary clone of the filter!
 
             // Acquire read lock


### PR DESCRIPTION
Fixes: #1022

### Description

`RelayOptions::ban_relay_on_mismatch` doesn't depends on `RelayOptions::verify_subscriptions` anymore, the events will be checked if one of them is enabled.

### Checklist

* [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [X] I ran `just precommit` or `just check` before committing
* [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
