### PR TITLE
nostr: Support NIP-73 kind

### DIFF
--- a/crates/nostr/CHANGELOG.md
+++ b/crates/nostr/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Add NIP-47 `state` field for transactions (https://github.com/rust-nostr/nostr/pull/1021)
 - Add `nip47::Method::as_str` method
 - Add `CommentTarget::{event, coordinate, external}` to point to a specific thing (https://github.com/rust-nostr/nostr/pull/1034)
+- Add `nips::nip73::Nip73Kind` and `TagStandard::Nip73Kind`
 
 ### Changed
 


### PR DESCRIPTION
### Description

- Add `nips::nip73::Nip73Kind`
- Add `TagStandard::Nip73Kind`
- Support `Nip37Kind` in `TagStandard::to_vec`
- Support `Nip37Kind` in `TagStandard::parse`
- Unit tests for `Nip37Kind` and `Kind`

### Notes to the reviewers

`TagStandard::parse` wasn't parsing `Kind`, I fix it as a minor fix (Should I add it to the changelog?)

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
