### PR TITLE
Replace relays trait method and add test framework for consistency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3323,7 +3323,10 @@ name = "nostr-mls-storage"
 version = "0.43.0"
 dependencies = [
  "nostr",
+ "nostr-mls-memory-storage",
+ "nostr-mls-sqlite-storage",
  "openmls",
+ "openmls_memory_storage",
  "openmls_traits",
  "serde",
  "serde_json",

--- a/mls/nostr-mls-memory-storage/CHANGELOG.md
+++ b/mls/nostr-mls-memory-storage/CHANGELOG.md
@@ -27,7 +27,7 @@
 
 ### Breaking changes
 
-- Remove group type from groups
+- Replaced `save_group_relay` with `replace_group_relays` trait method
 
 ### Changed
 

--- a/mls/nostr-mls-memory-storage/src/lib.rs
+++ b/mls/nostr-mls-memory-storage/src/lib.rs
@@ -306,19 +306,9 @@ mod tests {
         nostr_storage.save_group(group.clone()).unwrap();
         let relay_url1 = RelayUrl::parse("wss://relay1.example.com").unwrap();
         let relay_url2 = RelayUrl::parse("wss://relay2.example.com").unwrap();
-        let group_relay1 = GroupRelay {
-            mls_group_id: mls_group_id.clone(),
-            relay_url: relay_url1,
-        };
-        let group_relay2 = GroupRelay {
-            mls_group_id: mls_group_id.clone(),
-            relay_url: relay_url2,
-        };
+        let relays = BTreeSet::from([relay_url1, relay_url2]);
         nostr_storage
-            .save_group_relay(group_relay1.clone())
-            .unwrap();
-        nostr_storage
-            .save_group_relay(group_relay2.clone())
+            .replace_group_relays(&mls_group_id, relays)
             .unwrap();
         let found_relays = nostr_storage.group_relays(&mls_group_id).unwrap();
         assert_eq!(found_relays.len(), 2);
@@ -333,11 +323,6 @@ mod tests {
                 panic!("Group relays not found in cache");
             }
         }
-        nostr_storage
-            .save_group_relay(group_relay1.clone())
-            .unwrap();
-        let found_relays_after_duplicate = nostr_storage.group_relays(&mls_group_id).unwrap();
-        assert_eq!(found_relays_after_duplicate.len(), 2);
     }
 
     #[test]

--- a/mls/nostr-mls-sqlite-storage/CHANGELOG.md
+++ b/mls/nostr-mls-sqlite-storage/CHANGELOG.md
@@ -27,7 +27,7 @@
 
 ### Breaking changes
 
-- Remove group type from groups
+- Replaced `save_group_relay` with `replace_group_relays` trait method
 
 ### Changed
 

--- a/mls/nostr-mls-sqlite-storage/src/groups.rs
+++ b/mls/nostr-mls-sqlite-storage/src/groups.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeSet;
 
-use nostr::PublicKey;
+use nostr::{PublicKey, RelayUrl};
 use nostr_mls_storage::groups::error::GroupError;
 use nostr_mls_storage::groups::types::{Group, GroupExporterSecret, GroupRelay};
 use nostr_mls_storage::groups::GroupStorage;
@@ -190,29 +190,42 @@ impl GroupStorage for NostrMlsSqliteStorage {
         Ok(relays)
     }
 
-    fn save_group_relay(&self, group_relay: GroupRelay) -> Result<(), GroupError> {
+    fn replace_group_relays(
+        &self,
+        group_id: &GroupId,
+        relays: BTreeSet<RelayUrl>,
+    ) -> Result<(), GroupError> {
         // First verify the group exists
-        if self
-            .find_group_by_mls_group_id(&group_relay.mls_group_id)?
-            .is_none()
-        {
+        if self.find_group_by_mls_group_id(group_id)?.is_none() {
             return Err(GroupError::InvalidParameters(format!(
                 "Group with MLS ID {:?} not found",
-                group_relay.mls_group_id
+                group_id
             )));
         }
 
         let conn_guard = self.db_connection.lock().map_err(into_group_err)?;
 
-        conn_guard
-            .execute(
-                "INSERT OR REPLACE INTO group_relays (mls_group_id, relay_url) VALUES (?, ?)",
-                params![
-                    group_relay.mls_group_id.as_slice(),
-                    group_relay.relay_url.as_str()
-                ],
+        // Use a transaction for atomicity
+        let tx = conn_guard.unchecked_transaction().map_err(into_group_err)?;
+
+        // Clear existing relays for this group
+        tx.execute(
+            "DELETE FROM group_relays WHERE mls_group_id = ?",
+            params![group_id.as_slice()],
+        )
+        .map_err(into_group_err)?;
+
+        // Insert new relays
+        for relay_url in relays {
+            tx.execute(
+                "INSERT INTO group_relays (mls_group_id, relay_url) VALUES (?, ?)",
+                params![group_id.as_slice(), relay_url.as_str()],
             )
             .map_err(into_group_err)?;
+        }
+
+        // Commit the transaction
+        tx.commit().map_err(into_group_err)?;
 
         Ok(())
     }
@@ -274,7 +287,6 @@ impl GroupStorage for NostrMlsSqliteStorage {
 mod tests {
     use aes_gcm::aead::OsRng;
     use aes_gcm::{Aes128Gcm, KeyInit};
-    use nostr::RelayUrl;
     use nostr_mls_storage::groups::types::GroupState;
 
     use super::*;
@@ -331,52 +343,8 @@ mod tests {
         assert_eq!(all_groups.len(), 1);
     }
 
-    #[test]
-    fn test_group_relay() {
-        let storage = NostrMlsSqliteStorage::new_in_memory().unwrap();
-
-        // Create a test group
-        let mls_group_id = GroupId::from_slice(&[1, 2, 3, 4]);
-        let mut nostr_group_id = [0u8; 32];
-        nostr_group_id[0..13].copy_from_slice(b"test_group_12");
-
-        let group = Group {
-            mls_group_id: mls_group_id.clone(),
-            nostr_group_id,
-            name: "Test Group".to_string(),
-            description: "A test group".to_string(),
-            admin_pubkeys: BTreeSet::new(),
-            last_message_id: None,
-            last_message_at: None,
-            epoch: 0,
-            state: GroupState::Active,
-            image_url: None,
-            image_key: None,
-        };
-
-        // Save the group
-        let result = storage.save_group(group);
-        assert!(result.is_ok());
-
-        // Create a group relay
-        let relay_url = RelayUrl::parse("wss://relay.example.com").unwrap();
-        let group_relay = GroupRelay {
-            mls_group_id: mls_group_id.clone(),
-            relay_url,
-        };
-
-        // Save the group relay
-        let result = storage.save_group_relay(group_relay);
-        assert!(result.is_ok());
-
-        // Get group relays
-        let relays = storage.group_relays(&mls_group_id).unwrap();
-        assert_eq!(relays.len(), 1);
-        assert_eq!(
-            relays.first().unwrap().relay_url.to_string(),
-            "wss://relay.example.com"
-        );
-    }
+    // Note: Comprehensive storage functionality tests are now in nostr-mls-storage/tests/
+    // using shared test functions to ensure consistency between storage implementations
 
     #[test]
     fn test_group_exporter_secret() {

--- a/mls/nostr-mls-storage/CHANGELOG.md
+++ b/mls/nostr-mls-storage/CHANGELOG.md
@@ -28,10 +28,16 @@
 ### Breaking changes
 
 - Remove group type from groups
+- Remove `save_group_relay` method
 
 ### Changed
 
 - Upgrade openmls to v0.7.0
+
+### Added
+
+- Added `replace_group_relays` to make relay replace for groups an atomic operation
+- Comprehensive consistency testing framework for testing all nostr-mls-storage implementations for correctness and consistency
 
 ## v0.43.0 - 2025/07/28
 

--- a/mls/nostr-mls-storage/Cargo.toml
+++ b/mls/nostr-mls-storage/Cargo.toml
@@ -17,3 +17,8 @@ openmls = { version = "0.7.0", default-features = false }
 openmls_traits = { version = "0.4.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["std"] }
+
+[dev-dependencies]
+nostr-mls-sqlite-storage = { version = "0.43", path = "../nostr-mls-sqlite-storage" }
+nostr-mls-memory-storage = { version = "0.43", path = "../nostr-mls-memory-storage" }
+openmls_memory_storage = "0.4"

--- a/mls/nostr-mls-storage/src/groups/mod.rs
+++ b/mls/nostr-mls-storage/src/groups/mod.rs
@@ -9,7 +9,7 @@
 
 use std::collections::BTreeSet;
 
-use nostr::PublicKey;
+use nostr::{PublicKey, RelayUrl};
 use openmls::group::GroupId;
 
 pub mod error;
@@ -45,8 +45,13 @@ pub trait GroupStorage {
     /// Get all relays for a group
     fn group_relays(&self, group_id: &GroupId) -> Result<BTreeSet<GroupRelay>, GroupError>;
 
-    /// Save a group relay
-    fn save_group_relay(&self, group_relay: GroupRelay) -> Result<(), GroupError>;
+    /// Replace all relays for a group with the provided set
+    /// This operation is atomic - either all relays are replaced or none are changed
+    fn replace_group_relays(
+        &self,
+        group_id: &GroupId,
+        relays: BTreeSet<RelayUrl>,
+    ) -> Result<(), GroupError>;
 
     /// Get an exporter secret for a group and epoch
     fn get_group_exporter_secret(

--- a/mls/nostr-mls-storage/src/lib.rs
+++ b/mls/nostr-mls-storage/src/lib.rs
@@ -11,6 +11,8 @@ pub mod groups;
 pub mod messages;
 pub mod welcomes;
 
+pub mod test_utils;
+
 use self::groups::GroupStorage;
 use self::messages::MessageStorage;
 use self::welcomes::WelcomeStorage;

--- a/mls/nostr-mls-storage/src/test_utils.rs
+++ b/mls/nostr-mls-storage/src/test_utils.rs
@@ -1,0 +1,610 @@
+//! Test utilities for cross-storage consistency testing
+
+/// Cross-storage consistency testing utilities
+pub mod cross_storage {
+    use std::collections::BTreeSet;
+
+    use nostr::{EventId, RelayUrl, Timestamp};
+    use openmls::group::GroupId;
+
+    use crate::groups::error::GroupError;
+    use crate::groups::types::{Group, GroupExporterSecret, GroupState};
+    use crate::groups::GroupStorage;
+    use crate::messages::types::{Message, MessageState, ProcessedMessage, ProcessedMessageState};
+    use crate::messages::MessageStorage;
+    use crate::welcomes::types::{ProcessedWelcome, ProcessedWelcomeState, Welcome, WelcomeState};
+    use crate::welcomes::WelcomeStorage;
+
+    /// Creates a test group with the given ID for testing purposes
+    pub fn create_test_group(mls_group_id: GroupId) -> Group {
+        let mut nostr_group_id = [0u8; 32];
+        // Use first 4 bytes of mls_group_id to make nostr_group_id somewhat unique
+        let mls_bytes = mls_group_id.as_slice();
+        if mls_bytes.len() >= 4 {
+            nostr_group_id[0..4].copy_from_slice(&mls_bytes[0..4]);
+        }
+
+        Group {
+            mls_group_id,
+            nostr_group_id,
+            name: "Test Group".to_string(),
+            description: "A test group".to_string(),
+            admin_pubkeys: BTreeSet::new(),
+            last_message_id: None,
+            last_message_at: None,
+            epoch: 0,
+            state: GroupState::Active,
+            image_url: None,
+            image_key: None,
+        }
+    }
+
+    /// Test scenarios for replace_group_relays functionality
+    pub fn test_replace_group_relays_comprehensive<S: GroupStorage>(storage: S) {
+        let mls_group_id = GroupId::from_slice(&[1, 2, 3, 4]);
+        let group = create_test_group(mls_group_id.clone());
+
+        // Save the test group
+        storage.save_group(group).unwrap();
+
+        // Test 1: Replace with initial relay set
+        let relay1 = RelayUrl::parse("wss://relay1.example.com").unwrap();
+        let relay2 = RelayUrl::parse("wss://relay2.example.com").unwrap();
+        let initial_relays = BTreeSet::from([relay1.clone(), relay2.clone()]);
+
+        storage
+            .replace_group_relays(&mls_group_id, initial_relays.clone())
+            .unwrap();
+        let stored_relays = storage.group_relays(&mls_group_id).unwrap();
+        assert_eq!(stored_relays.len(), 2);
+        assert!(stored_relays.iter().any(|r| r.relay_url == relay1));
+        assert!(stored_relays.iter().any(|r| r.relay_url == relay2));
+
+        // Test 2: Replace with different relay set (should remove old ones)
+        let relay3 = RelayUrl::parse("wss://relay3.example.com").unwrap();
+        let relay4 = RelayUrl::parse("wss://relay4.example.com").unwrap();
+        let new_relays = BTreeSet::from([relay3.clone(), relay4.clone()]);
+
+        storage
+            .replace_group_relays(&mls_group_id, new_relays.clone())
+            .unwrap();
+        let stored_relays = storage.group_relays(&mls_group_id).unwrap();
+        assert_eq!(stored_relays.len(), 2);
+        assert!(stored_relays.iter().any(|r| r.relay_url == relay3));
+        assert!(stored_relays.iter().any(|r| r.relay_url == relay4));
+        // Old relays should be gone
+        assert!(!stored_relays.iter().any(|r| r.relay_url == relay1));
+        assert!(!stored_relays.iter().any(|r| r.relay_url == relay2));
+
+        // Test 3: Replace with empty set
+        storage
+            .replace_group_relays(&mls_group_id, BTreeSet::new())
+            .unwrap();
+        let stored_relays = storage.group_relays(&mls_group_id).unwrap();
+        assert_eq!(stored_relays.len(), 0);
+
+        // Test 4: Replace with single relay after empty
+        let single_relay = BTreeSet::from([relay1.clone()]);
+        storage
+            .replace_group_relays(&mls_group_id, single_relay)
+            .unwrap();
+        let stored_relays = storage.group_relays(&mls_group_id).unwrap();
+        assert_eq!(stored_relays.len(), 1);
+        assert_eq!(stored_relays.first().unwrap().relay_url, relay1);
+
+        // Test 5: Replace with large set
+        let large_set: BTreeSet<RelayUrl> = (1..=10)
+            .map(|i| RelayUrl::parse(&format!("wss://relay{}.example.com", i)).unwrap())
+            .collect();
+        storage
+            .replace_group_relays(&mls_group_id, large_set.clone())
+            .unwrap();
+        let stored_relays = storage.group_relays(&mls_group_id).unwrap();
+        assert_eq!(stored_relays.len(), 10);
+        for expected_relay in &large_set {
+            assert!(stored_relays.iter().any(|r| r.relay_url == *expected_relay));
+        }
+    }
+
+    /// Test error cases for replace_group_relays
+    pub fn test_replace_group_relays_error_cases<S: GroupStorage>(storage: S) {
+        // Test: Replace relays for non-existent group
+        let non_existent_group_id = GroupId::from_slice(&[99, 99, 99, 99]);
+        let relay = RelayUrl::parse("wss://relay.example.com").unwrap();
+        let relays = BTreeSet::from([relay]);
+
+        let result = storage.replace_group_relays(&non_existent_group_id, relays);
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            GroupError::InvalidParameters(_)
+        ));
+    }
+
+    /// Test duplicate handling for replace_group_relays
+    pub fn test_replace_group_relays_duplicate_handling<S: GroupStorage>(storage: S) {
+        let mls_group_id = GroupId::from_slice(&[1, 2, 3, 5]);
+        let group = create_test_group(mls_group_id.clone());
+
+        storage.save_group(group).unwrap();
+
+        // Test: BTreeSet naturally handles duplicates, but test behavior is consistent
+        let relay = RelayUrl::parse("wss://relay.example.com").unwrap();
+        let relays = BTreeSet::from([relay.clone()]);
+
+        // Add same relay multiple times - should be idempotent
+        storage
+            .replace_group_relays(&mls_group_id, relays.clone())
+            .unwrap();
+        storage
+            .replace_group_relays(&mls_group_id, relays.clone())
+            .unwrap();
+
+        let stored_relays = storage.group_relays(&mls_group_id).unwrap();
+        assert_eq!(stored_relays.len(), 1);
+        assert_eq!(stored_relays.first().unwrap().relay_url, relay);
+    }
+
+    /// Test basic group save and find functionality
+    pub fn test_save_and_find_group<S: GroupStorage>(storage: S) {
+        let mls_group_id = GroupId::from_slice(&[1, 2, 3, 6]);
+        let group = create_test_group(mls_group_id.clone());
+
+        // Test save
+        storage.save_group(group.clone()).unwrap();
+
+        // Test find by MLS group ID
+        let found_group = storage.find_group_by_mls_group_id(&mls_group_id).unwrap();
+        assert!(found_group.is_some());
+        let found_group = found_group.unwrap();
+        assert_eq!(found_group.mls_group_id, group.mls_group_id);
+        assert_eq!(found_group.nostr_group_id, group.nostr_group_id);
+        assert_eq!(found_group.name, group.name);
+        assert_eq!(found_group.description, group.description);
+
+        // Test find by Nostr group ID
+        let found_group = storage
+            .find_group_by_nostr_group_id(&group.nostr_group_id)
+            .unwrap();
+        assert!(found_group.is_some());
+        let found_group = found_group.unwrap();
+        assert_eq!(found_group.mls_group_id, group.mls_group_id);
+
+        // Test find non-existent group
+        let non_existent_id = GroupId::from_slice(&[99, 99, 99, 99]);
+        let result = storage
+            .find_group_by_mls_group_id(&non_existent_id)
+            .unwrap();
+        assert!(result.is_none());
+    }
+
+    /// Test edge cases and error conditions for group operations
+    pub fn test_group_edge_cases<S: GroupStorage>(storage: S) {
+        // Test saving group with empty name
+        let mls_group_id = GroupId::from_slice(&[1, 2, 3, 14]);
+        let mut group = create_test_group(mls_group_id.clone());
+        group.name = String::new();
+
+        // Should still work (empty names are valid)
+        storage.save_group(group.clone()).unwrap();
+        let found = storage
+            .find_group_by_mls_group_id(&mls_group_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(found.name, "");
+
+        // Test saving group with very long name
+        let long_name = "a".repeat(1000);
+        group.name = long_name.clone();
+        storage.save_group(group).unwrap();
+        let found = storage
+            .find_group_by_mls_group_id(&mls_group_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(found.name, long_name);
+
+        // Test duplicate group save (should update existing)
+        let mut updated_group = create_test_group(mls_group_id.clone());
+        updated_group.description = "Updated description".to_string();
+        storage.save_group(updated_group).unwrap();
+        let found = storage
+            .find_group_by_mls_group_id(&mls_group_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(found.description, "Updated description");
+    }
+
+    /// Test concurrent relay operations and edge cases
+    pub fn test_replace_relays_edge_cases<S: GroupStorage>(storage: S) {
+        let mls_group_id = GroupId::from_slice(&[1, 2, 3, 15]);
+        let group = create_test_group(mls_group_id.clone());
+        storage.save_group(group).unwrap();
+
+        // Test with very large relay sets
+        let large_relay_set: BTreeSet<RelayUrl> = (1..=100)
+            .map(|i| RelayUrl::parse(&format!("wss://relay{}.example.com", i)).unwrap())
+            .collect();
+
+        storage
+            .replace_group_relays(&mls_group_id, large_relay_set.clone())
+            .unwrap();
+        let stored = storage.group_relays(&mls_group_id).unwrap();
+        assert_eq!(stored.len(), 100);
+
+        // Test multiple rapid replacements
+        for i in 0..10 {
+            let relay_set =
+                BTreeSet::from([RelayUrl::parse(&format!("wss://test{}.com", i)).unwrap()]);
+            storage
+                .replace_group_relays(&mls_group_id, relay_set)
+                .unwrap();
+        }
+        let final_relays = storage.group_relays(&mls_group_id).unwrap();
+        assert_eq!(final_relays.len(), 1);
+        assert_eq!(
+            final_relays.first().unwrap().relay_url.to_string(),
+            "wss://test9.com"
+        );
+    }
+
+    /// Test group exporter secret functionality
+    pub fn test_group_exporter_secret<S: GroupStorage>(storage: S) {
+        let mls_group_id = GroupId::from_slice(&[1, 2, 3, 7]);
+        let group = create_test_group(mls_group_id.clone());
+        storage.save_group(group).unwrap();
+
+        let epoch = 42u64;
+        let secret = [0x42u8; 32];
+        let exporter_secret = GroupExporterSecret {
+            mls_group_id: mls_group_id.clone(),
+            epoch,
+            secret,
+        };
+
+        // Test save
+        storage
+            .save_group_exporter_secret(exporter_secret.clone())
+            .unwrap();
+
+        // Test get
+        let retrieved = storage
+            .get_group_exporter_secret(&mls_group_id, epoch)
+            .unwrap();
+        assert!(retrieved.is_some());
+        let retrieved = retrieved.unwrap();
+        assert_eq!(retrieved.mls_group_id, mls_group_id);
+        assert_eq!(retrieved.epoch, epoch);
+        assert_eq!(retrieved.secret, secret);
+
+        // Test get non-existent
+        let result = storage
+            .get_group_exporter_secret(&mls_group_id, 999)
+            .unwrap();
+        assert!(result.is_none());
+    }
+
+    /// Test all groups functionality
+    pub fn test_all_groups<S: GroupStorage>(storage: S) {
+        // Initially should be empty
+        let groups = storage.all_groups().unwrap();
+        assert_eq!(groups.len(), 0);
+
+        // Add some groups
+        let group1 = create_test_group(GroupId::from_slice(&[1, 2, 3, 8]));
+        let group2 = create_test_group(GroupId::from_slice(&[1, 2, 3, 9]));
+        let group3 = create_test_group(GroupId::from_slice(&[1, 2, 3, 10]));
+
+        storage.save_group(group1.clone()).unwrap();
+        storage.save_group(group2.clone()).unwrap();
+        storage.save_group(group3.clone()).unwrap();
+
+        // Test all groups
+        let groups = storage.all_groups().unwrap();
+        assert_eq!(groups.len(), 3);
+
+        let group_ids: BTreeSet<_> = groups.iter().map(|g| g.mls_group_id.clone()).collect();
+        assert!(group_ids.contains(&group1.mls_group_id));
+        assert!(group_ids.contains(&group2.mls_group_id));
+        assert!(group_ids.contains(&group3.mls_group_id));
+    }
+
+    /// Test basic group relay functionality (not the comprehensive replace tests)
+    pub fn test_basic_group_relays<S: GroupStorage>(storage: S) {
+        let mls_group_id = GroupId::from_slice(&[1, 2, 3, 11]);
+        let group = create_test_group(mls_group_id.clone());
+        storage.save_group(group).unwrap();
+
+        // Initially should be empty
+        let relays = storage.group_relays(&mls_group_id).unwrap();
+        assert_eq!(relays.len(), 0);
+
+        // Add a relay using replace
+        let relay_url = RelayUrl::parse("wss://relay.example.com").unwrap();
+        let relays_set = BTreeSet::from([relay_url.clone()]);
+        storage
+            .replace_group_relays(&mls_group_id, relays_set)
+            .unwrap();
+
+        // Verify it's there
+        let relays = storage.group_relays(&mls_group_id).unwrap();
+        assert_eq!(relays.len(), 1);
+        assert_eq!(relays.first().unwrap().relay_url, relay_url);
+    }
+
+    /// Creates a test message for testing purposes
+    pub fn create_test_message(mls_group_id: GroupId, event_id: EventId) -> Message {
+        use nostr::{Kind, PublicKey, Tags, Timestamp, UnsignedEvent};
+
+        let pubkey =
+            PublicKey::parse("npub1a6awmmklxfmspwdv52qq58sk5c07kghwc4v2eaudjx2ju079cdqs2452ys")
+                .unwrap();
+        let created_at = Timestamp::now();
+        let content = "Test message content".to_string();
+        let tags = Tags::new();
+
+        let event = UnsignedEvent {
+            id: Some(event_id),
+            pubkey,
+            created_at,
+            kind: Kind::Custom(445),
+            tags: tags.clone(),
+            content: content.clone(),
+        };
+
+        Message {
+            id: event_id,
+            pubkey,
+            kind: Kind::Custom(445),
+            mls_group_id,
+            created_at,
+            content,
+            tags,
+            event,
+            wrapper_event_id: event_id,
+            state: MessageState::Processed,
+        }
+    }
+
+    /// Creates a test processed message for testing purposes
+    pub fn create_test_processed_message(
+        wrapper_event_id: EventId,
+        message_event_id: Option<EventId>,
+    ) -> ProcessedMessage {
+        ProcessedMessage {
+            wrapper_event_id,
+            message_event_id,
+            processed_at: Timestamp::now(),
+            state: ProcessedMessageState::Processed,
+            failure_reason: None,
+        }
+    }
+
+    /// Test message storage functionality
+    pub fn test_save_and_find_message<S: MessageStorage + GroupStorage>(storage: S) {
+        use nostr::EventId;
+
+        let mls_group_id = GroupId::from_slice(&[1, 2, 3, 12]);
+
+        // First create the group (required for foreign key constraints)
+        let group = create_test_group(mls_group_id.clone());
+        storage.save_group(group).unwrap();
+
+        let event_id = EventId::all_zeros();
+        let message = create_test_message(mls_group_id.clone(), event_id);
+
+        // Test save
+        storage.save_message(message.clone()).unwrap();
+
+        // Test find
+        let found_message = storage.find_message_by_event_id(&event_id).unwrap();
+        assert!(found_message.is_some());
+        let found_message = found_message.unwrap();
+        assert_eq!(found_message.id, message.id);
+        assert_eq!(found_message.content, message.content);
+        assert_eq!(found_message.mls_group_id, message.mls_group_id);
+
+        // Test find non-existent
+        let non_existent_id =
+            EventId::from_hex("abababababababababababababababababababababababababababababababab")
+                .unwrap();
+        let result = storage.find_message_by_event_id(&non_existent_id).unwrap();
+        assert!(result.is_none());
+    }
+
+    /// Test message storage functionality with group queries
+    pub fn test_messages_for_group<S: GroupStorage>(storage: S) {
+        let mls_group_id = GroupId::from_slice(&[1, 2, 3, 12]);
+        let group = create_test_group(mls_group_id.clone());
+        storage.save_group(group).unwrap();
+
+        // Test messages for group (initially empty)
+        let messages = storage.messages(&mls_group_id).unwrap();
+        assert_eq!(messages.len(), 0);
+    }
+
+    /// Test processed message functionality
+    pub fn test_processed_message<S: MessageStorage>(storage: S) {
+        use nostr::EventId;
+
+        let wrapper_event_id = EventId::all_zeros();
+        let message_event_id =
+            EventId::from_hex("1111111111111111111111111111111111111111111111111111111111111111")
+                .unwrap();
+        let processed_message =
+            create_test_processed_message(wrapper_event_id, Some(message_event_id));
+
+        // Test save
+        storage
+            .save_processed_message(processed_message.clone())
+            .unwrap();
+
+        // Test find by wrapper event id
+        let found = storage
+            .find_processed_message_by_event_id(&wrapper_event_id)
+            .unwrap();
+        assert!(found.is_some());
+        let found = found.unwrap();
+        assert_eq!(found.wrapper_event_id, wrapper_event_id);
+        assert_eq!(found.message_event_id, Some(message_event_id));
+
+        // Note: The MessageStorage trait doesn't have find_processed_message_by_message_event_id
+        // We only test find_processed_message_by_event_id which finds by wrapper event id
+
+        // Test find non-existent
+        let non_existent_id =
+            EventId::from_hex("abababababababababababababababababababababababababababababababab")
+                .unwrap();
+        let result = storage
+            .find_processed_message_by_event_id(&non_existent_id)
+            .unwrap();
+        assert!(result.is_none());
+    }
+
+    /// Creates a test welcome for testing purposes
+    pub fn create_test_welcome(mls_group_id: GroupId, event_id: EventId) -> Welcome {
+        use nostr::{Kind, PublicKey, RelayUrl, Tags, Timestamp, UnsignedEvent};
+
+        let pubkey =
+            PublicKey::parse("npub1a6awmmklxfmspwdv52qq58sk5c07kghwc4v2eaudjx2ju079cdqs2452ys")
+                .unwrap();
+        let created_at = Timestamp::now();
+        let content = "Test welcome content".to_string();
+        let tags = Tags::new();
+
+        let event = UnsignedEvent {
+            id: Some(event_id),
+            pubkey,
+            created_at,
+            kind: Kind::Custom(444),
+            tags,
+            content,
+        };
+
+        Welcome {
+            id: event_id,
+            event,
+            mls_group_id,
+            nostr_group_id: [0u8; 32],
+            group_name: "Test Group".to_string(),
+            group_description: "A test group".to_string(),
+            group_image_url: None,
+            group_image_key: None,
+            group_admin_pubkeys: BTreeSet::from([pubkey]),
+            group_relays: BTreeSet::from([RelayUrl::parse("wss://relay.example.com").unwrap()]),
+            welcomer: pubkey,
+            member_count: 1,
+            state: WelcomeState::Pending,
+            wrapper_event_id: event_id,
+        }
+    }
+
+    /// Creates a test processed welcome for testing purposes
+    pub fn create_test_processed_welcome(
+        wrapper_event_id: EventId,
+        welcome_event_id: Option<EventId>,
+    ) -> ProcessedWelcome {
+        ProcessedWelcome {
+            wrapper_event_id,
+            welcome_event_id,
+            processed_at: Timestamp::now(),
+            state: ProcessedWelcomeState::Processed,
+            failure_reason: None,
+        }
+    }
+
+    /// Test welcome storage functionality
+    pub fn test_save_and_find_welcome<S: WelcomeStorage + GroupStorage>(storage: S) {
+        use nostr::EventId;
+
+        let mls_group_id = GroupId::from_slice(&[1, 2, 3, 13]);
+
+        // First create the group (required for foreign key constraints)
+        let group = create_test_group(mls_group_id.clone());
+        storage.save_group(group).unwrap();
+
+        let event_id = EventId::all_zeros();
+        let welcome = create_test_welcome(mls_group_id.clone(), event_id);
+
+        // Test save
+        storage.save_welcome(welcome.clone()).unwrap();
+
+        // Test find
+        let found_welcome = storage.find_welcome_by_event_id(&event_id).unwrap();
+        assert!(found_welcome.is_some());
+        let found_welcome = found_welcome.unwrap();
+        assert_eq!(found_welcome.id, welcome.id);
+        assert_eq!(found_welcome.group_name, welcome.group_name);
+        assert_eq!(found_welcome.mls_group_id, welcome.mls_group_id);
+
+        // Test find non-existent
+        let non_existent_id =
+            EventId::from_hex("abababababababababababababababababababababababababababababababab")
+                .unwrap();
+        let result = storage.find_welcome_by_event_id(&non_existent_id).unwrap();
+        assert!(result.is_none());
+
+        // Test pending welcomes
+        let pending = storage.pending_welcomes().unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].id, event_id);
+    }
+
+    /// Test processed welcome functionality
+    pub fn test_processed_welcome<S: WelcomeStorage>(storage: S) {
+        use nostr::EventId;
+
+        let wrapper_event_id = EventId::all_zeros();
+        let welcome_event_id =
+            EventId::from_hex("1111111111111111111111111111111111111111111111111111111111111111")
+                .unwrap();
+        let processed_welcome =
+            create_test_processed_welcome(wrapper_event_id, Some(welcome_event_id));
+
+        // Test save
+        storage
+            .save_processed_welcome(processed_welcome.clone())
+            .unwrap();
+
+        // Test find by wrapper event id
+        let found = storage
+            .find_processed_welcome_by_event_id(&wrapper_event_id)
+            .unwrap();
+        assert!(found.is_some());
+        let found = found.unwrap();
+        assert_eq!(found.wrapper_event_id, wrapper_event_id);
+        assert_eq!(found.welcome_event_id, Some(welcome_event_id));
+
+        // Test find non-existent
+        let non_existent_id =
+            EventId::from_hex("abababababababababababababababababababababababababababababababab")
+                .unwrap();
+        let result = storage
+            .find_processed_welcome_by_event_id(&non_existent_id)
+            .unwrap();
+        assert!(result.is_none());
+    }
+}
+
+/// Macro to generate cross-storage tests for both SQLite and Memory implementations
+#[macro_export]
+macro_rules! test_both_storages {
+    ($test_name:ident, $test_fn:path) => {
+        mod $test_name {
+            use super::*;
+
+            #[test]
+            fn sqlite() {
+                let storage = $crate::NostrMlsSqliteStorage::new_in_memory().unwrap();
+                $test_fn(storage);
+            }
+
+            #[test]
+            fn memory() {
+                let storage = $crate::NostrMlsMemoryStorage::new(
+                    ::openmls_memory_storage::MemoryStorage::default(),
+                );
+                $test_fn(storage);
+            }
+        }
+    };
+}

--- a/mls/nostr-mls-storage/tests/cross_storage.rs
+++ b/mls/nostr-mls-storage/tests/cross_storage.rs
@@ -1,0 +1,178 @@
+//! Cross-storage consistency tests
+//!
+//! These tests ensure that SQLite and Memory storage implementations behave identically
+//! for the same operations by running them side-by-side and comparing results.
+
+use std::collections::BTreeSet;
+
+use nostr::RelayUrl;
+use nostr_mls_memory_storage::NostrMlsMemoryStorage;
+use nostr_mls_sqlite_storage::NostrMlsSqliteStorage;
+use nostr_mls_storage::groups::GroupStorage;
+use openmls::group::GroupId;
+use openmls_memory_storage::MemoryStorage;
+
+#[path = "shared/mod.rs"]
+mod shared;
+
+/// Test harness for differential testing between storage implementations
+pub struct StorageTestHarness {
+    pub sqlite: NostrMlsSqliteStorage,
+    pub memory: NostrMlsMemoryStorage,
+}
+
+impl Default for StorageTestHarness {
+    fn default() -> Self {
+        Self {
+            sqlite: NostrMlsSqliteStorage::new(":memory:")
+                .expect("Failed to create SQLite storage"),
+            memory: NostrMlsMemoryStorage::new(MemoryStorage::default()),
+        }
+    }
+}
+
+impl StorageTestHarness {
+    /// Create a new test harness with fresh storage instances
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Execute the same operation on both storages and assert they behave identically
+    pub fn assert_consistent_save_group(&self, group: nostr_mls_storage::groups::types::Group) {
+        let sqlite_result = self.sqlite.save_group(group.clone());
+        let memory_result = self.memory.save_group(group.clone());
+
+        assert_eq!(
+            sqlite_result.is_ok(),
+            memory_result.is_ok(),
+            "save_group results differ"
+        );
+
+        if sqlite_result.is_ok() {
+            let sqlite_group = self
+                .sqlite
+                .find_group_by_mls_group_id(&group.mls_group_id)
+                .unwrap()
+                .unwrap();
+            let memory_group = self
+                .memory
+                .find_group_by_mls_group_id(&group.mls_group_id)
+                .unwrap()
+                .unwrap();
+            assert_eq!(
+                sqlite_group, memory_group,
+                "Stored groups differ after successful save"
+            );
+        } else {
+            assert_eq!(
+                format!("{:?}", sqlite_result.unwrap_err()),
+                format!("{:?}", memory_result.unwrap_err()),
+                "Error messages differ"
+            );
+        }
+    }
+
+    pub fn assert_consistent_replace_relays(&self, group_id: &GroupId, relays: BTreeSet<RelayUrl>) {
+        let sqlite_result = self.sqlite.replace_group_relays(group_id, relays.clone());
+        let memory_result = self.memory.replace_group_relays(group_id, relays);
+
+        assert_eq!(
+            sqlite_result.is_ok(),
+            memory_result.is_ok(),
+            "replace_group_relays results differ"
+        );
+
+        if sqlite_result.is_ok() {
+            let sqlite_relays = self.sqlite.group_relays(group_id).unwrap();
+            let memory_relays = self.memory.group_relays(group_id).unwrap();
+            assert_eq!(
+                sqlite_relays, memory_relays,
+                "Stored relays differ after successful replacement"
+            );
+        } else {
+            assert_eq!(
+                format!("{:?}", sqlite_result.unwrap_err()),
+                format!("{:?}", memory_result.unwrap_err()),
+                "Error messages differ"
+            );
+        }
+    }
+
+    pub fn assert_consistent_group_relays(&self, group_id: &GroupId) {
+        let sqlite_relays = self.sqlite.group_relays(group_id).unwrap();
+        let memory_relays = self.memory.group_relays(group_id).unwrap();
+        assert_eq!(sqlite_relays, memory_relays, "Group relays differ");
+    }
+}
+
+/// Helper to create a dummy group for testing
+fn create_test_group_for_cross_storage(
+    mls_group_id: &GroupId,
+    nostr_group_id: [u8; 32],
+) -> nostr_mls_storage::groups::types::Group {
+    use nostr_mls_storage::groups::types::{Group, GroupState};
+
+    Group {
+        mls_group_id: mls_group_id.clone(),
+        nostr_group_id,
+        name: "Test Group".to_string(),
+        description: "A test group".to_string(),
+        admin_pubkeys: BTreeSet::new(),
+        last_message_id: None,
+        last_message_at: None,
+        epoch: 0,
+        state: GroupState::Active,
+        image_url: None,
+        image_key: None,
+    }
+}
+
+#[test]
+fn test_replace_relays_basic_consistency() {
+    let harness = StorageTestHarness::new();
+    let mls_group_id = GroupId::from_slice(&[1, 2, 3, 4]);
+    let mut nostr_group_id = [0u8; 32];
+    nostr_group_id[0..10].copy_from_slice(b"basic_cons");
+
+    let group = create_test_group_for_cross_storage(&mls_group_id, nostr_group_id);
+    harness.assert_consistent_save_group(group);
+
+    let relay1 = RelayUrl::parse("wss://relay1.com").unwrap();
+    let relay2 = RelayUrl::parse("wss://relay2.com").unwrap();
+    let relays = BTreeSet::from([relay1, relay2]);
+
+    harness.assert_consistent_replace_relays(&mls_group_id, relays);
+}
+
+#[test]
+fn test_replace_relays_error_consistency() {
+    let harness = StorageTestHarness::new();
+    let non_existent_group_id = GroupId::from_slice(&[99, 99, 99, 99]);
+    let relay = RelayUrl::parse("wss://error.com").unwrap();
+    let relays = BTreeSet::from([relay]);
+
+    harness.assert_consistent_replace_relays(&non_existent_group_id, relays);
+}
+
+#[test]
+fn test_replace_relays_sequence_consistency() {
+    let harness = StorageTestHarness::new();
+    let mls_group_id = GroupId::from_slice(&[1, 2, 3, 6]);
+    let mut nostr_group_id = [0u8; 32];
+    nostr_group_id[0..8].copy_from_slice(b"seq_cons");
+
+    let group = create_test_group_for_cross_storage(&mls_group_id, nostr_group_id);
+    harness.assert_consistent_save_group(group);
+
+    let r1 = RelayUrl::parse("wss://r1.com").unwrap();
+    let r2 = RelayUrl::parse("wss://r2.com").unwrap();
+    let r3 = RelayUrl::parse("wss://r3.com").unwrap();
+
+    // Execute sequence of operations
+    harness.assert_consistent_replace_relays(&mls_group_id, BTreeSet::from([r1.clone()]));
+    harness
+        .assert_consistent_replace_relays(&mls_group_id, BTreeSet::from([r1.clone(), r2.clone()]));
+    harness.assert_consistent_replace_relays(&mls_group_id, BTreeSet::from([r3.clone()]));
+    harness.assert_consistent_replace_relays(&mls_group_id, BTreeSet::new());
+    harness.assert_consistent_replace_relays(&mls_group_id, BTreeSet::from([r1, r2, r3]));
+}

--- a/mls/nostr-mls-storage/tests/memory_storage.rs
+++ b/mls/nostr-mls-storage/tests/memory_storage.rs
@@ -1,0 +1,89 @@
+//! Memory storage implementation tests using shared test functions
+
+use nostr_mls_memory_storage::NostrMlsMemoryStorage;
+use openmls_memory_storage::MemoryStorage;
+
+#[path = "shared/mod.rs"]
+mod shared;
+
+/// Macro to generate tests that run against Memory storage using shared test functions
+macro_rules! test_memory_storage {
+    ($test_name:ident, $test_fn:path) => {
+        #[test]
+        fn $test_name() {
+            let storage = NostrMlsMemoryStorage::new(MemoryStorage::default());
+            $test_fn(storage);
+        }
+    };
+}
+
+// Group functionality tests
+test_memory_storage!(
+    test_save_and_find_group_memory,
+    shared::group_tests::test_save_and_find_group
+);
+
+test_memory_storage!(test_all_groups_memory, shared::group_tests::test_all_groups);
+
+test_memory_storage!(
+    test_group_exporter_secret_memory,
+    shared::group_tests::test_group_exporter_secret
+);
+
+test_memory_storage!(
+    test_basic_group_relays_memory,
+    shared::group_tests::test_basic_group_relays
+);
+
+test_memory_storage!(
+    test_group_edge_cases_memory,
+    shared::group_tests::test_group_edge_cases
+);
+
+test_memory_storage!(
+    test_replace_relays_edge_cases_memory,
+    shared::group_tests::test_replace_relays_edge_cases
+);
+
+// Comprehensive relay tests
+test_memory_storage!(
+    test_replace_group_relays_comprehensive_memory,
+    shared::group_tests::test_replace_group_relays_comprehensive
+);
+
+test_memory_storage!(
+    test_replace_group_relays_error_cases_memory,
+    shared::group_tests::test_replace_group_relays_error_cases
+);
+
+test_memory_storage!(
+    test_replace_group_relays_duplicate_handling_memory,
+    shared::group_tests::test_replace_group_relays_duplicate_handling
+);
+
+// Message functionality tests
+test_memory_storage!(
+    test_save_and_find_message_memory,
+    shared::message_tests::test_save_and_find_message
+);
+
+test_memory_storage!(
+    test_processed_message_memory,
+    shared::message_tests::test_processed_message
+);
+
+test_memory_storage!(
+    test_messages_for_group_memory,
+    shared::group_tests::test_messages_for_group
+);
+
+// Welcome functionality tests
+test_memory_storage!(
+    test_save_and_find_welcome_memory,
+    shared::welcome_tests::test_save_and_find_welcome
+);
+
+test_memory_storage!(
+    test_processed_welcome_memory,
+    shared::welcome_tests::test_processed_welcome
+);

--- a/mls/nostr-mls-storage/tests/shared/group_tests.rs
+++ b/mls/nostr-mls-storage/tests/shared/group_tests.rs
@@ -1,0 +1,323 @@
+//! Group storage test functions
+
+use std::collections::BTreeSet;
+
+use nostr::RelayUrl;
+use nostr_mls_storage::groups::error::GroupError;
+use nostr_mls_storage::groups::types::GroupExporterSecret;
+use nostr_mls_storage::groups::GroupStorage;
+use openmls::group::GroupId;
+
+use super::create_test_group;
+
+/// Test basic group save and find functionality
+#[allow(dead_code)]
+pub fn test_save_and_find_group<S: GroupStorage>(storage: S) {
+    let mls_group_id = GroupId::from_slice(&[1, 2, 3, 6]);
+    let group = create_test_group(mls_group_id.clone());
+
+    // Test save
+    storage.save_group(group.clone()).unwrap();
+
+    // Test find by MLS group ID
+    let found_group = storage.find_group_by_mls_group_id(&mls_group_id).unwrap();
+    assert!(found_group.is_some());
+    let found_group = found_group.unwrap();
+    assert_eq!(found_group.mls_group_id, group.mls_group_id);
+    assert_eq!(found_group.nostr_group_id, group.nostr_group_id);
+    assert_eq!(found_group.name, group.name);
+    assert_eq!(found_group.description, group.description);
+
+    // Test find by Nostr group ID
+    let found_group = storage
+        .find_group_by_nostr_group_id(&group.nostr_group_id)
+        .unwrap();
+    assert!(found_group.is_some());
+    let found_group = found_group.unwrap();
+    assert_eq!(found_group.mls_group_id, group.mls_group_id);
+
+    // Test find non-existent group
+    let non_existent_id = GroupId::from_slice(&[99, 99, 99, 99]);
+    let result = storage
+        .find_group_by_mls_group_id(&non_existent_id)
+        .unwrap();
+    assert!(result.is_none());
+}
+
+/// Test all groups functionality
+#[allow(dead_code)]
+pub fn test_all_groups<S: GroupStorage>(storage: S) {
+    // Initially should be empty
+    let groups = storage.all_groups().unwrap();
+    assert_eq!(groups.len(), 0);
+
+    // Add some groups
+    let group1 = create_test_group(GroupId::from_slice(&[1, 2, 3, 8]));
+    let group2 = create_test_group(GroupId::from_slice(&[1, 2, 3, 9]));
+    let group3 = create_test_group(GroupId::from_slice(&[1, 2, 3, 10]));
+
+    storage.save_group(group1.clone()).unwrap();
+    storage.save_group(group2.clone()).unwrap();
+    storage.save_group(group3.clone()).unwrap();
+
+    // Test all groups
+    let groups = storage.all_groups().unwrap();
+    assert_eq!(groups.len(), 3);
+
+    let group_ids: BTreeSet<_> = groups.iter().map(|g| g.mls_group_id.clone()).collect();
+    assert!(group_ids.contains(&group1.mls_group_id));
+    assert!(group_ids.contains(&group2.mls_group_id));
+    assert!(group_ids.contains(&group3.mls_group_id));
+}
+
+/// Test group exporter secret functionality
+#[allow(dead_code)]
+pub fn test_group_exporter_secret<S: GroupStorage>(storage: S) {
+    let mls_group_id = GroupId::from_slice(&[1, 2, 3, 7]);
+    let group = create_test_group(mls_group_id.clone());
+    storage.save_group(group).unwrap();
+
+    let epoch = 42u64;
+    let secret = [0x42u8; 32];
+    let exporter_secret = GroupExporterSecret {
+        mls_group_id: mls_group_id.clone(),
+        epoch,
+        secret,
+    };
+
+    // Test save
+    storage
+        .save_group_exporter_secret(exporter_secret.clone())
+        .unwrap();
+
+    // Test get
+    let retrieved = storage
+        .get_group_exporter_secret(&mls_group_id, epoch)
+        .unwrap();
+    assert!(retrieved.is_some());
+    let retrieved = retrieved.unwrap();
+    assert_eq!(retrieved.mls_group_id, mls_group_id);
+    assert_eq!(retrieved.epoch, epoch);
+    assert_eq!(retrieved.secret, secret);
+
+    // Test get non-existent
+    let result = storage
+        .get_group_exporter_secret(&mls_group_id, 999)
+        .unwrap();
+    assert!(result.is_none());
+}
+
+/// Test basic group relay functionality (not the comprehensive replace tests)
+#[allow(dead_code)]
+pub fn test_basic_group_relays<S: GroupStorage>(storage: S) {
+    let mls_group_id = GroupId::from_slice(&[1, 2, 3, 11]);
+    let group = create_test_group(mls_group_id.clone());
+    storage.save_group(group).unwrap();
+
+    // Initially should be empty
+    let relays = storage.group_relays(&mls_group_id).unwrap();
+    assert_eq!(relays.len(), 0);
+
+    // Add a relay using replace
+    let relay_url = RelayUrl::parse("wss://relay.example.com").unwrap();
+    let relays_set = BTreeSet::from([relay_url.clone()]);
+    storage
+        .replace_group_relays(&mls_group_id, relays_set)
+        .unwrap();
+
+    // Verify it's there
+    let relays = storage.group_relays(&mls_group_id).unwrap();
+    assert_eq!(relays.len(), 1);
+    assert_eq!(relays.first().unwrap().relay_url, relay_url);
+}
+
+/// Test comprehensive relay replacement functionality
+#[allow(dead_code)]
+pub fn test_replace_group_relays_comprehensive<S: GroupStorage>(storage: S) {
+    let mls_group_id = GroupId::from_slice(&[1, 2, 3, 4]);
+    let group = create_test_group(mls_group_id.clone());
+
+    // Save the test group
+    storage.save_group(group).unwrap();
+
+    // Test 1: Replace with initial relay set
+    let relay1 = RelayUrl::parse("wss://relay1.example.com").unwrap();
+    let relay2 = RelayUrl::parse("wss://relay2.example.com").unwrap();
+    let initial_relays = BTreeSet::from([relay1.clone(), relay2.clone()]);
+
+    storage
+        .replace_group_relays(&mls_group_id, initial_relays.clone())
+        .unwrap();
+    let stored_relays = storage.group_relays(&mls_group_id).unwrap();
+    assert_eq!(stored_relays.len(), 2);
+    assert!(stored_relays.iter().any(|r| r.relay_url == relay1));
+    assert!(stored_relays.iter().any(|r| r.relay_url == relay2));
+
+    // Test 2: Replace with different relay set (should remove old ones)
+    let relay3 = RelayUrl::parse("wss://relay3.example.com").unwrap();
+    let relay4 = RelayUrl::parse("wss://relay4.example.com").unwrap();
+    let new_relays = BTreeSet::from([relay3.clone(), relay4.clone()]);
+
+    storage
+        .replace_group_relays(&mls_group_id, new_relays.clone())
+        .unwrap();
+    let stored_relays = storage.group_relays(&mls_group_id).unwrap();
+    assert_eq!(stored_relays.len(), 2);
+    assert!(stored_relays.iter().any(|r| r.relay_url == relay3));
+    assert!(stored_relays.iter().any(|r| r.relay_url == relay4));
+    // Old relays should be gone
+    assert!(!stored_relays.iter().any(|r| r.relay_url == relay1));
+    assert!(!stored_relays.iter().any(|r| r.relay_url == relay2));
+
+    // Test 3: Replace with empty set
+    storage
+        .replace_group_relays(&mls_group_id, BTreeSet::new())
+        .unwrap();
+    let stored_relays = storage.group_relays(&mls_group_id).unwrap();
+    assert_eq!(stored_relays.len(), 0);
+
+    // Test 4: Replace with single relay after empty
+    let single_relay = BTreeSet::from([relay1.clone()]);
+    storage
+        .replace_group_relays(&mls_group_id, single_relay)
+        .unwrap();
+    let stored_relays = storage.group_relays(&mls_group_id).unwrap();
+    assert_eq!(stored_relays.len(), 1);
+    assert_eq!(stored_relays.first().unwrap().relay_url, relay1);
+
+    // Test 5: Replace with large set
+    let large_set: BTreeSet<RelayUrl> = (1..=10)
+        .map(|i| RelayUrl::parse(&format!("wss://relay{}.example.com", i)).unwrap())
+        .collect();
+    storage
+        .replace_group_relays(&mls_group_id, large_set.clone())
+        .unwrap();
+    let stored_relays = storage.group_relays(&mls_group_id).unwrap();
+    assert_eq!(stored_relays.len(), 10);
+    for expected_relay in &large_set {
+        assert!(stored_relays.iter().any(|r| r.relay_url == *expected_relay));
+    }
+}
+
+/// Test error cases for relay replacement
+#[allow(dead_code)]
+pub fn test_replace_group_relays_error_cases<S: GroupStorage>(storage: S) {
+    // Test: Replace relays for non-existent group
+    let non_existent_group_id = GroupId::from_slice(&[99, 99, 99, 99]);
+    let relay = RelayUrl::parse("wss://relay.example.com").unwrap();
+    let relays = BTreeSet::from([relay]);
+
+    let result = storage.replace_group_relays(&non_existent_group_id, relays);
+    assert!(result.is_err());
+    assert!(matches!(
+        result.unwrap_err(),
+        GroupError::InvalidParameters(_)
+    ));
+}
+
+/// Test duplicate handling for replace_group_relays
+#[allow(dead_code)]
+pub fn test_replace_group_relays_duplicate_handling<S: GroupStorage>(storage: S) {
+    let mls_group_id = GroupId::from_slice(&[1, 2, 3, 5]);
+    let group = create_test_group(mls_group_id.clone());
+
+    storage.save_group(group).unwrap();
+
+    // Test: BTreeSet naturally handles duplicates, but test behavior is consistent
+    let relay = RelayUrl::parse("wss://relay.example.com").unwrap();
+    let relays = BTreeSet::from([relay.clone()]);
+
+    // Add same relay multiple times - should be idempotent
+    storage
+        .replace_group_relays(&mls_group_id, relays.clone())
+        .unwrap();
+    storage
+        .replace_group_relays(&mls_group_id, relays.clone())
+        .unwrap();
+
+    let stored_relays = storage.group_relays(&mls_group_id).unwrap();
+    assert_eq!(stored_relays.len(), 1);
+    assert_eq!(stored_relays.first().unwrap().relay_url, relay);
+}
+
+/// Test edge cases and error conditions for group operations
+#[allow(dead_code)]
+pub fn test_group_edge_cases<S: GroupStorage>(storage: S) {
+    // Test saving group with empty name
+    let mls_group_id = GroupId::from_slice(&[1, 2, 3, 14]);
+    let mut group = create_test_group(mls_group_id.clone());
+    group.name = String::new();
+
+    // Should still work (empty names are valid)
+    storage.save_group(group.clone()).unwrap();
+    let found = storage
+        .find_group_by_mls_group_id(&mls_group_id)
+        .unwrap()
+        .unwrap();
+    assert_eq!(found.name, "");
+
+    // Test saving group with very long name
+    let long_name = "a".repeat(1000);
+    group.name = long_name.clone();
+    storage.save_group(group).unwrap();
+    let found = storage
+        .find_group_by_mls_group_id(&mls_group_id)
+        .unwrap()
+        .unwrap();
+    assert_eq!(found.name, long_name);
+
+    // Test duplicate group save (should update existing)
+    let mut updated_group = create_test_group(mls_group_id.clone());
+    updated_group.description = "Updated description".to_string();
+    storage.save_group(updated_group).unwrap();
+    let found = storage
+        .find_group_by_mls_group_id(&mls_group_id)
+        .unwrap()
+        .unwrap();
+    assert_eq!(found.description, "Updated description");
+}
+
+/// Test concurrent relay operations and edge cases
+#[allow(dead_code)]
+pub fn test_replace_relays_edge_cases<S: GroupStorage>(storage: S) {
+    let mls_group_id = GroupId::from_slice(&[1, 2, 3, 15]);
+    let group = create_test_group(mls_group_id.clone());
+    storage.save_group(group).unwrap();
+
+    // Test with very large relay sets
+    let large_relay_set: BTreeSet<RelayUrl> = (1..=100)
+        .map(|i| RelayUrl::parse(&format!("wss://relay{}.example.com", i)).unwrap())
+        .collect();
+
+    storage
+        .replace_group_relays(&mls_group_id, large_relay_set.clone())
+        .unwrap();
+    let stored = storage.group_relays(&mls_group_id).unwrap();
+    assert_eq!(stored.len(), 100);
+
+    // Test multiple rapid replacements
+    for i in 0..10 {
+        let relay_set = BTreeSet::from([RelayUrl::parse(&format!("wss://test{}.com", i)).unwrap()]);
+        storage
+            .replace_group_relays(&mls_group_id, relay_set)
+            .unwrap();
+    }
+    let final_relays = storage.group_relays(&mls_group_id).unwrap();
+    assert_eq!(final_relays.len(), 1);
+    assert_eq!(
+        final_relays.first().unwrap().relay_url.to_string(),
+        "wss://test9.com"
+    );
+}
+
+/// Test message storage functionality with group queries
+#[allow(dead_code)]
+pub fn test_messages_for_group<S: GroupStorage>(storage: S) {
+    let mls_group_id = GroupId::from_slice(&[1, 2, 3, 12]);
+    let group = create_test_group(mls_group_id.clone());
+    storage.save_group(group).unwrap();
+
+    // Test messages for group (initially empty)
+    let messages = storage.messages(&mls_group_id).unwrap();
+    assert_eq!(messages.len(), 0);
+}

--- a/mls/nostr-mls-storage/tests/shared/message_tests.rs
+++ b/mls/nostr-mls-storage/tests/shared/message_tests.rs
@@ -1,0 +1,75 @@
+//! Message storage test functions
+
+use nostr::EventId;
+use nostr_mls_storage::groups::GroupStorage;
+use nostr_mls_storage::messages::MessageStorage;
+use openmls::group::GroupId;
+
+use super::{create_test_group, create_test_message, create_test_processed_message};
+
+/// Test message storage functionality
+#[allow(dead_code)]
+pub fn test_save_and_find_message<S: MessageStorage + GroupStorage>(storage: S) {
+    let mls_group_id = GroupId::from_slice(&[1, 2, 3, 12]);
+
+    // First create the group (required for foreign key constraints)
+    let group = create_test_group(mls_group_id.clone());
+    storage.save_group(group).unwrap();
+
+    let event_id = EventId::all_zeros();
+    let message = create_test_message(mls_group_id.clone(), event_id);
+
+    // Test save
+    storage.save_message(message.clone()).unwrap();
+
+    // Test find
+    let found_message = storage.find_message_by_event_id(&event_id).unwrap();
+    assert!(found_message.is_some());
+    let found_message = found_message.unwrap();
+    assert_eq!(found_message.id, message.id);
+    assert_eq!(found_message.content, message.content);
+    assert_eq!(found_message.mls_group_id, message.mls_group_id);
+
+    // Test find non-existent
+    let non_existent_id =
+        EventId::from_hex("abababababababababababababababababababababababababababababababab")
+            .unwrap();
+    let result = storage.find_message_by_event_id(&non_existent_id).unwrap();
+    assert!(result.is_none());
+}
+
+/// Test processed message functionality
+#[allow(dead_code)]
+pub fn test_processed_message<S: MessageStorage>(storage: S) {
+    let wrapper_event_id = EventId::all_zeros();
+    let message_event_id =
+        EventId::from_hex("1111111111111111111111111111111111111111111111111111111111111111")
+            .unwrap();
+    let processed_message = create_test_processed_message(wrapper_event_id, Some(message_event_id));
+
+    // Test save
+    storage
+        .save_processed_message(processed_message.clone())
+        .unwrap();
+
+    // Test find by wrapper event id
+    let found = storage
+        .find_processed_message_by_event_id(&wrapper_event_id)
+        .unwrap();
+    assert!(found.is_some());
+    let found = found.unwrap();
+    assert_eq!(found.wrapper_event_id, wrapper_event_id);
+    assert_eq!(found.message_event_id, Some(message_event_id));
+
+    // Note: The MessageStorage trait doesn't have find_processed_message_by_message_event_id
+    // We only test find_processed_message_by_event_id which finds by wrapper event id
+
+    // Test find non-existent
+    let non_existent_id =
+        EventId::from_hex("abababababababababababababababababababababababababababababababab")
+            .unwrap();
+    let result = storage
+        .find_processed_message_by_event_id(&non_existent_id)
+        .unwrap();
+    assert!(result.is_none());
+}

--- a/mls/nostr-mls-storage/tests/shared/mod.rs
+++ b/mls/nostr-mls-storage/tests/shared/mod.rs
@@ -1,0 +1,145 @@
+//! Shared test utilities and functions for storage testing
+
+pub mod group_tests;
+pub mod message_tests;
+pub mod welcome_tests;
+
+use std::collections::BTreeSet;
+
+use nostr::{EventId, PublicKey, RelayUrl, Timestamp};
+use nostr_mls_storage::groups::types::{Group, GroupState};
+use nostr_mls_storage::messages::types::{
+    Message, MessageState, ProcessedMessage, ProcessedMessageState,
+};
+use nostr_mls_storage::welcomes::types::{
+    ProcessedWelcome, ProcessedWelcomeState, Welcome, WelcomeState,
+};
+use openmls::group::GroupId;
+
+/// Creates a test group with the given ID for testing purposes
+#[allow(dead_code)]
+pub fn create_test_group(mls_group_id: GroupId) -> Group {
+    let mut nostr_group_id = [0u8; 32];
+    // Use first 4 bytes of mls_group_id to make nostr_group_id somewhat unique
+    let id_bytes = mls_group_id.as_slice();
+    let copy_len = std::cmp::min(id_bytes.len(), 4);
+    nostr_group_id[0..copy_len].copy_from_slice(&id_bytes[0..copy_len]);
+
+    Group {
+        mls_group_id,
+        nostr_group_id,
+        name: "Test Group".to_string(),
+        description: "A test group".to_string(),
+        admin_pubkeys: BTreeSet::new(),
+        last_message_id: None,
+        last_message_at: None,
+        epoch: 0,
+        state: GroupState::Active,
+        image_url: None,
+        image_key: None,
+    }
+}
+
+/// Creates a test message for testing purposes
+#[allow(dead_code)]
+pub fn create_test_message(mls_group_id: GroupId, event_id: EventId) -> Message {
+    use nostr::{Kind, Tags, UnsignedEvent};
+
+    let pubkey =
+        PublicKey::parse("npub1a6awmmklxfmspwdv52qq58sk5c07kghwc4v2eaudjx2ju079cdqs2452ys")
+            .unwrap();
+    let created_at = Timestamp::now();
+    let content = "Test message content".to_string();
+    let tags = Tags::new();
+
+    let event = UnsignedEvent {
+        id: Some(event_id),
+        pubkey,
+        created_at,
+        kind: Kind::Custom(445),
+        tags: tags.clone(),
+        content: content.clone(),
+    };
+
+    Message {
+        id: event_id,
+        pubkey,
+        kind: Kind::Custom(445),
+        mls_group_id,
+        created_at,
+        content,
+        tags,
+        event,
+        wrapper_event_id: event_id,
+        state: MessageState::Processed,
+    }
+}
+
+/// Creates a test processed message for testing purposes
+#[allow(dead_code)]
+pub fn create_test_processed_message(
+    wrapper_event_id: EventId,
+    message_event_id: Option<EventId>,
+) -> ProcessedMessage {
+    ProcessedMessage {
+        wrapper_event_id,
+        message_event_id,
+        processed_at: Timestamp::now(),
+        state: ProcessedMessageState::Processed,
+        failure_reason: None,
+    }
+}
+
+/// Creates a test welcome for testing purposes
+#[allow(dead_code)]
+pub fn create_test_welcome(mls_group_id: GroupId, event_id: EventId) -> Welcome {
+    use nostr::{Kind, Tags, UnsignedEvent};
+
+    let pubkey =
+        PublicKey::parse("npub1a6awmmklxfmspwdv52qq58sk5c07kghwc4v2eaudjx2ju079cdqs2452ys")
+            .unwrap();
+    let created_at = Timestamp::now();
+    let content = "Test welcome content".to_string();
+    let tags = Tags::new();
+
+    let event = UnsignedEvent {
+        id: Some(event_id),
+        pubkey,
+        created_at,
+        kind: Kind::Custom(444),
+        tags,
+        content,
+    };
+
+    Welcome {
+        id: event_id,
+        event,
+        mls_group_id,
+        nostr_group_id: [0u8; 32],
+        group_name: "Test Group".to_string(),
+        group_description: "A test group".to_string(),
+        group_image_url: None,
+        group_image_key: None,
+        group_admin_pubkeys: BTreeSet::from([pubkey]),
+        group_relays: BTreeSet::from([RelayUrl::parse("wss://relay.example.com").unwrap()]),
+        welcomer: pubkey,
+        member_count: 1,
+        state: WelcomeState::Pending,
+        wrapper_event_id: event_id,
+    }
+}
+
+/// Creates a test processed welcome for testing purposes
+#[allow(dead_code)]
+pub fn create_test_processed_welcome(
+    wrapper_event_id: EventId,
+    welcome_event_id: Option<EventId>,
+) -> ProcessedWelcome {
+    ProcessedWelcome {
+        wrapper_event_id,
+        welcome_event_id,
+        processed_at: Timestamp::now(),
+        state: ProcessedWelcomeState::Processed,
+        failure_reason: None,
+    }
+}

--- a/mls/nostr-mls-storage/tests/shared/welcome_tests.rs
+++ b/mls/nostr-mls-storage/tests/shared/welcome_tests.rs
@@ -1,0 +1,77 @@
+//! Welcome storage test functions
+
+use nostr::EventId;
+use nostr_mls_storage::groups::GroupStorage;
+use nostr_mls_storage::welcomes::WelcomeStorage;
+use openmls::group::GroupId;
+
+use super::{create_test_group, create_test_processed_welcome, create_test_welcome};
+
+/// Test welcome storage functionality
+#[allow(dead_code)]
+pub fn test_save_and_find_welcome<S: WelcomeStorage + GroupStorage>(storage: S) {
+    let mls_group_id = GroupId::from_slice(&[1, 2, 3, 13]);
+
+    // First create the group (required for foreign key constraints)
+    let group = create_test_group(mls_group_id.clone());
+    storage.save_group(group).unwrap();
+
+    let event_id = EventId::all_zeros();
+    let welcome = create_test_welcome(mls_group_id.clone(), event_id);
+
+    // Test save
+    storage.save_welcome(welcome.clone()).unwrap();
+
+    // Test find
+    let found_welcome = storage.find_welcome_by_event_id(&event_id).unwrap();
+    assert!(found_welcome.is_some());
+    let found_welcome = found_welcome.unwrap();
+    assert_eq!(found_welcome.id, welcome.id);
+    assert_eq!(found_welcome.group_name, welcome.group_name);
+    assert_eq!(found_welcome.mls_group_id, welcome.mls_group_id);
+
+    // Test find non-existent
+    let non_existent_id =
+        EventId::from_hex("abababababababababababababababababababababababababababababababab")
+            .unwrap();
+    let result = storage.find_welcome_by_event_id(&non_existent_id).unwrap();
+    assert!(result.is_none());
+
+    // Test pending welcomes
+    let pending = storage.pending_welcomes().unwrap();
+    assert_eq!(pending.len(), 1);
+    assert_eq!(pending[0].id, event_id);
+}
+
+/// Test processed welcome functionality
+#[allow(dead_code)]
+pub fn test_processed_welcome<S: WelcomeStorage>(storage: S) {
+    let wrapper_event_id = EventId::all_zeros();
+    let welcome_event_id =
+        EventId::from_hex("1111111111111111111111111111111111111111111111111111111111111111")
+            .unwrap();
+    let processed_welcome = create_test_processed_welcome(wrapper_event_id, Some(welcome_event_id));
+
+    // Test save
+    storage
+        .save_processed_welcome(processed_welcome.clone())
+        .unwrap();
+
+    // Test find by wrapper event id
+    let found = storage
+        .find_processed_welcome_by_event_id(&wrapper_event_id)
+        .unwrap();
+    assert!(found.is_some());
+    let found = found.unwrap();
+    assert_eq!(found.wrapper_event_id, wrapper_event_id);
+    assert_eq!(found.welcome_event_id, Some(welcome_event_id));
+
+    // Test find non-existent
+    let non_existent_id =
+        EventId::from_hex("abababababababababababababababababababababababababababababababab")
+            .unwrap();
+    let result = storage
+        .find_processed_welcome_by_event_id(&non_existent_id)
+        .unwrap();
+    assert!(result.is_none());
+}

--- a/mls/nostr-mls-storage/tests/sqlite_storage.rs
+++ b/mls/nostr-mls-storage/tests/sqlite_storage.rs
@@ -1,0 +1,88 @@
+//! SQLite storage implementation tests using shared test functions
+
+use nostr_mls_sqlite_storage::NostrMlsSqliteStorage;
+
+#[path = "shared/mod.rs"]
+mod shared;
+
+/// Macro to generate tests that run against SQLite storage using shared test functions
+macro_rules! test_sqlite_storage {
+    ($test_name:ident, $test_fn:path) => {
+        #[test]
+        fn $test_name() {
+            let storage = NostrMlsSqliteStorage::new(":memory:").unwrap();
+            $test_fn(storage);
+        }
+    };
+}
+
+// Group functionality tests
+test_sqlite_storage!(
+    test_save_and_find_group_sqlite,
+    shared::group_tests::test_save_and_find_group
+);
+
+test_sqlite_storage!(test_all_groups_sqlite, shared::group_tests::test_all_groups);
+
+test_sqlite_storage!(
+    test_group_exporter_secret_sqlite,
+    shared::group_tests::test_group_exporter_secret
+);
+
+test_sqlite_storage!(
+    test_basic_group_relays_sqlite,
+    shared::group_tests::test_basic_group_relays
+);
+
+test_sqlite_storage!(
+    test_group_edge_cases_sqlite,
+    shared::group_tests::test_group_edge_cases
+);
+
+test_sqlite_storage!(
+    test_replace_relays_edge_cases_sqlite,
+    shared::group_tests::test_replace_relays_edge_cases
+);
+
+// Comprehensive relay tests
+test_sqlite_storage!(
+    test_replace_group_relays_comprehensive_sqlite,
+    shared::group_tests::test_replace_group_relays_comprehensive
+);
+
+test_sqlite_storage!(
+    test_replace_group_relays_error_cases_sqlite,
+    shared::group_tests::test_replace_group_relays_error_cases
+);
+
+test_sqlite_storage!(
+    test_replace_group_relays_duplicate_handling_sqlite,
+    shared::group_tests::test_replace_group_relays_duplicate_handling
+);
+
+// Message functionality tests
+test_sqlite_storage!(
+    test_save_and_find_message_sqlite,
+    shared::message_tests::test_save_and_find_message
+);
+
+test_sqlite_storage!(
+    test_processed_message_sqlite,
+    shared::message_tests::test_processed_message
+);
+
+test_sqlite_storage!(
+    test_messages_for_group_sqlite,
+    shared::group_tests::test_messages_for_group
+);
+
+// Welcome functionality tests
+test_sqlite_storage!(
+    test_save_and_find_welcome_sqlite,
+    shared::welcome_tests::test_save_and_find_welcome
+);
+
+test_sqlite_storage!(
+    test_processed_welcome_sqlite,
+    shared::welcome_tests::test_processed_welcome
+);

--- a/mls/nostr-mls/CHANGELOG.md
+++ b/mls/nostr-mls/CHANGELOG.md
@@ -42,6 +42,10 @@
 - Improved synchronization between MLSGroup and stored Group state on all commits. (https://github.com/rust-nostr/nostr/pull/1050)
 - Added `NostrMls::update_group_data` method to handle updates of any of the fields of the `NostrGroupDataExtension` (https://github.com/rust-nostr/nostr/pull/1050)
 
+### Fixed
+
+- Bug where group relays weren't being persisted properly on change in NostrGroupDataExtension
+
 ## v0.43.0 - 2025/07/28
 
 ### Breaking changes

--- a/mls/nostr-mls/src/groups.rs
+++ b/mls/nostr-mls/src/groups.rs
@@ -916,17 +916,10 @@ where
             |e: nostr_mls_storage::groups::error::GroupError| Error::Group(e.to_string()),
         )?;
 
-        // Always (re-)save the group relays after saving the group
-        for relay_url in config.relays.into_iter() {
-            let group_relay = group_types::GroupRelay {
-                mls_group_id: group.mls_group_id.clone(),
-                relay_url,
-            };
-
-            self.storage()
-                .save_group_relay(group_relay)
-                .map_err(|e| Error::Group(e.to_string()))?;
-        }
+        // Save the group relays after saving the group
+        self.storage()
+            .replace_group_relays(&group.mls_group_id, config.relays.into_iter().collect())
+            .map_err(|e| Error::Group(e.to_string()))?;
 
         Ok(GroupResult {
             group,
@@ -1141,6 +1134,11 @@ where
             stored_group.image_key = group_data.image_key;
             stored_group.admin_pubkeys = group_data.admins;
             stored_group.nostr_group_id = group_data.nostr_group_id;
+
+            // Sync relays atomically - replace entire relay set with current extension data
+            self.storage()
+                .replace_group_relays(group_id, group_data.relays)
+                .map_err(|e| Error::Group(e.to_string()))?;
         }
 
         self.storage()

--- a/mls/nostr-mls/src/welcomes.rs
+++ b/mls/nostr-mls/src/welcomes.rs
@@ -111,16 +111,12 @@ where
             .map_err(|e| Error::Group(e.to_string()))?;
 
         // Save the group relays
-        for relay in welcome_preview.nostr_group_data.relays.iter() {
-            let group_relay = group_types::GroupRelay {
-                mls_group_id: mls_group_id.clone(),
-                relay_url: relay.clone(),
-            };
-
-            self.storage()
-                .save_group_relay(group_relay)
-                .map_err(|e| Error::Group(e.to_string()))?;
-        }
+        self.storage()
+            .replace_group_relays(
+                &mls_group_id,
+                welcome_preview.nostr_group_data.relays.clone(),
+            )
+            .map_err(|e| Error::Group(e.to_string()))?;
 
         let processed_welcome = welcome_types::ProcessedWelcome {
             wrapper_event_id: *wrapper_event_id,
@@ -186,17 +182,10 @@ where
                 |e: nostr_mls_storage::groups::error::GroupError| Error::Group(e.to_string()),
             )?;
 
-            // Always (re-)save the group relays after saving the group
-            for relay_url in welcome_preview.nostr_group_data.relays.into_iter() {
-                let group_relay = group_types::GroupRelay {
-                    mls_group_id: mls_group_id.clone(),
-                    relay_url,
-                };
-
-                self.storage()
-                    .save_group_relay(group_relay)
-                    .map_err(|e| Error::Group(e.to_string()))?;
-            }
+            // Save the group relays after saving the group
+            self.storage()
+                .replace_group_relays(&mls_group_id, welcome_preview.nostr_group_data.relays)
+                .map_err(|e| Error::Group(e.to_string()))?;
         }
 
         Ok(())


### PR DESCRIPTION
### Description

This PR fixes a bug where Group relays weren't being updated by NostrDataExtension updates. Additionally, I've created a simple test framework for testing both nostr-mls storage adapters against the same tests to ensure correctness and consistency.

### Checklist

- [x] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [x] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
