### PR TITLE
sdk: don't send kind 3 to inbox relays when using gossip

### DIFF
--- a/crates/nostr-sdk/CHANGELOG.md
+++ b/crates/nostr-sdk/CHANGELOG.md
@@ -34,6 +34,7 @@
 
 - Fetch gossip NIP-17 list only if really needed (https://github.com/rust-nostr/nostr/pull/1090)
 - Try to fetch only newer events when updating gossip lists (https://github.com/rust-nostr/nostr/pull/1090)
+- Don't send kind 3 (contact list) to inbox relays when using gossip (https://github.com/rust-nostr/nostr/pull/1112)
 
 ### Added
 


### PR DESCRIPTION
Closes nostr:nevent1qvzqqqqx25pzpepndn2jthmelfxn4umylktqp493ph8yy9d2fse76al2ppprgjcsqqsdp02ns3rrcnwdlnpxte3yctp5sm5kj2vkjz92rtyfky8lmekv0vcu9c9su
