### PR TITLE
nostr: add `Kind::Highlight`

### DIFF
--- a/crates/nostr/CHANGELOG.md
+++ b/crates/nostr/CHANGELOG.md
@@ -46,6 +46,7 @@
 - Add `EventBuilder::git_pull_request`, `EventBuilder::git_pull_request_update` and `EventBuilder::git_user_grasp_list` (https://gitworkshop.dev/yukikishimoto.com/nostr/prs/note1jwe7k8fuynzze6w8pfxp2zkfehk9cteuuxuamvjkavefxq9a7m7qffreyq)
 - Add `RelayUrlScheme` enum and `RelayUrl::scheme` method (https://github.com/rust-nostr/nostr/pull/1127)
 - Add `Method::Unknown` variant (https://github.com/rust-nostr/nostr/pull/1162)
+- Add `Kind::Highlight` variant (https://github.com/rust-nostr/nostr/pull/1191)
 
 ### Removed
 

--- a/crates/nostr/src/event/kind.rs
+++ b/crates/nostr/src/event/kind.rs
@@ -111,6 +111,7 @@ kind_variants! {
     ZapPrivateMessage => 9733, "Zap Private Message ", "<https://github.com/nostr-protocol/nips/blob/master/57.md>",
     ZapRequest => 9734, "Zap Request ", "<https://github.com/nostr-protocol/nips/blob/master/57.md>",
     ZapReceipt => 9735, "Zap Receipt ", "<https://github.com/nostr-protocol/nips/blob/master/57.md>",
+    Highlight => 9802, "Highlights", "<https://github.com/nostr-protocol/nips/blob/master/84.md>",
     MuteList => 10000, "Mute List", "<https://github.com/nostr-protocol/nips/blob/master/51.md>",
     PinList => 10001, "Pin List", "<https://github.com/nostr-protocol/nips/blob/master/51.md>",
     Bookmarks => 10003, "Bookmarks", "<https://github.com/nostr-protocol/nips/blob/master/51.md>",


### PR DESCRIPTION
Fixes: [nevent1qqsvrkg6quvp4vrzh45z5ske8ex70zr2n9ay5wfetfm53e08h8cqg2cpz3mhxue69uhhyetvv9ujuerpd46hxtnfduqs6amnwvaz7tmwdaejumr0ds78956y](https://gitworkshop.dev/npub1drvpzev3syqt0kjrls50050uzf25gehpz9vgdw08hvex7e0vgfeq0eseet/nostr/issues/note1c8v35pccr2cx90tg9fpdj0jdu7yx4xt6fgunjknhfrj70w0sqs4sgaaxmu)
Suggested-by: @dluvian (npub1useke4f9maul5nf67dj0m9sq6jcsmnjzzk4ycvldwl4qss35fvgqjdk5ks)

### Description

add `Kind::Highlight`, the kind is 9802

### Notes to the reviewers

N/A

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
