### PR TITLE
relay-builder: align LocalRelay building APIs with other libraries

### DIFF
--- a/crates/nostr-relay-builder/CHANGELOG.md
+++ b/crates/nostr-relay-builder/CHANGELOG.md
@@ -25,12 +25,19 @@
 
 ## Unreleased
 
+### Breaking changes
+
+- Change `LocalRelay::new` constructor signature (https://github.com/rust-nostr/nostr/pull/1147)
+
 ### Changes
 
 - Rename all `RelayBuilder*` structs and enums to `LocalRelayBuilder*` (https://github.com/rust-nostr/nostr/pull/1145)
 
 ### Added
 
+- Add `LocalRelay::builder` constructor (https://github.com/rust-nostr/nostr/pull/1147)
+- Add `LocalRelayBuilder::build` method (https://github.com/rust-nostr/nostr/pull/1147)
+- Impl `Default` for `LocalRelay` (https://github.com/rust-nostr/nostr/pull/1147)
 - Add `LocalRelay::sync_with` method (https://github.com/rust-nostr/nostr/pull/1146)
 
 ## v0.44.0 - 2025/11/06

--- a/crates/nostr-relay-builder/README.md
+++ b/crates/nostr-relay-builder/README.md
@@ -18,17 +18,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Open a database (all databases that implements `NostrDatabase` trait can be used).
     let database = NostrLmdb::open("nostr-relay").await?;
 
-    // Configure the relay.
-    let builder = LocalRelayBuilder::default()
+    // Create the relay.
+    let relay = LocalRelay::builder()
         .port(7777)
         .database(database)
         .rate_limit(RateLimit {
             max_reqs: 128,
             notes_per_minute: 30,
-        });
-
-    // Construct the relay instance.
-    let relay = LocalRelay::new(builder);
+        })
+        .build();
 
     // Start the relay.
     relay.run().await?;

--- a/crates/nostr-relay-builder/examples/hyper.rs
+++ b/crates/nostr-relay-builder/examples/hyper.rs
@@ -15,7 +15,7 @@ use hyper::{Request, Response};
 use hyper_util::rt::TokioIo;
 use nostr::hashes::sha1::Hash as Sha1Hash;
 use nostr::hashes::{Hash, HashEngine};
-use nostr_relay_builder::{LocalRelay, LocalRelayBuilder};
+use nostr_relay_builder::LocalRelay;
 use tokio::net::TcpListener;
 
 struct HttpServer {
@@ -114,8 +114,7 @@ impl Service<Request<Incoming>> for HttpServer {
 async fn main() -> nostr_relay_builder::prelude::Result<()> {
     tracing_subscriber::fmt::init();
 
-    let builder = LocalRelayBuilder::default();
-    let relay = LocalRelay::new(builder);
+    let relay = LocalRelay::new();
 
     let http_addr: SocketAddr = "127.0.0.1:8000".parse()?;
     let listener = TcpListener::bind(&http_addr).await?;

--- a/crates/nostr-relay-builder/examples/local-with-hs.rs
+++ b/crates/nostr-relay-builder/examples/local-with-hs.rs
@@ -10,10 +10,8 @@ use nostr_relay_builder::prelude::*;
 async fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
 
-    let tor = RelayBuilderHiddenService::new("rust-nostr-local-hs-test");
-    let builder = RelayBuilder::default().tor(tor);
-
-    let relay = LocalRelay::new(builder);
+    let tor = LocalRelayBuilderHiddenService::new("rust-nostr-local-hs-test");
+    let relay = LocalRelay::builder().tor(tor).build();
 
     relay.run().await?;
 

--- a/crates/nostr-relay-builder/examples/policy.rs
+++ b/crates/nostr-relay-builder/examples/policy.rs
@@ -62,11 +62,10 @@ async fn main() -> Result<()> {
 
     let low_author_limit = RejectAuthorLimit { limit: 2 };
 
-    let builder = LocalRelayBuilder::default()
+    let relay = LocalRelay::builder()
         .write_policy(accept_profile_data)
-        .query_policy(low_author_limit);
-
-    let relay = LocalRelay::new(builder);
+        .query_policy(low_author_limit)
+        .build();
 
     relay.run().await?;
 

--- a/crates/nostr-relay-builder/examples/simple_relay.rs
+++ b/crates/nostr-relay-builder/examples/simple_relay.rs
@@ -9,9 +9,7 @@ async fn main() -> Result<()> {
 
     let db = NostrLmdb::open("./db/nostr-lmdb").await?;
 
-    let builder = LocalRelayBuilder::default().port(7777).database(db);
-
-    let relay = LocalRelay::new(builder);
+    let relay = LocalRelay::builder().port(7777).database(db).build();
 
     relay.run().await?;
 

--- a/crates/nostr-relay-builder/src/builder.rs
+++ b/crates/nostr-relay-builder/src/builder.rs
@@ -16,6 +16,8 @@ use std::time::Duration;
 
 use nostr_database::prelude::*;
 
+use crate::local::LocalRelay;
+
 /// Rate limit
 #[derive(Debug, Clone)]
 pub struct RateLimit {
@@ -388,5 +390,11 @@ impl LocalRelayBuilder {
     pub(crate) fn test(mut self, test: LocalRelayTestOptions) -> Self {
         self.test = test;
         self
+    }
+
+    /// Build local relay
+    #[inline]
+    pub fn build(self) -> LocalRelay {
+        LocalRelay::from_builder(self)
     }
 }

--- a/crates/nostr-relay-builder/src/local/mod.rs
+++ b/crates/nostr-relay-builder/src/local/mod.rs
@@ -27,10 +27,30 @@ pub struct LocalRelay {
     inner: AtomicDestructor<InnerLocalRelay>,
 }
 
-impl LocalRelay {
-    /// Create a new local relay
+impl Default for LocalRelay {
     #[inline]
-    pub fn new(builder: LocalRelayBuilder) -> Self {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LocalRelay {
+    /// Create a new local relay with the default configuration.
+    ///
+    /// Use [`LocalRelay::builder`] for customizing it!
+    #[inline]
+    pub fn new() -> Self {
+        Self::builder().build()
+    }
+
+    /// Create a new local relay builder
+    #[inline]
+    pub fn builder() -> LocalRelayBuilder {
+        LocalRelayBuilder::default()
+    }
+
+    #[inline]
+    pub(super) fn from_builder(builder: LocalRelayBuilder) -> Self {
         Self {
             inner: AtomicDestructor::new(InnerLocalRelay::new(builder)),
         }

--- a/crates/nostr-relay-builder/src/mock.rs
+++ b/crates/nostr-relay-builder/src/mock.rs
@@ -31,7 +31,7 @@ impl Deref for MockRelay {
 
 impl MockRelay {
     async fn new(builder: LocalRelayBuilder) -> Result<Self, Error> {
-        let relay = LocalRelay::new(builder);
+        let relay: LocalRelay = builder.build();
         relay.run().await?;
         Ok(Self { local: relay })
     }

--- a/crates/nostr-relay-pool/src/relay/mod.rs
+++ b/crates/nostr-relay-pool/src/relay/mod.rs
@@ -1288,8 +1288,7 @@ mod tests {
         let opts = LocalRelayBuilderNip42 {
             mode: LocalRelayBuilderNip42Mode::Write,
         };
-        let builder = LocalRelayBuilder::default().nip42(opts);
-        let mock = LocalRelay::new(builder);
+        let mock = LocalRelay::builder().nip42(opts).build();
         mock.run().await.unwrap();
         let url = mock.url().await;
 
@@ -1332,8 +1331,7 @@ mod tests {
         let opts = LocalRelayBuilderNip42 {
             mode: LocalRelayBuilderNip42Mode::Read,
         };
-        let builder = LocalRelayBuilder::default().nip42(opts);
-        let mock = LocalRelay::new(builder);
+        let mock = LocalRelay::builder().nip42(opts).build();
         mock.run().await.unwrap();
         let url = mock.url().await;
 

--- a/database/nostr-sqlite/examples/sqlite-relay.rs
+++ b/database/nostr-sqlite/examples/sqlite-relay.rs
@@ -15,8 +15,7 @@ async fn main() -> Result<()> {
     let db = NostrSqlite::open("nostr.sqlite").await?;
 
     // Create relay
-    let builder = LocalRelayBuilder::default().database(db);
-    let relay = LocalRelay::new(builder);
+    let relay = LocalRelay::builder().database(db).build();
 
     relay.run().await?;
 


### PR DESCRIPTION
- Add `LocalRelay::builder` constructor
- Add `LocalRelayBuilder::build` method
- Change `LocalRelay::new` constructor signature
- Impl `Default` for `LocalRelay`

Ref https://github.com/rust-nostr/nostr/issues/1000