### PR TITLE
relay-builder: add event and query kind listener

### DIFF
--- a/crates/nostr-relay-builder/CHANGELOG.md
+++ b/crates/nostr-relay-builder/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Add `LocalRelayBuilder::build` method (https://github.com/rust-nostr/nostr/pull/1147)
 - Impl `Default` for `LocalRelay` (https://github.com/rust-nostr/nostr/pull/1147)
 - Add `LocalRelay::sync_with` method (https://github.com/rust-nostr/nostr/pull/1146)
+- Add event and query kind listener (https://github.com/rust-nostr/nostr/pull/1149)
 
 ## v0.44.0 - 2025/11/06
 


### PR DESCRIPTION
resolve #1148

Add support for registering kind listeners for both events and queries.

For more details, see issue #1148.

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
