### PR TITLE
sqlite: support NIP-62

### DIFF
--- a/crates/nostr-relay-pool/src/relay/inner.rs
+++ b/crates/nostr-relay-pool/src/relay/inner.rs
@@ -1243,6 +1243,7 @@ impl InnerRelay {
                         RejectedReason::Expired => false,
                         RejectedReason::Replaced => false,
                         RejectedReason::InvalidDelete => false,
+                        RejectedReason::Vanished => false,
                         RejectedReason::Other => true,
                     },
                 };

--- a/database/nostr-database/src/lib.rs
+++ b/database/nostr-database/src/lib.rs
@@ -124,6 +124,8 @@ pub enum RejectedReason {
     Replaced,
     /// Attempt to delete a non-owned event
     InvalidDelete,
+    /// The event author vanished before
+    Vanished,
     /// Other reason
     Other,
 }

--- a/database/nostr-sqlite/README.md
+++ b/database/nostr-sqlite/README.md
@@ -10,6 +10,16 @@ The following crate feature flags are available:
 |-------------|:-------:|-----------------------|
 | `unbundled` |   No    | Uses unbundled SQLite |
 
+## Supported NIPs
+
+| Supported | NIP                                                                                                  |
+|:---------:|------------------------------------------------------------------------------------------------------|
+|    ❌    | [40 - Expiration Timestamp](https://github.com/nostr-protocol/nips/blob/master/40.md)                 |
+|    ✅    | [50 - Search Capability](https://github.com/nostr-protocol/nips/blob/master/50.md)                    |
+|    ✅*    | [62 - Request to Vanish](https://github.com/nostr-protocol/nips/blob/master/62.md)                   |
+
+*: `ALL_RELAYS` only
+
 ## State
 
 **This library is in an ALPHA state**, things that are implemented generally work but the API will change in breaking ways.

--- a/database/nostr-sqlite/migrations/002_vanished_public_keys.sql
+++ b/database/nostr-sqlite/migrations/002_vanished_public_keys.sql
@@ -1,0 +1,3 @@
+CREATE TABLE vanished_public_keys (
+    pubkey BLOB PRIMARY KEY NOT NULL CHECK(length(pubkey) = 32)
+) WITHOUT ROWID;

--- a/database/nostr-sqlite/migrations/README.md
+++ b/database/nostr-sqlite/migrations/README.md
@@ -77,3 +77,15 @@ CREATE TABLE deleted_coordinates (
 ) WITHOUT ROWID;
 
 ```
+
+### Vanished Public Keys (NIP-62)
+
+The `vanished_public_keys` table records the public key that has requested to vanish.
+
+Complete SQL schema:
+
+```sql
+CREATE TABLE vanished_public_keys (
+    pubkey BLOB PRIMARY KEY NOT NULL CHECK(length(pubkey) = 32),  -- The public key that has requested to vanish via NIP-62
+) WITHOUT ROWID;
+```


### PR DESCRIPTION

### Description

Support for NIP-62 (Request to Vanish) is implemented. Currently, the database doesn't know the relay URL, so it only handles `ALL_RELAYS`.

REFS: https://github.com/nostr-protocol/nips/blob/619e3be/62.md

### Notes to the reviewers

- I'm not that good at writing SQL, but I did my best :).
~- Where can I write the tests?~ Done, there is a test now
~- Should we add `RejectedReason::Vanished` to `nostr-database`?~ I did

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
