### PR TITLE
nostr: implement `fmt::Display` for `CoordinateBorrow`

### DIFF
--- a/crates/nostr/CHANGELOG.md
+++ b/crates/nostr/CHANGELOG.md
@@ -47,6 +47,7 @@
 - Add `RelayUrlScheme` enum and `RelayUrl::scheme` method (https://github.com/rust-nostr/nostr/pull/1127)
 - Add `Method::Unknown` variant (https://github.com/rust-nostr/nostr/pull/1162)
 - Add `Kind::Highlight` variant (https://github.com/rust-nostr/nostr/pull/1191)
+- Implement `fmt::Display` for `CoordinateBorrow` (https://github.com/rust-nostr/nostr/pull/1194)
 
 ### Removed
 

--- a/crates/nostr/src/nips/nip01.rs
+++ b/crates/nostr/src/nips/nip01.rs
@@ -74,7 +74,7 @@ pub struct Coordinate {
 
 impl fmt::Display for Coordinate {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}:{}:{}", self.kind, self.public_key, self.identifier)
+        self.borrow().fmt(f)
     }
 }
 
@@ -264,6 +264,18 @@ impl CoordinateBorrow<'_> {
             public_key: *self.public_key,
             identifier: self.identifier.map(|s| s.to_string()).unwrap_or_default(),
         }
+    }
+}
+
+impl fmt::Display for CoordinateBorrow<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}:{}:{}",
+            self.kind,
+            self.public_key,
+            self.identifier.unwrap_or_default()
+        )
     }
 }
 
@@ -582,6 +594,32 @@ mod tests {
             "30023:aa4fc8665f5696e33db7e1a572e3b0f5b3d615837b0f362dcb1c8068b098c7b4:";
         let coordinate: Coordinate = Coordinate::parse(coordinate).unwrap();
         assert!(coordinate.verify().is_err());
+    }
+
+    #[test]
+    fn display_addressable_coordinate() {
+        let pkey = "00000001505e7e48927046e9bbaa728b1f3b511227e2200c578d6e6bb0c77eb9";
+        let coordinate = Coordinate::new(
+            Kind::GitRepoAnnouncement,
+            PublicKey::from_hex(pkey).unwrap(),
+        )
+        .identifier("n34");
+
+        assert_eq!(
+            coordinate.to_string(),
+            "30617:00000001505e7e48927046e9bbaa728b1f3b511227e2200c578d6e6bb0c77eb9:n34"
+        )
+    }
+
+    #[test]
+    fn display_replaceable_coordinate() {
+        let pkey = "00000001505e7e48927046e9bbaa728b1f3b511227e2200c578d6e6bb0c77eb9";
+        let coordinate = Coordinate::new(Kind::MuteList, PublicKey::from_hex(pkey).unwrap());
+
+        assert_eq!(
+            coordinate.to_string(),
+            "10000:00000001505e7e48927046e9bbaa728b1f3b511227e2200c578d6e6bb0c77eb9:"
+        )
     }
 }
 


### PR DESCRIPTION
### Description
implement `fmt::Display` for `CoordinateBorrow`

Fixes: [nevent1qqsqzm905cw775qlp8t4t4khhq4gjy96sx668r0ed0grxe93kfvv5dqpp4mhxue69uhkummn9ekx7mqgm9kum](https://gitworkshop.dev/npub1drvpzev3syqt0kjrls50050uzf25gehpz9vgdw08hvex7e0vgfeq0eseet/nostr/issues/note1q9k2lfsaaagp7zwh2htd0wp23ygt4qd45wxlj67sxdjtrvjceg6qc44g5y)
Suggested-by: @dluvian



<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

N/A

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
