### PR TITLE
relay-builder: implement NIP-42 authenticated DMs

### DIFF
--- a/crates/nostr-relay-builder/CHANGELOG.md
+++ b/crates/nostr-relay-builder/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Add `RelayBuilder::max_filter_limit` and `RelayBuilder::default_filter_limit` to limit the filter's limit (https://github.com/rust-nostr/nostr/pull/1096)
 - Add `RelayBuilder::max_subid_length` to enforce a limit on subscription ID size (https://github.com/rust-nostr/nostr/pull/1098)
 - Add support for multi-filter REQ (https://github.com/rust-nostr/nostr/pull/1099)
+- Add support for NIP-42 DMs, DMs returned for the mentioned public key only (https://github.com/rust-nostr/nostr/pull/1104)
 
 ### Fixed
 

--- a/crates/nostr-relay-builder/src/builder.rs
+++ b/crates/nostr-relay-builder/src/builder.rs
@@ -192,6 +192,9 @@ pub struct RelayBuilder {
     pub(crate) max_filter_limit: Option<usize>,
     /// Default filter's limit if there is no limit
     pub(crate) default_filter_limit: usize,
+    /// Enables NIP-42 authentication for kind 1059 (GiftWrap), ensuring the
+    /// authenticated pubkey is the only "p" tag
+    pub(crate) auth_dm: bool,
     /// Min POW difficulty
     pub(crate) min_pow: Option<u8>,
     /// Write policy plugins
@@ -220,6 +223,7 @@ impl Default for RelayBuilder {
             max_subid_length: 250,
             max_filter_limit: None,
             default_filter_limit: 500,
+            auth_dm: false,
             min_pow: None,
             write_plugins: Vec::new(),
             query_plugins: Vec::new(),
@@ -308,6 +312,14 @@ impl RelayBuilder {
     #[inline]
     pub fn default_filter_limit(mut self, limit: usize) -> Self {
         self.default_filter_limit = limit;
+        self
+    }
+
+    /// If enabled, NIP-42 will be used for DMs, returning GiftWrap events for
+    /// the mentioned public key only.
+    #[inline]
+    pub fn auth_dm(mut self, enable: bool) -> Self {
+        self.auth_dm = enable;
         self
     }
 


### PR DESCRIPTION
Add support for NIP-42 authenticated direct messages by ensuring GiftWraps filters contain only the authenticated user's public key. This aligns with the NIP-17 specification for secure DM delivery.

Implementation inspired by NIP-17 and insights from the coop source code[1]. Thanks to @reyamir for the reference.

[1]: https://github.com/lumehq/coop

Fixes: https://github.com/rust-nostr/nostr/issues/1095

### Notes to the reviewers

- I think callback function is a good idea, and I think it's simple

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
