### PR TITLE
relay-builder: check if pow is 0 before calculating

### DIFF
--- a/crates/nostr-relay-builder/CHANGELOG.md
+++ b/crates/nostr-relay-builder/CHANGELOG.md
@@ -23,6 +23,12 @@
 
 -->
 
+## Unreleased
+
+### Fixed
+
+- Consider a PoW difficulty if it’s greater than 0 in `RelayBuilder::min_pow` (https://github.com/rust-nostr/nostr/pull/1085)
+
 ## v0.43.0 - 2025/07/28
 
 No notable changes in this release.

--- a/crates/nostr-relay-builder/src/builder.rs
+++ b/crates/nostr-relay-builder/src/builder.rs
@@ -280,10 +280,14 @@ impl RelayBuilder {
         self
     }
 
-    /// Set min POW difficulty
+    /// Sets the minimum Proof of Work difficulty.
+    ///
+    /// Only values `> 0` are accepted!
     #[inline]
     pub fn min_pow(mut self, difficulty: u8) -> Self {
-        self.min_pow = Some(difficulty);
+        if difficulty > 0 {
+            self.min_pow = Some(difficulty);
+        }
         self
     }
 


### PR DESCRIPTION
### Description

There is no need to calculate the pow of each event if the `min_pow` is 0. Most of the relays default PoW is 0.

So I can do this

```rust
    let relay_builder = RelayBuilder::default()
        .addr(config.net.ip)
        .port(config.net.port)
        .min_pow(config.relay.min_pow);
```

Instead of this

```rust
    let mut relay_builder = RelayBuilder::default()
        .addr(config.net.ip)
        .port(config.net.port);

    if config.relay.min_pow != 0 {
        relay_builder.min_pow(config.relay.min_pow);
    }
```

### Notes to the reviewers

This behavior is already implemented in `Event::pow`

```rust
    /// Set POW difficulty
    ///
    /// Only values `> 0` are accepted!
    #[inline]
    pub fn pow(mut self, difficulty: u8) -> Self {
        if difficulty > 0 {
            self.pow = Some(difficulty);
        }
        self
    }
```

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
