### PR TITLE
nostr: add `a` tag of replaceable and addressable events in `EventBuilder::repost`

### DIFF
--- a/crates/nostr/CHANGELOG.md
+++ b/crates/nostr/CHANGELOG.md
@@ -55,6 +55,7 @@
 ### Fixed
 
 - Remove unused generic in `EventBuilder::request_vanish` function (https://github.com/rust-nostr/nostr/pull/1181)
+- Add `a` tag of replaceable and addressable events in `EventBuilder::repost` (https://github.com/rust-nostr/nostr/pull/1184)
 
 ## v0.44.2 - 2025/12/04
 


### PR DESCRIPTION



### Descriptio

add `a` tag of replaceable and addressable events in `EventBuilder::repost`

Fixes: [nevent1qqs99u9tfwzuxesuwqcspe6ltmau6m7xu4cax3n6t45hk94rwzlcucqzyrjrxmx4yh0hn7jd8tekflvkqr2tzrwwgg265npna4m75zzzx393qqgkwaehxw309aex2mrp0yhxummnw3ezucnpdejqzrthwden5te0dehhxtnvdakqxpqqqqr92825789](https://gitworkshop.dev/yukikishimoto.com/nostr/issues/note12tc2kju9cdnpcup3qrn47hhme4hudet36dr85htf0vt2xu9l3esqeauhn5)
Reported-by: @dluvian


### Notes to the reviewers

- Should it be an option?


### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
