### PR TITLE
nostr: handle legacy events with `mention` marker

### DIFF
--- a/crates/nostr/CHANGELOG.md
+++ b/crates/nostr/CHANGELOG.md
@@ -60,6 +60,7 @@
 
 - Remove unused generic in `EventBuilder::request_vanish` function (https://github.com/rust-nostr/nostr/pull/1181)
 - Add `a` tag of replaceable and addressable events in `EventBuilder::repost` (https://github.com/rust-nostr/nostr/pull/1184)
+- Handle legacy events with `mention` marker (https://github.com/rust-nostr/nostr/pull/1193)
 
 ## v0.44.2 - 2025/12/04
 

--- a/crates/nostr/src/event/tag/standard.rs
+++ b/crates/nostr/src/event/tag/standard.rs
@@ -1123,7 +1123,11 @@ where
     // Try getting indexes 2, 3 and 4 and make sure they are not empty.
     // If these are empty, they are handled as None.
     let tag_2: Option<&str> = tag.get(2).map(|r| r.as_ref()).filter(|r| !r.is_empty());
-    let tag_3: Option<&str> = tag.get(3).map(|r| r.as_ref()).filter(|r| !r.is_empty());
+    // "mention" is a removed marker from NIP-10
+    let tag_3: Option<&str> = tag
+        .get(3)
+        .map(|r| r.as_ref())
+        .filter(|r| !r.is_empty() && *r != "mention");
     let tag_4: Option<&str> = tag.get(4).map(|r| r.as_ref()).filter(|r| !r.is_empty());
 
     // Check if it's a report
@@ -2983,5 +2987,24 @@ mod tests {
         );
         assert!(TagStandard::parse(&["t", "nostr"]).is_ok());
         assert!(TagStandard::parse(&["t", "سلام"]).is_ok());
+    }
+
+    #[test]
+    fn e_tag_with_mention_marker() {
+        let hex = "19bb195b83fd26db217b6feebb444de4808d90eb4375c31c75ba5bb5c5c10cfc";
+        let id = EventId::from_hex(hex).unwrap();
+
+        let result = TagStandard::parse(&["e", hex, "", "mention"]);
+
+        assert_eq!(
+            result,
+            Ok(TagStandard::Event {
+                event_id: id,
+                relay_url: None,
+                marker: None,
+                public_key: None,
+                uppercase: false
+            })
+        );
     }
 }


### PR DESCRIPTION
If the marker is `mention` set it to `None`

Fixes: [nevent1qqsxq6vesrl8h2wf6tyy5zmt720ygtth4qnmlnu3gz5m8teu9u859xspzfmhxue69uhkummnw3ezudrjwvhxumqpp4mhxue69uhkummn9ekx7mqusw2x9](https://gitworkshop.dev/npub1drvpzev3syqt0kjrls50050uzf25gehpz9vgdw08hvex7e0vgfeq0eseet/nostr/issues/note1vp5enq870w5un5kgfg9khu57gskh02p8hl8ezs9fkwhnctc0g2dqp8hrxy)
Reported-by: @dluvian

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

N/A

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
