### PR TITLE
nostr(NIP-22): Ability to create a `CommentTarget` from specific event

### DIFF
--- a/crates/nostr/CHANGELOG.md
+++ b/crates/nostr/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Add nip47 holdinvoice methods and notification (https://github.com/rust-nostr/nostr/pull/1019)
 - Add NIP-47 `state` field for transactions (https://github.com/rust-nostr/nostr/pull/1021)
 - Add `nip47::Method::as_str` method
+- Add `CommentTarget::{event, coordinate, external}` to point to a specific thing (https://github.com/rust-nostr/nostr/pull/1034)
 
 ### Changed
 
@@ -39,6 +40,10 @@
 ### Deprecated
 
 - Deprecate `kind` field in `CommentTarget::Coordinate` variant (https://github.com/rust-nostr/nostr/pull/1035)
+
+### Breaking changes
+
+- Change the `address` field type in `CommentTarget::Coordinate` to `CoordinateBorrow` (https://github.com/rust-nostr/nostr/pull/1034)
 
 ## v0.43.0 - 2025/07/28
 


### PR DESCRIPTION
### Description

- Add `CommentTarget::event` to construct from an event
- Add `CommentTarget::coordinate` to construct from a coordinate
- Add `CommentTarget::external` to construct from an external content
- Impl `From<&'a Event'> for CommentTarget<'a'>` to construct from `&Event`
- Change the type of `address` field in `CommentTarget::Coordinate ` from `&'a Coordinate` to `CoordinateBorrow<'a>`

Why?:

To use it in `EventBuilder::comment` and
`EventBuilder::voice_message_reply` (#1032)

### Checklist

* [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
* [X] I ran `just precommit` or `just check` before committing
* [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
