### PR TITLE
nostr: `RelayUrl::host` function

### DIFF
--- a/crates/nostr/CHANGELOG.md
+++ b/crates/nostr/CHANGELOG.md
@@ -48,6 +48,7 @@
 - Support NIP-A0 (Voice Messages) (https://github.com/rust-nostr/nostr/pull/1032)
 - Add `hex` dependency (https://github.com/rust-nostr/nostr/pull/1051)
 - Add `nip25::ReactionTarget` (https://github.com/rust-nostr/nostr/pull/1063)
+- Add `RelayUrl::host` function (https://github.com/rust-nostr/nostr/pull/1066)
 
 ### Changed
 

--- a/crates/nostr/src/types/url.rs
+++ b/crates/nostr/src/types/url.rs
@@ -166,6 +166,14 @@ impl RelayUrl {
         self.url.domain()
     }
 
+    /// Return the parsed representation of the host for this URL.
+    /// Non-ASCII domain labels are punycode-encoded per IDNA if this is the host
+    /// of a special URL, or percent encoded for non-special URLs.
+    #[inline]
+    pub fn host(&self) -> Option<Host<&str>> {
+        self.url.host()
+    }
+
     /// Return the serialization of this relay URL without the trailing slash.
     ///
     /// This method will always remove the trailing slash.


### PR DESCRIPTION
### Description

A function to return the relay host

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
