### PR TITLE
nostr: some adj. to NIP-47 implementation

### DIFF
--- a/crates/nostr/CHANGELOG.md
+++ b/crates/nostr/CHANGELOG.md
@@ -32,7 +32,7 @@
 ### Added
 
 - Add nip47 holdinvoice methods and notification (https://github.com/rust-nostr/nostr/pull/1019)
-- Add `TransactionState` to `LookupInvoiceResponse` (https://github.com/rust-nostr/nostr/pull/1045)
+- Add `TransactionState` to `LookupInvoiceResponse` and `PaymentNotification` (https://github.com/rust-nostr/nostr/pull/1045)
 - Add `description`, `description_hash`, `preimage`, `amount`, `created_at` and `expires_at` optional fields to `MakeInvoiceResponse` (https://github.com/rust-nostr/nostr/pull/1045)
 - Add `fees_paid` field to `PayKeysendResponse` (https://github.com/rust-nostr/nostr/pull/1045)
 - Add `nip47::Method::as_str` method

--- a/crates/nostr/src/nips/nip47.rs
+++ b/crates/nostr/src/nips/nip47.rs
@@ -1391,6 +1391,9 @@ pub struct PaymentNotification {
     #[serde(rename = "type")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub transaction_type: Option<TransactionType>,
+    /// Transaction state
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<TransactionState>,
     /// Bolt11 invoice
     pub invoice: String,
     /// Invoice's description
@@ -1633,6 +1636,7 @@ mod tests {
             "notification_type": "payment_received",
             "notification": {
                 "type": "incoming",
+                "state": "settled",
                 "invoice": "abcd",
                 "description": "string1",
                 "description_hash": "string2",
@@ -1653,6 +1657,7 @@ mod tests {
         );
         let notification_result = NotificationResult::PaymentReceived(PaymentNotification {
             transaction_type: Some(TransactionType::Incoming),
+            state: Some(TransactionState::Settled),
             invoice: String::from("abcd"),
             description: Some(String::from("string1")),
             description_hash: Some(String::from("string2")),


### PR DESCRIPTION
- Revert commit 4e8e015690efadf0a6033e90fdb50aebe8f43d3f
- Add `TransactionState` enum
- Add `state` field to `LookupInvoiceResponse`
- Add `description`, `description_hash`, `preimage`, `amount`, `created_at` and `expires_at` optional fields to `MakeInvoiceResponse`
- Set `payment_hash` as optional in `MakeInvoiceResponse` (now all fields are optional apart the `invoice`)