### PR TITLE
relay-builder: add max subscription length option

### DIFF
--- a/crates/nostr-relay-builder/CHANGELOG.md
+++ b/crates/nostr-relay-builder/CHANGELOG.md
@@ -28,6 +28,7 @@
 ### Added
 
 - Add `RelayBuilder::max_filter_limit` and `RelayBuilder::default_filter_limit` to limit the filter's limit (https://github.com/rust-nostr/nostr/pull/1096)
+- Add `RelayBuilder::max_subid_length` to enforce a limit on subscription ID size (https://github.com/rust-nostr/nostr/pull/1098)
 
 ### Fixed
 

--- a/crates/nostr-relay-builder/src/builder.rs
+++ b/crates/nostr-relay-builder/src/builder.rs
@@ -186,6 +186,8 @@ pub struct RelayBuilder {
     pub(crate) tor: Option<RelayBuilderHiddenService>,
     /// Max connections allowed
     pub(crate) max_connections: Option<usize>,
+    /// Max subscription ID length
+    pub(crate) max_subid_length: usize,
     /// Max filter's limit
     pub(crate) max_filter_limit: Option<usize>,
     /// Default filter's limit if there is no limit
@@ -215,6 +217,7 @@ impl Default for RelayBuilder {
             #[cfg(feature = "tor")]
             tor: None,
             max_connections: None,
+            max_subid_length: 250,
             max_filter_limit: None,
             default_filter_limit: 500,
             min_pow: None,
@@ -283,6 +286,13 @@ impl RelayBuilder {
     #[inline]
     pub fn max_connections(mut self, max: usize) -> Self {
         self.max_connections = Some(max);
+        self
+    }
+
+    /// Sets the maximum subscription ID length. Defaults 250.
+    #[inline]
+    pub fn max_subid_length(mut self, max: usize) -> Self {
+        self.max_subid_length = max;
         self
     }
 


### PR DESCRIPTION
Introduce a `max_subid_length` option to `RelayBuilder` to enforce a limit on subscription ID size, improving performance by preventing excessively large IDs (e.g., 1MB).

This aligns with the NIP-11 `limitation.max_subid_length` [1]

[1]: https://github.com/nostr-protocol/nips/blob/master/11.md

### Notes to the reviewers

- Should we add a default limit instead of an option? Something like 250 will be enough I think

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
