### PR TITLE
nwc: subscribe to the response using the request event ID

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3586,7 +3586,6 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 name = "nwc"
 version = "0.43.0"
 dependencies = [
- "async-utility",
  "nostr",
  "nostr-relay-pool",
  "tokio",

--- a/crates/nwc/CHANGELOG.md
+++ b/crates/nwc/CHANGELOG.md
@@ -25,10 +25,18 @@
 
 ## Unreleased
 
+### Changed
+
+- Subscribe to the response using the request event ID (https://github.com/rust-nostr/nostr/pull/1073)
+
 ### Added
 
 - Add `NWC::reconnect_relay` (https://github.com/rust-nostr/nostr/pull/1020)
 - Add `NWC::uri`
+
+### Fixed
+
+- Fix the compatibility issues with some NWC services, like Primal (https://github.com/rust-nostr/nostr/pull/1073)
 
 ## v0.43.0 - 2025/07/28
 

--- a/crates/nwc/Cargo.toml
+++ b/crates/nwc/Cargo.toml
@@ -16,7 +16,6 @@ default = []
 tor = ["nostr-relay-pool/tor"]
 
 [dependencies]
-async-utility.workspace = true
 nostr = { workspace = true, features = ["std", "nip47"] }
 nostr-relay-pool.workspace = true
 tracing = { workspace = true, features = ["std"] }


### PR DESCRIPTION
This fixes the compatibility issues with some NWC services, like Primal.