### PR TITLE
nostr: deprecate `kind` field in `CommentTarget::Coordinate` variant

### DIFF
--- a/crates/nostr/CHANGELOG.md
+++ b/crates/nostr/CHANGELOG.md
@@ -34,6 +34,11 @@
 ### Changed
 
 - NIP-47 fields synchronized with current specs (https://github.com/rust-nostr/nostr/pull/1021)
+- Check that `a`/`A` and `k`/`K` tags have the same event kind in NIP-22 events (https://github.com/rust-nostr/nostr/pull/1035)
+
+### Deprecated
+
+- Deprecate `kind` field in `CommentTarget::Coordinate` variant (https://github.com/rust-nostr/nostr/pull/1035)
 
 ## v0.43.0 - 2025/07/28
 

--- a/crates/nostr/src/nips/nip22.rs
+++ b/crates/nostr/src/nips/nip22.rs
@@ -34,6 +34,7 @@ pub enum CommentTarget<'a> {
         /// Relay hint
         relay_hint: Option<&'a RelayUrl>,
         /// Kind
+        #[deprecated(since = "0.44.0", note = "Use `address.kind` instead")]
         kind: Option<&'a Kind>,
     },
     /// External content
@@ -72,10 +73,22 @@ fn extract_data(event: &Event, is_root: bool) -> Option<CommentTarget> {
 
     // Try to extract coordinate
     if let Some((address, relay_hint)) = extract_coordinate(event, is_root) {
+        // Extract kind
+        // TODO: for now we allow optional `k`/`K` tag, but according to NIP-22, it should be mandatory.
+        let kind: Option<&Kind> = extract_kind(event, is_root);
+
+        // Check if matches the address kind
+        if let Some(kind) = kind {
+            if kind != &address.kind {
+                return None;
+            }
+        }
+
         return Some(CommentTarget::Coordinate {
             address,
             relay_hint,
-            kind: extract_kind(event, is_root),
+            #[allow(deprecated)]
+            kind,
         });
     }
 


### PR DESCRIPTION
Add a check to verify that `a`/`A` and `k`/`K` tags have the same event kind.

Closes https://github.com/rust-nostr/nostr/issues/1031
