### PR TITLE
relay-builder: move write policy between mode and ephemeral kind checks

### DIFF
--- a/crates/nostr-relay-builder/CHANGELOG.md
+++ b/crates/nostr-relay-builder/CHANGELOG.md
@@ -32,6 +32,7 @@
 ### Changes
 
 - Rename all `RelayBuilder*` structs and enums to `LocalRelayBuilder*` (https://github.com/rust-nostr/nostr/pull/1145)
+- Move write policy checks between mode and ephemeral kind checks (https://github.com/rust-nostr/nostr/pull/1155)
 
 ### Added
 


### PR DESCRIPTION
Check the write policies only after checking the status of the event in the database and the relay mode.

Ref https://github.com/rust-nostr/nostr/pull/1149#discussion_r2572214452