### PR TITLE
nostr: custom SECP256K1 global context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2808,6 +2808,7 @@ dependencies = [
  "hex",
  "instant",
  "nostr-ots",
+ "once_cell",
  "rand 0.8.5",
  "reqwest",
  "scrypt",

--- a/crates/nostr/Cargo.toml
+++ b/crates/nostr/Cargo.toml
@@ -27,6 +27,7 @@ std = [
     "chacha20?/std",
     "chacha20poly1305?/std",
     "hex/std",
+    "once_cell/std",
     "rand?/std",
     "scrypt?/std",
     "secp256k1/std",
@@ -43,6 +44,7 @@ alloc = [
     "cbc?/alloc",
     "chacha20poly1305?/alloc",
     "hex/alloc",
+    "once_cell/alloc",
     "rand?/alloc",
     "secp256k1/alloc",
     "serde/alloc",
@@ -77,6 +79,7 @@ chacha20 = { version = "0.9", optional = true }
 chacha20poly1305 = { version = "0.10", default-features = false, optional = true }
 hex = { workspace = true, default-features = false }
 nostr-ots = { version = "0.2", optional = true }
+once_cell = { version = "1.21", default-features = false }
 rand = { version = "0.8", default-features = false, optional = true }
 scrypt = { version = "0.11", default-features = false, optional = true }
 secp256k1 = { version = "0.29", default-features = false, features = ["serde"] }

--- a/crates/nostr/src/event/builder.rs
+++ b/crates/nostr/src/event/builder.rs
@@ -516,7 +516,7 @@ impl EventBuilder {
     #[inline]
     #[cfg(all(feature = "std", feature = "rand"))]
     pub fn sign_with_keys(self, keys: &Keys) -> Result<Event, Error> {
-        self.sign_with_ctx(SECP256K1, &mut OsRng, &Instant::now(), keys)
+        self.sign_with_ctx(&SECP256K1, &mut OsRng, &Instant::now(), keys)
     }
 
     /// Build, sign and return [`Event`] using [`Keys`] signer

--- a/crates/nostr/src/event/mod.rs
+++ b/crates/nostr/src/event/mod.rs
@@ -158,7 +158,7 @@ impl Event {
     #[inline]
     #[cfg(feature = "std")]
     pub fn verify(&self) -> Result<(), Error> {
-        self.verify_with_ctx(SECP256K1)
+        self.verify_with_ctx(&SECP256K1)
     }
 
     /// Verify both [`EventId`] and [`Signature`]
@@ -195,7 +195,7 @@ impl Event {
     #[inline]
     #[cfg(feature = "std")]
     pub fn verify_signature(&self) -> bool {
-        self.verify_signature_with_ctx(SECP256K1)
+        self.verify_signature_with_ctx(&SECP256K1)
     }
 
     /// Verify event signature

--- a/crates/nostr/src/event/unsigned.rs
+++ b/crates/nostr/src/event/unsigned.rs
@@ -119,7 +119,7 @@ impl UnsignedEvent {
     #[inline]
     #[cfg(all(feature = "std", feature = "rand"))]
     pub fn sign_with_keys(self, keys: &Keys) -> Result<Event, Error> {
-        self.sign_with_ctx(SECP256K1, &mut OsRng, keys)
+        self.sign_with_ctx(&SECP256K1, &mut OsRng, keys)
     }
 
     /// Sign an unsigned event with [`Keys`] signer
@@ -164,7 +164,7 @@ impl UnsignedEvent {
     #[inline]
     #[cfg(feature = "std")]
     pub fn add_signature(self, sig: Signature) -> Result<Event, Error> {
-        self.add_signature_with_ctx(SECP256K1, sig)
+        self.add_signature_with_ctx(&SECP256K1, sig)
     }
 
     /// Add signature to unsigned event

--- a/crates/nostr/src/key/mod.rs
+++ b/crates/nostr/src/key/mod.rs
@@ -127,7 +127,7 @@ impl Keys {
     #[inline]
     #[cfg(feature = "std")]
     pub fn new(secret_key: SecretKey) -> Self {
-        Self::new_with_ctx(SECP256K1, secret_key)
+        Self::new_with_ctx(&SECP256K1, secret_key)
     }
 
     /// Construct from a secret key.
@@ -153,7 +153,7 @@ impl Keys {
     #[inline]
     #[cfg(feature = "std")]
     pub fn parse(secret_key: &str) -> Result<Self, Error> {
-        Self::parse_with_ctx(SECP256K1, secret_key)
+        Self::parse_with_ctx(&SECP256K1, secret_key)
     }
 
     /// Parse secret key and construct keys.
@@ -176,7 +176,7 @@ impl Keys {
     #[inline]
     #[cfg(all(feature = "std", feature = "rand"))]
     pub fn generate() -> Self {
-        Self::generate_with_rng(SECP256K1, &mut OsRng)
+        Self::generate_with_rng(&SECP256K1, &mut OsRng)
     }
 
     /// Generate random keys
@@ -229,7 +229,7 @@ impl Keys {
     #[inline]
     #[cfg(all(feature = "std", feature = "rand"))]
     pub fn sign_schnorr(&self, message: &Message) -> Signature {
-        self.sign_schnorr_with_rng(SECP256K1, message, &mut OsRng)
+        self.sign_schnorr_with_rng(&SECP256K1, message, &mut OsRng)
     }
 
     /// Creates a schnorr signature of the [`Message`] using a custom random number generation source.

--- a/crates/nostr/src/nips/nip06/mod.rs
+++ b/crates/nostr/src/nips/nip06/mod.rs
@@ -106,7 +106,7 @@ pub trait FromMnemonic: Sized {
     where
         S: AsRef<str>,
     {
-        Self::from_mnemonic_with_ctx(SECP256K1, mnemonic, passphrase, account, r#type, index)
+        Self::from_mnemonic_with_ctx(&SECP256K1, mnemonic, passphrase, account, r#type, index)
     }
 
     /// Derive from BIP-39 mnemonics with **custom account** (ENGLISH wordlist).

--- a/crates/nostr/src/nips/nip57.rs
+++ b/crates/nostr/src/nips/nip57.rs
@@ -277,7 +277,7 @@ pub fn anonymous_zap_request(data: ZapRequestData) -> Result<Event, Error> {
 #[inline]
 #[cfg(all(feature = "std", feature = "rand"))]
 pub fn private_zap_request(data: ZapRequestData, keys: &Keys) -> Result<Event, Error> {
-    private_zap_request_with_ctx(SECP256K1, &mut OsRng, &Instant::now(), data, keys)
+    private_zap_request_with_ctx(&SECP256K1, &mut OsRng, &Instant::now(), data, keys)
 }
 
 /// Create **private** zap request

--- a/crates/nostr/src/nips/nip59.rs
+++ b/crates/nostr/src/nips/nip59.rs
@@ -82,7 +82,7 @@ impl UnwrappedGift {
     where
         T: NostrSigner,
     {
-        Self::from_gift_wrap_with_ctx(SECP256K1, signer, gift_wrap).await
+        Self::from_gift_wrap_with_ctx(&SECP256K1, signer, gift_wrap).await
     }
 
     /// Unwrap Gift Wrap event

--- a/crates/nostr/src/util/mod.rs
+++ b/crates/nostr/src/util/mod.rs
@@ -10,11 +10,16 @@ use core::fmt::Debug;
 use core::future::Future;
 use core::pin::Pin;
 
+// TODO: replace with LazyLock when MSRV will be >= 1.80.0
+#[cfg(feature = "std")]
+use once_cell::sync::Lazy;
+#[cfg(all(feature = "std", feature = "rand"))]
+use rand::rngs::OsRng;
 #[cfg(feature = "rand")]
 use rand::RngCore;
-#[cfg(feature = "std")]
-use secp256k1::global::GlobalContext;
 use secp256k1::{ecdh, Parity, PublicKey as NormalizedPublicKey, XOnlyPublicKey};
+#[cfg(feature = "std")]
+use secp256k1::{All, Secp256k1};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
@@ -60,7 +65,21 @@ pub fn generate_shared_key(
 
 /// Secp256k1 global context
 #[cfg(feature = "std")]
-pub static SECP256K1: &GlobalContext = secp256k1::global::SECP256K1;
+pub static SECP256K1: Lazy<Secp256k1<All>> = Lazy::new(|| {
+    #[cfg(feature = "rand")]
+    let mut ctx: Secp256k1<All> = Secp256k1::new();
+    #[cfg(not(feature = "rand"))]
+    let ctx: Secp256k1<All> = Secp256k1::new();
+
+    // Randomize
+    #[cfg(feature = "rand")]
+    {
+        let seed: [u8; 32] = random_32_bytes(&mut OsRng);
+        ctx.seeded_randomize(&seed);
+    }
+
+    ctx
+});
 
 /// JSON util
 pub trait JsonUtil: Sized + Serialize + DeserializeOwned


### PR DESCRIPTION
This is needed to allow randomizing the secp256k1 context after commit 1145f446eb44bb5df4668c77b81513875994f1d2 

Revert commit fb8cadbf4ed030fcf1de447b0ea30c3189777333