### PR TITLE
relay-builder: replace `PolicyResult` with `WritePolicyResult` and `QueryPolicyResult`

### DIFF
--- a/crates/nostr-relay-builder/CHANGELOG.md
+++ b/crates/nostr-relay-builder/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 - Change `LocalRelay::new` constructor signature (https://github.com/rust-nostr/nostr/pull/1147)
 - Allow only a single `write` and `query` policy (https://github.com/rust-nostr/nostr/pull/1165)
+- Replace `PolicyResult` with `WritePolicyResult` and `QueryPolicyResult` (https://github.com/rust-nostr/nostr/pull/1166)
 
 ### Changes
 


### PR DESCRIPTION
This makes the write policy result more customizable

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
