### PR TITLE
sdk: `Client::public_key` function to retrieve the public key

### DIFF
--- a/crates/nostr-sdk/CHANGELOG.md
+++ b/crates/nostr-sdk/CHANGELOG.md
@@ -23,6 +23,12 @@
 
 -->
 
+## Unreleased
+
+### Added
+
+- `Client::public_key` function to retrieve the public key (https://github.com/rust-nostr/nostr/pull/1028)
+
 ## v0.43.0 - 2025/07/28
 
 ### Breaking changes

--- a/crates/nostr-sdk/src/client/mod.rs
+++ b/crates/nostr-sdk/src/client/mod.rs
@@ -145,6 +145,17 @@ impl Client {
         self.pool.state().unset_signer().await;
     }
 
+    /// Retrieves the client's public key
+    ///
+    /// # Errors
+    ///
+    /// - If the signer isn't set.
+    /// - Error by the signer.
+    #[inline]
+    pub async fn public_key(&self) -> Result<PublicKey, Error> {
+        Ok(self.signer().await?.get_public_key().await?)
+    }
+
     /// Get [`RelayPool`]
     #[inline]
     pub fn pool(&self) -> &RelayPool {


### PR DESCRIPTION
### Description

`Client::public_key` function to retrieve the public key

### Checklist

* [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [X] I ran `just precommit` or `just check` before committing
* [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
