### PR TITLE
relay-builder: NIP-40 support at the relay level

### DIFF
--- a/crates/nostr-relay-builder/CHANGELOG.md
+++ b/crates/nostr-relay-builder/CHANGELOG.md
@@ -42,6 +42,7 @@
 - Add `LocalRelayBuilder::build` method (https://github.com/rust-nostr/nostr/pull/1147)
 - Impl `Default` for `LocalRelay` (https://github.com/rust-nostr/nostr/pull/1147)
 - Add `LocalRelay::sync_with` method (https://github.com/rust-nostr/nostr/pull/1146)
+- Reject expired events and ensure they are not sent to clients (https://github.com/rust-nostr/nostr/pull/1183)
 
 ## v0.44.0 - 2025/11/06
 

--- a/crates/nostr-relay-builder/README.md
+++ b/crates/nostr-relay-builder/README.md
@@ -58,7 +58,7 @@ The following crate feature flags are available:
 |     ✅     | [09 - Event Deletion](https://github.com/nostr-protocol/nips/blob/master/09.md)                      |
 |     ❌     | [11 - Relay Information Document](https://github.com/nostr-protocol/nips/blob/master/11.md)          |
 |     ✅     | [17 - Private Direct Messages](https://github.com/nostr-protocol/nips/blob/master/17.md)             |
-|     🔧     | [40 - Expiration Timestamp](https://github.com/nostr-protocol/nips/blob/master/40.md)                |
+|    🔧*     | [40 - Expiration Timestamp](https://github.com/nostr-protocol/nips/blob/master/40.md)                |
 |     ✅     | [42 - Authentication of clients to relays](https://github.com/nostr-protocol/nips/blob/master/42.md) |
 |     🔧     | [50 - Search Capability](https://github.com/nostr-protocol/nips/blob/master/50.md)                   |
 |     🔧     | [62 - Request to Vanish](https://github.com/nostr-protocol/nips/blob/master/62.md)                   |
@@ -69,6 +69,8 @@ The following crate feature flags are available:
 - ✅ Fully supported
 - 🔧 Depends on the database implementation
 - ❌ Not supported
+
+*: The relay does not accept or send expired events. The database have to delete them.
 
 ## Changelog
 


### PR DESCRIPTION
### Description

Added support for NIP-40 by rejecting expired events at the relay level. Expired events are now filtered out and not sent to clients.

Why? I don't think that we have to write `if event.is_expired() {return ...}` on each database implementation to reject expired events, we can just handle it like we handle PoW.

For not sending expired event, yes it makes senses to let the database handle it, **but** we already map the events to JSON, so why not make it `filter_map` to reject expired events? IDK, it makes sense to me to reject them :)

### Notes to the reviewers

- The database still have to delete the expired events

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
