### PR TITLE
nostr: add nip47 accepted state for hold invoices

### DIFF
--- a/crates/nostr/src/nips/nip47.rs
+++ b/crates/nostr/src/nips/nip47.rs
@@ -499,7 +499,7 @@ pub struct MakeHoldInvoiceRequest {
     pub payment_hash: String,
     /// The minimum CLTV delta to use for the final hop
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub cltv_expiry_delta: Option<u32>,
+    pub min_cltv_expiry_delta: Option<u32>,
 }
 
 /// Cancel Hold Invoice Request


### PR DESCRIPTION
This was recently added to the hold invoice PR https://github.com/nostr-protocol/nips/pull/1913 which seems close to merge.
