### PR TITLE
gossip-memory: replace `Mutex` with `RwLock` for better concurrency

### DIFF
--- a/gossip/nostr-gossip-memory/CHANGELOG.md
+++ b/gossip/nostr-gossip-memory/CHANGELOG.md
@@ -23,6 +23,12 @@
 
 -->
 
+## Unreleased
+
+### Changed
+
+- Replace `Mutex` with `RwLock` for better concurrency (https://github.com/rust-nostr/nostr/pull/1126)
+
 ## v0.44.0 - 2025/11/06
 
 First release.


### PR DESCRIPTION
Ref https://gitworkshop.dev/nevent1qvzqqqqx25pzpepndn2jthmelfxn4umylktqp493ph8yy9d2fse76al2ppprgjcsqqsgqu7w8sdhelm5dksy2g9r25u9u0x0q0qwnsnxgcdwas4z50fwvhgyfrrjh