### PR TITLE
doc: fix `Tag::head` function doc

### DIFF
--- a/crates/nostr/src/event/tag/mod.rs
+++ b/crates/nostr/src/event/tag/mod.rs
@@ -407,7 +407,7 @@ impl Tag {
 
     /// Repository head
     ///
-    /// JSON: `["HEAD", "<branch-name>"]`
+    /// JSON: `["HEAD", "ref: refs/heads/<branch-name>"]`
     ///
     /// <https://github.com/nostr-protocol/nips/blob/master/34.md>
     #[inline]


### PR DESCRIPTION
### Description

The documentation were saying the JSON will be `["HEAD", "<branch-name>"]` but the branch name will be prefixed with `ref: refs/heads/`.

https://github.com/rust-nostr/nostr/blob/8d031ef927ac353c6d636def663912fab8cb0726/crates/nostr/src/event/tag/standard.rs#L843-L845

### Notes to the reviewers

- Should I update the changelog?

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [ ] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
