### PR TITLE
nostr: Add `HEAD` tag kind

### DIFF
--- a/crates/nostr/CHANGELOG.md
+++ b/crates/nostr/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Add `nip47::Method::as_str` method
 - Add `CommentTarget::{event, coordinate, external}` to point to a specific thing (https://github.com/rust-nostr/nostr/pull/1034)
 - Add `nips::nip73::Nip73Kind` and `TagStandard::Nip73Kind` (https://github.com/rust-nostr/nostr/pull/1039)
+- Add `HEAD` tag kind (https://github.com/rust-nostr/nostr/pull/1043)
 
 ### Changed
 

--- a/crates/nostr/src/event/tag/kind.rs
+++ b/crates/nostr/src/event/tag/kind.rs
@@ -41,6 +41,10 @@ pub enum TagKind<'a> {
     ///
     /// <https://github.com/nostr-protocol/nips/blob/master/34.md>
     Commit,
+    /// HEAD
+    ///
+    /// <https://github.com/nostr-protocol/nips/blob/master/34.md>
+    Head,
     /// Content warning
     ContentWarning,
     /// Current participants
@@ -327,6 +331,7 @@ impl<'a> TagKind<'a> {
             Self::Expiration => "expiration",
             Self::Extension => "extension",
             Self::File => "file",
+            Self::Head => "HEAD",
             Self::Image => "image",
             Self::License => "license",
             Self::Lnurl => "lnurl",
@@ -501,6 +506,9 @@ mod tests {
 
         assert_eq!(TagKind::from("file"), TagKind::File);
         assert_eq!(TagKind::File.as_str(), "file");
+
+        assert_eq!(TagKind::from("HEAD"), TagKind::Head);
+        assert_eq!(TagKind::Head.as_str(), "HEAD");
 
         assert_eq!(TagKind::from("license"), TagKind::License);
         assert_eq!(TagKind::License.as_str(), "license");

--- a/crates/nostr/src/event/tag/mod.rs
+++ b/crates/nostr/src/event/tag/mod.rs
@@ -405,6 +405,19 @@ impl Tag {
         Self::from_standardized_without_cell(TagStandard::AllRelays)
     }
 
+    /// Repository head
+    ///
+    /// JSON: `["HEAD", "<branch-name>"]`
+    ///
+    /// <https://github.com/nostr-protocol/nips/blob/master/34.md>
+    #[inline]
+    pub fn head<S>(branch_name: S) -> Self
+    where
+        S: Into<String>,
+    {
+        Self::from_standardized_without_cell(TagStandard::GitHead(branch_name.into()))
+    }
+
     /// Compose `["t", "<hashtag>"]` tag
     ///
     /// This will convert the hashtag to lowercase.

--- a/crates/nostr/src/event/tag/standard.rs
+++ b/crates/nostr/src/event/tag/standard.rs
@@ -34,6 +34,7 @@ use crate::{
 };
 
 const ALL_RELAYS: &str = "ALL_RELAYS";
+const GIT_REFS_HEADS: &str = "ref: refs/heads/";
 
 /// Standardized tag
 #[allow(deprecated)]
@@ -72,6 +73,10 @@ pub enum TagStandard {
     ///
     /// <https://github.com/nostr-protocol/nips/blob/master/56.md>
     EventReport(EventId, Report),
+    /// Git head ([`TagKind::Head`] tag)
+    ///
+    /// <https://github.com/nostr-protocol/nips/blob/master/34.md>
+    GitHead(String),
     /// Git clone ([`TagKind::Clone`] tag)
     ///
     /// <https://github.com/nostr-protocol/nips/blob/master/34.md>
@@ -458,6 +463,7 @@ impl TagStandard {
                 TagKind::Repository => Ok(Self::Repository(tag_1.to_string())),
                 TagKind::Subject => Ok(Self::Subject(tag_1.to_string())),
                 TagKind::Challenge => Ok(Self::Challenge(tag_1.to_string())),
+                TagKind::Head => Ok(Self::GitHead(tag_1.to_string())),
                 TagKind::Commit => Ok(Self::GitCommit(Sha1Hash::from_str(tag_1)?)),
                 TagKind::Title => Ok(Self::Title(tag_1.to_string())),
                 TagKind::Image => Ok(Self::Image(Url::parse(tag_1)?, None)),
@@ -605,6 +611,7 @@ impl TagStandard {
                 })
             }
             Self::EventReport(..) => TagKind::SingleLetter(SingleLetterTag::lowercase(Alphabet::E)),
+            Self::GitHead(..) => TagKind::Head,
             Self::GitClone(..) => TagKind::Clone,
             Self::GitCommit(..) => TagKind::Commit,
             Self::GitEarliestUniqueCommitId(..) => {
@@ -820,6 +827,9 @@ impl From<TagStandard> for Vec<String> {
             }
             TagStandard::EventReport(id, report) => {
                 vec![tag_kind, id.to_hex(), report.to_string()]
+            }
+            TagStandard::GitHead(branch) => {
+                vec![tag_kind, format!("{GIT_REFS_HEADS}{branch}")]
             }
             TagStandard::GitClone(urls) => {
                 let mut tag: Vec<String> = Vec::with_capacity(1 + urls.len());


### PR DESCRIPTION
### Description

- Add `TagKind::Head`
- Add `Tag::head` function
- Add `TagStandard::GitHead`
- Support `TagStandard::GitHead` in `TagStandard::to_vec`
- Support `TagStandard::GitHead` in `TagStandard::parse`


<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

none

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
