### PR TITLE
nostr: remove `EventBuilder::request_vanish` unused generic

### DIFF
--- a/crates/nostr/CHANGELOG.md
+++ b/crates/nostr/CHANGELOG.md
@@ -51,6 +51,10 @@
 - Remove unnecessary `#[cfg(feature = "std")]` from `UnsignedEvent::sign` method
 - Remove `url-fork` dependency (https://github.com/rust-nostr/nostr/pull/1179)
 
+### Fixed
+
+- Remove unused generic in `EventBuilder::request_vanish` function (https://github.com/rust-nostr/nostr/pull/1181)
+
 ## v0.44.2 - 2025/12/04
 
 ### Fixed

--- a/crates/nostr/src/event/builder.rs
+++ b/crates/nostr/src/event/builder.rs
@@ -784,7 +784,7 @@ impl EventBuilder {
     ///
     /// <https://github.com/nostr-protocol/nips/blob/master/62.md>
     #[inline]
-    pub fn request_vanish<I>(target: VanishTarget) -> Result<Self, Error> {
+    pub fn request_vanish(target: VanishTarget) -> Result<Self, Error> {
         Self::request_vanish_with_reason(target, "")
     }
 


### PR DESCRIPTION
### Description

I forgot to remove it here #777

### Notes to the reviewers

N/A

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
