### PR TITLE
refactor(nostr): change `EventBuilder::comment` parameters to `CommentTarget<'_>`

### DIFF
--- a/crates/nostr-sdk/examples/comment.rs
+++ b/crates/nostr-sdk/examples/comment.rs
@@ -25,7 +25,7 @@ async fn main() -> Result<()> {
         .await?;
 
     let comment_to = events.first().unwrap();
-    let builder = EventBuilder::comment("This is a reply", comment_to, None, None);
+    let builder = EventBuilder::comment("This is a reply", CommentTarget::from(comment_to), None);
 
     let output = client.send_event_builder(builder).await?;
     println!("Output: {:?}", output);

--- a/crates/nostr/CHANGELOG.md
+++ b/crates/nostr/CHANGELOG.md
@@ -48,6 +48,7 @@
 ### Breaking changes
 
 - Change the `address` field type in `CommentTarget::Coordinate` to `CoordinateBorrow` (https://github.com/rust-nostr/nostr/pull/1034)
+- Change the `EventBuilder::comment` function `root` and `comment_to` parameters types from `&Event` to `CommentTarget<'_>` (https://github.com/rust-nostr/nostr/pull/1047)
 
 ## v0.43.0 - 2025/07/28
 


### PR DESCRIPTION
### Description

Change the `EventBuilder::comment` function `root` and `comment_to` parameters types from `&Event` to `CommentTarget<'_>` 

### Why?

- Makes the API more flexible by allowing comments on any target, not just `Event`
- Enables replying to events without requiring a signed event

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
