### PR TITLE
relay-builder: rename `RelayBuilder` to `LocalRelayBuilder`

### DIFF
--- a/crates/nostr-relay-builder/CHANGELOG.md
+++ b/crates/nostr-relay-builder/CHANGELOG.md
@@ -23,6 +23,12 @@
 
 -->
 
+## Unreleased
+
+### Changes
+
+- Rename all `RelayBuilder*` structs and enums to `LocalRelayBuilder*` (https://github.com/rust-nostr/nostr/pull/1145)
+
 ## v0.44.0 - 2025/11/06
 
 ### Breaking change

--- a/crates/nostr-relay-builder/README.md
+++ b/crates/nostr-relay-builder/README.md
@@ -19,7 +19,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let database = NostrLmdb::open("nostr-relay").await?;
 
     // Configure the relay.
-    let builder = RelayBuilder::default()
+    let builder = LocalRelayBuilder::default()
         .port(7777)
         .database(database)
         .rate_limit(RateLimit {

--- a/crates/nostr-relay-builder/examples/hyper.rs
+++ b/crates/nostr-relay-builder/examples/hyper.rs
@@ -15,7 +15,7 @@ use hyper::{Request, Response};
 use hyper_util::rt::TokioIo;
 use nostr::hashes::sha1::Hash as Sha1Hash;
 use nostr::hashes::{Hash, HashEngine};
-use nostr_relay_builder::{LocalRelay, RelayBuilder};
+use nostr_relay_builder::{LocalRelay, LocalRelayBuilder};
 use tokio::net::TcpListener;
 
 struct HttpServer {
@@ -114,7 +114,7 @@ impl Service<Request<Incoming>> for HttpServer {
 async fn main() -> nostr_relay_builder::prelude::Result<()> {
     tracing_subscriber::fmt::init();
 
-    let builder = RelayBuilder::default();
+    let builder = LocalRelayBuilder::default();
     let relay = LocalRelay::new(builder);
 
     let http_addr: SocketAddr = "127.0.0.1:8000".parse()?;

--- a/crates/nostr-relay-builder/examples/policy.rs
+++ b/crates/nostr-relay-builder/examples/policy.rs
@@ -62,7 +62,7 @@ async fn main() -> Result<()> {
 
     let low_author_limit = RejectAuthorLimit { limit: 2 };
 
-    let builder = RelayBuilder::default()
+    let builder = LocalRelayBuilder::default()
         .write_policy(accept_profile_data)
         .query_policy(low_author_limit);
 

--- a/crates/nostr-relay-builder/examples/simple_relay.rs
+++ b/crates/nostr-relay-builder/examples/simple_relay.rs
@@ -9,7 +9,7 @@ async fn main() -> Result<()> {
 
     let db = NostrLmdb::open("./db/nostr-lmdb").await?;
 
-    let builder = RelayBuilder::default().port(7777).database(db);
+    let builder = LocalRelayBuilder::default().port(7777).database(db);
 
     let relay = LocalRelay::new(builder);
 

--- a/crates/nostr-relay-builder/src/builder.rs
+++ b/crates/nostr-relay-builder/src/builder.rs
@@ -35,10 +35,18 @@ impl Default for RateLimit {
     }
 }
 
+#[cfg(feature = "tor")]
+#[allow(missing_docs)]
+#[deprecated(
+    since = "0.45.0",
+    note = "Use `LocalRelayBuilderHiddenService` instead"
+)]
+pub type RelayBuilderHiddenService = LocalRelayBuilderHiddenService;
+
 /// Relay builder tor hidden service options
 #[derive(Debug, Clone)]
 #[cfg(feature = "tor")]
-pub struct RelayBuilderHiddenService {
+pub struct LocalRelayBuilderHiddenService {
     /// Nickname (local identifier) for a Tor hidden service
     ///
     /// Used to look up this service's keys, state, configuration, etc., and distinguish them from other services.
@@ -48,7 +56,7 @@ pub struct RelayBuilderHiddenService {
 }
 
 #[cfg(feature = "tor")]
-impl RelayBuilderHiddenService {
+impl LocalRelayBuilderHiddenService {
     /// New tor hidden service options
     ///
     /// The nickname is a local identifier for a Tor hidden service.
@@ -83,9 +91,13 @@ impl RelayBuilderHiddenService {
     }
 }
 
+#[allow(missing_docs)]
+#[deprecated(since = "0.45.0", note = "Use `LocalRelayBuilderMode` instead")]
+pub type RelayBuilderMode = LocalRelayBuilderMode;
+
 /// Mode
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum RelayBuilderMode {
+pub enum LocalRelayBuilderMode {
     /// Generic mode
     #[default]
     Generic,
@@ -123,18 +135,26 @@ pub trait QueryPolicy: fmt::Debug + Send + Sync {
     ) -> BoxedFuture<'a, PolicyResult>;
 }
 
+#[allow(missing_docs)]
+#[deprecated(since = "0.45.0", note = "Use `LocalRelayTestOptions` instead")]
+pub type RelayTestOptions = LocalRelayTestOptions;
+
 /// Testing options
 #[derive(Debug, Clone, Default)]
-pub struct RelayTestOptions {
+pub struct LocalRelayTestOptions {
     /// Simulate unresponsive connection
     pub unresponsive_connection: Option<Duration>,
     /// Send random events to the clients
     pub send_random_events: bool,
 }
 
+#[allow(missing_docs)]
+#[deprecated(since = "0.45.0", note = "Use `LocalRelayBuilderNip42Mode` instead")]
+pub type RelayBuilderNip42Mode = LocalRelayBuilderNip42Mode;
+
 /// NIP42 mode
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum RelayBuilderNip42Mode {
+pub enum LocalRelayBuilderNip42Mode {
     /// Require authentication for writing
     Write,
     /// Require authentication for reading
@@ -144,32 +164,40 @@ pub enum RelayBuilderNip42Mode {
     Both,
 }
 
-impl RelayBuilderNip42Mode {
-    /// Check if is [`RelayBuilderNip42Mode::Read`] or [`RelayBuilderNip42Mode::Both`]
+impl LocalRelayBuilderNip42Mode {
+    /// Check if is [`LocalRelayBuilderNip42Mode::Read`] or [`LocalRelayBuilderNip42Mode::Both`]
     #[inline]
     pub fn is_read(&self) -> bool {
         matches!(self, Self::Read | Self::Both)
     }
 
-    /// Check if is [`RelayBuilderNip42Mode::Write`] or [`RelayBuilderNip42Mode::Both`]
+    /// Check if is [`LocalRelayBuilderNip42Mode::Write`] or [`LocalRelayBuilderNip42Mode::Both`]
     #[inline]
     pub fn is_write(&self) -> bool {
         matches!(self, Self::Write | Self::Both)
     }
 }
 
+#[allow(missing_docs)]
+#[deprecated(since = "0.45.0", note = "Use `LocalRelayBuilderNip42` instead")]
+pub type RelayBuilderNip42 = LocalRelayBuilderNip42;
+
 /// NIP42 options
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct RelayBuilderNip42 {
+pub struct LocalRelayBuilderNip42 {
     /// Mode
-    pub mode: RelayBuilderNip42Mode,
+    pub mode: LocalRelayBuilderNip42Mode,
     // /// Allowed public keys
     // pub allowed: HashSet<PublicKey>,
 }
 
-/// Relay builder
+#[allow(missing_docs)]
+#[deprecated(since = "0.45.0", note = "Use `LocalRelayBuilder` instead")]
+pub type RelayBuilder = LocalRelayBuilder;
+
+/// Local relay builder
 #[derive(Debug, Clone)]
-pub struct RelayBuilder {
+pub struct LocalRelayBuilder {
     /// IP address
     pub(crate) addr: Option<IpAddr>,
     /// Port
@@ -177,14 +205,14 @@ pub struct RelayBuilder {
     /// Database
     pub(crate) database: Arc<dyn NostrDatabase>,
     /// Mode
-    pub(crate) mode: RelayBuilderMode,
+    pub(crate) mode: LocalRelayBuilderMode,
     /// Rate limit
     pub(crate) rate_limit: RateLimit,
     /// NIP42 options
-    pub(crate) nip42: Option<RelayBuilderNip42>,
+    pub(crate) nip42: Option<LocalRelayBuilderNip42>,
     /// Tor hidden service
     #[cfg(feature = "tor")]
-    pub(crate) tor: Option<RelayBuilderHiddenService>,
+    pub(crate) tor: Option<LocalRelayBuilderHiddenService>,
     /// Max connections allowed
     pub(crate) max_connections: Option<usize>,
     /// Max subscription ID length
@@ -203,10 +231,10 @@ pub struct RelayBuilder {
     /// Query policy plugins
     pub(crate) query_plugins: Vec<Arc<dyn QueryPolicy>>,
     /// Test options
-    pub(crate) test: RelayTestOptions,
+    pub(crate) test: LocalRelayTestOptions,
 }
 
-impl Default for RelayBuilder {
+impl Default for LocalRelayBuilder {
     fn default() -> Self {
         Self {
             addr: None,
@@ -215,7 +243,7 @@ impl Default for RelayBuilder {
                 events: true,
                 max_events: Some(NonZeroUsize::new(75_000).unwrap()),
             })),
-            mode: RelayBuilderMode::default(),
+            mode: LocalRelayBuilderMode::default(),
             rate_limit: RateLimit::default(),
             nip42: None,
             #[cfg(feature = "tor")]
@@ -228,12 +256,12 @@ impl Default for RelayBuilder {
             min_pow: None,
             write_plugins: Vec::new(),
             query_plugins: Vec::new(),
-            test: RelayTestOptions::default(),
+            test: LocalRelayTestOptions::default(),
         }
     }
 }
 
-impl RelayBuilder {
+impl LocalRelayBuilder {
     /// Set IP address
     #[inline]
     pub fn addr(mut self, ip: IpAddr) -> Self {
@@ -260,7 +288,7 @@ impl RelayBuilder {
 
     /// Set mode
     #[inline]
-    pub fn mode(mut self, mode: RelayBuilderMode) -> Self {
+    pub fn mode(mut self, mode: LocalRelayBuilderMode) -> Self {
         self.mode = mode;
         self
     }
@@ -274,7 +302,7 @@ impl RelayBuilder {
 
     /// Require NIP42 authentication
     #[inline]
-    pub fn nip42(mut self, opts: RelayBuilderNip42) -> Self {
+    pub fn nip42(mut self, opts: LocalRelayBuilderNip42) -> Self {
         self.nip42 = Some(opts);
         self
     }
@@ -282,7 +310,7 @@ impl RelayBuilder {
     /// Set tor options
     #[inline]
     #[cfg(feature = "tor")]
-    pub fn tor(mut self, opts: RelayBuilderHiddenService) -> Self {
+    pub fn tor(mut self, opts: LocalRelayBuilderHiddenService) -> Self {
         self.tor = Some(opts);
         self
     }
@@ -357,7 +385,7 @@ impl RelayBuilder {
 
     /// Testing options
     #[inline]
-    pub(crate) fn test(mut self, test: RelayTestOptions) -> Self {
+    pub(crate) fn test(mut self, test: LocalRelayTestOptions) -> Self {
         self.test = test;
         self
     }

--- a/crates/nostr-relay-builder/src/lib.rs
+++ b/crates/nostr-relay-builder/src/lib.rs
@@ -16,7 +16,7 @@ pub mod local;
 pub mod mock;
 pub mod prelude;
 
-pub use self::builder::RelayBuilder;
+pub use self::builder::LocalRelayBuilder;
 pub use self::error::Error;
 pub use self::local::LocalRelay;
 pub use self::mock::MockRelay;

--- a/crates/nostr-relay-builder/src/local/inner.rs
+++ b/crates/nostr-relay-builder/src/local/inner.rs
@@ -21,10 +21,10 @@ use tokio::sync::{broadcast, Notify, OnceCell, Semaphore};
 use super::session::{Nip42Session, RateLimiterResponse, Session, Tokens};
 use super::util;
 #[cfg(feature = "tor")]
-use crate::builder::RelayBuilderHiddenService;
+use crate::builder::LocalRelayBuilderHiddenService;
 use crate::builder::{
-    PolicyResult, QueryPolicy, RateLimit, RelayBuilder, RelayBuilderMode, RelayBuilderNip42,
-    RelayTestOptions, WritePolicy,
+    LocalRelayBuilder, LocalRelayBuilderMode, LocalRelayBuilderNip42, LocalRelayTestOptions,
+    PolicyResult, QueryPolicy, RateLimit, WritePolicy,
 };
 use crate::error::Error;
 
@@ -41,7 +41,7 @@ pub(super) struct InnerLocalRelay {
     ///
     /// Every session will listen and check own subscriptions
     new_event: broadcast::Sender<Event>,
-    mode: RelayBuilderMode,
+    mode: LocalRelayBuilderMode,
     rate_limit: RateLimit,
     connections_limit: Arc<Semaphore>,
     max_subid_length: usize,
@@ -50,13 +50,13 @@ pub(super) struct InnerLocalRelay {
     auth_dm: bool,
     min_pow: Option<u8>, // TODO: use AtomicU8 to allow to change it?
     #[cfg(feature = "tor")]
-    tor: Option<RelayBuilderHiddenService>,
+    tor: Option<LocalRelayBuilderHiddenService>,
     #[cfg(feature = "tor")]
     hidden_service: OnceCell<Option<String>>,
     write_policy: Vec<Arc<dyn WritePolicy>>,
     query_policy: Vec<Arc<dyn QueryPolicy>>,
-    nip42: Option<RelayBuilderNip42>,
-    test: RelayTestOptions,
+    nip42: Option<LocalRelayBuilderNip42>,
+    test: LocalRelayTestOptions,
     running: Arc<AtomicBool>,
 }
 
@@ -67,7 +67,7 @@ impl AtomicDestroyer for InnerLocalRelay {
 }
 
 impl InnerLocalRelay {
-    pub fn new(builder: RelayBuilder) -> Self {
+    pub fn new(builder: LocalRelayBuilder) -> Self {
         // TODO: check if configured memory database with events option disabled
 
         // Get IP
@@ -517,7 +517,7 @@ impl InnerLocalRelay {
                 }
 
                 // Check mode
-                if let RelayBuilderMode::PublicKey(pk) = self.mode {
+                if let LocalRelayBuilderMode::PublicKey(pk) = self.mode {
                     let authored: bool = event.pubkey == pk;
                     let tagged: bool = event.tags.public_keys().any(|p| p == &pk);
 

--- a/crates/nostr-relay-builder/src/local/mod.rs
+++ b/crates/nostr-relay-builder/src/local/mod.rs
@@ -15,7 +15,7 @@ mod session;
 mod util;
 
 use self::inner::InnerLocalRelay;
-use crate::builder::RelayBuilder;
+use crate::builder::LocalRelayBuilder;
 use crate::error::Error;
 
 /// A local nostr relay
@@ -29,7 +29,7 @@ pub struct LocalRelay {
 impl LocalRelay {
     /// Create a new local relay
     #[inline]
-    pub fn new(builder: RelayBuilder) -> Self {
+    pub fn new(builder: LocalRelayBuilder) -> Self {
         Self {
             inner: AtomicDestructor::new(InnerLocalRelay::new(builder)),
         }

--- a/crates/nostr-relay-builder/src/mock.rs
+++ b/crates/nostr-relay-builder/src/mock.rs
@@ -9,7 +9,7 @@ use std::ops::Deref;
 use nostr::prelude::*;
 use nostr_database::prelude::*;
 
-use crate::builder::{RelayBuilder, RelayTestOptions};
+use crate::builder::{LocalRelayBuilder, LocalRelayTestOptions};
 use crate::error::Error;
 use crate::local::LocalRelay;
 
@@ -30,7 +30,7 @@ impl Deref for MockRelay {
 }
 
 impl MockRelay {
-    async fn new(builder: RelayBuilder) -> Result<Self, Error> {
+    async fn new(builder: LocalRelayBuilder) -> Result<Self, Error> {
         let relay = LocalRelay::new(builder);
         relay.run().await?;
         Ok(Self { local: relay })
@@ -39,14 +39,14 @@ impl MockRelay {
     /// Run mock relay
     #[inline]
     pub async fn run() -> Result<Self, Error> {
-        let builder = RelayBuilder::default();
+        let builder = LocalRelayBuilder::default();
         Self::new(builder).await
     }
 
     /// Run unresponsive relay
     #[inline]
-    pub async fn run_with_opts(opts: RelayTestOptions) -> Result<Self, Error> {
-        let builder = RelayBuilder::default().test(opts);
+    pub async fn run_with_opts(opts: LocalRelayTestOptions) -> Result<Self, Error> {
+        let builder = LocalRelayBuilder::default().test(opts);
         Self::new(builder).await
     }
 }

--- a/crates/nostr-relay-pool/src/relay/mod.rs
+++ b/crates/nostr-relay-pool/src/relay/mod.rs
@@ -1057,7 +1057,7 @@ mod tests {
     #[tokio::test]
     async fn test_disconnect_unresponsive_relay_that_connect() {
         // Mock relay
-        let opts = RelayTestOptions {
+        let opts = LocalRelayTestOptions {
             unresponsive_connection: Some(Duration::from_secs(2)),
             ..Default::default()
         };
@@ -1090,7 +1090,7 @@ mod tests {
     #[tokio::test]
     async fn test_disconnect_unresponsive_relay_that_not_connect() {
         // Mock relay
-        let opts = RelayTestOptions {
+        let opts = LocalRelayTestOptions {
             unresponsive_connection: Some(Duration::from_secs(10)),
             ..Default::default()
         };
@@ -1119,7 +1119,7 @@ mod tests {
     #[tokio::test]
     async fn test_disconnect_unresponsive_during_try_connect() {
         // Mock relay
-        let opts = RelayTestOptions {
+        let opts = LocalRelayTestOptions {
             unresponsive_connection: Some(Duration::from_secs(10)),
             ..Default::default()
         };
@@ -1183,7 +1183,7 @@ mod tests {
     #[tokio::test]
     async fn test_wait_for_connection() {
         // Mock relay
-        let opts = RelayTestOptions {
+        let opts = LocalRelayTestOptions {
             unresponsive_connection: Some(Duration::from_secs(2)),
             ..Default::default()
         };
@@ -1208,7 +1208,7 @@ mod tests {
     #[tokio::test]
     async fn test_fetch_events_ban_relay() {
         // Mock relay
-        let opts = RelayTestOptions {
+        let opts = LocalRelayTestOptions {
             unresponsive_connection: None,
             send_random_events: true,
         };
@@ -1242,7 +1242,7 @@ mod tests {
     #[tokio::test]
     async fn test_subscribe_ban_relay() {
         // Mock relay
-        let opts = RelayTestOptions {
+        let opts = LocalRelayTestOptions {
             unresponsive_connection: None,
             send_random_events: true,
         };
@@ -1285,10 +1285,10 @@ mod tests {
     #[tokio::test]
     async fn test_nip42_send_event() {
         // Mock relay
-        let opts = RelayBuilderNip42 {
-            mode: RelayBuilderNip42Mode::Write,
+        let opts = LocalRelayBuilderNip42 {
+            mode: LocalRelayBuilderNip42Mode::Write,
         };
-        let builder = RelayBuilder::default().nip42(opts);
+        let builder = LocalRelayBuilder::default().nip42(opts);
         let mock = LocalRelay::new(builder);
         mock.run().await.unwrap();
         let url = mock.url().await;
@@ -1329,10 +1329,10 @@ mod tests {
     #[tokio::test]
     async fn test_nip42_fetch_events() {
         // Mock relay
-        let opts = RelayBuilderNip42 {
-            mode: RelayBuilderNip42Mode::Read,
+        let opts = LocalRelayBuilderNip42 {
+            mode: LocalRelayBuilderNip42Mode::Read,
         };
-        let builder = RelayBuilder::default().nip42(opts);
+        let builder = LocalRelayBuilder::default().nip42(opts);
         let mock = LocalRelay::new(builder);
         mock.run().await.unwrap();
         let url = mock.url().await;

--- a/database/nostr-sqlite/examples/sqlite-relay.rs
+++ b/database/nostr-sqlite/examples/sqlite-relay.rs
@@ -15,7 +15,7 @@ async fn main() -> Result<()> {
     let db = NostrSqlite::open("nostr.sqlite").await?;
 
     // Create relay
-    let builder = RelayBuilder::default().database(db);
+    let builder = LocalRelayBuilder::default().database(db);
     let relay = LocalRelay::new(builder);
 
     relay.run().await?;


### PR DESCRIPTION
Rename all structs and enums from `RelayBuilder*` to `LocalRelayBuilder*`. Deprecate all previous names.