### PR TITLE
browser-signer-proxy: `BrowserSignerProxy::is_session_active` to return whether the session is active or not

### DIFF
--- a/signer/nostr-browser-signer-proxy/CHANGELOG.md
+++ b/signer/nostr-browser-signer-proxy/CHANGELOG.md
@@ -28,6 +28,7 @@
 ### Added
 
 - `BrowserSignerProxy::is_started` function to know if the server currently running or not (https://github.com/rust-nostr/nostr/pull/1025)
+- `BrowserSignerProxy::is_session_active` returns whether there is an active session with the browser (https://github.com/rust-nostr/nostr/pull/1026)
 
 ## v0.43.0 - 2025/07/28
 

--- a/signer/nostr-browser-signer-proxy/examples/browser-signer-proxy.rs
+++ b/signer/nostr-browser-signer-proxy/examples/browser-signer-proxy.rs
@@ -17,8 +17,13 @@ async fn main() -> Result<()> {
 
     println!("Url: {}", proxy.url());
 
-    // Give time to open the webpage
-    time::sleep(Duration::from_secs(10)).await;
+    // Waits until the proxy session becomes active, checking every second.
+    loop {
+        if proxy.is_session_active() {
+            break;
+        }
+        time::sleep(Duration::from_secs(1)).await;
+    }
 
     // Get public key
     let public_key = proxy.get_public_key().await?;


### PR DESCRIPTION
### Description

A function that returns `true` if the user is connected to the server and `false` if not

### Checklist

* [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [X] I ran `just precommit` or `just check` before committing
* [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)

