### PR TITLE
relay-builder: filter's limit enforcement

### DIFF
--- a/crates/nostr-relay-builder/CHANGELOG.md
+++ b/crates/nostr-relay-builder/CHANGELOG.md
@@ -25,6 +25,10 @@
 
 ## Unreleased
 
+### Added
+
+- Add `RelayBuilder::max_filter_limit` and `RelayBuilder::default_filter_limit` to limit the filter's limit (https://github.com/rust-nostr/nostr/pull/1096)
+
 ### Fixed
 
 - Consider a PoW difficulty if it’s greater than 0 in `RelayBuilder::min_pow` (https://github.com/rust-nostr/nostr/pull/1085)

--- a/crates/nostr-relay-builder/src/builder.rs
+++ b/crates/nostr-relay-builder/src/builder.rs
@@ -186,6 +186,10 @@ pub struct RelayBuilder {
     pub(crate) tor: Option<RelayBuilderHiddenService>,
     /// Max connections allowed
     pub(crate) max_connections: Option<usize>,
+    /// Max filter's limit
+    pub(crate) max_filter_limit: Option<usize>,
+    /// Default filter's limit if there is no limit
+    pub(crate) default_filter_limit: usize,
     /// Min POW difficulty
     pub(crate) min_pow: Option<u8>,
     /// Write policy plugins
@@ -211,6 +215,8 @@ impl Default for RelayBuilder {
             #[cfg(feature = "tor")]
             tor: None,
             max_connections: None,
+            max_filter_limit: None,
+            default_filter_limit: 500,
             min_pow: None,
             write_plugins: Vec::new(),
             query_plugins: Vec::new(),
@@ -277,6 +283,21 @@ impl RelayBuilder {
     #[inline]
     pub fn max_connections(mut self, max: usize) -> Self {
         self.max_connections = Some(max);
+        self
+    }
+
+    /// Sets the maximum limit for the filter. If the filter's limit exceeds
+    /// this value, it will fallback to this number.
+    #[inline]
+    pub fn max_filter_limit(mut self, max: usize) -> Self {
+        self.max_filter_limit = Some(max);
+        self
+    }
+
+    /// Sets the default filter limit when no limit is specified. Defaults 500.
+    #[inline]
+    pub fn default_filter_limit(mut self, limit: usize) -> Self {
+        self.default_filter_limit = limit;
         self
     }
 


### PR DESCRIPTION
### Description

Add `RelayBuilder::max_filter_limit` to enforce an upper bound on filter limits, causing values exceeding this maximum to fall back to it. Introduce `RelayBuilder::default_filter_limit` to specify a default limit when a filter has no limit or it's set to 0.

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

- This concept is inspired by https://github.com/nostr-protocol/nips/blob/master/11.md#server-limitations.
- Should the default limit be 500?

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
