### PR TITLE
ndb: respect the filter limit

### DIFF
--- a/database/nostr-ndb/CHANGELOG.md
+++ b/database/nostr-ndb/CHANGELOG.md
@@ -25,6 +25,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Respect the filter limit (https://github.com/rust-nostr/nostr/pull/1200)
+
 ### Added
 
 - Add search (NIP-50) capability (https://github.com/rust-nostr/nostr/pull/1196)

--- a/database/nostr-ndb/src/lib.rs
+++ b/database/nostr-ndb/src/lib.rs
@@ -187,7 +187,12 @@ fn ndb_query<'a>(
     filter: &Filter,
 ) -> Result<Vec<QueryResult<'a>>, DatabaseError> {
     let filter: nostrdb::Filter = ndb_filter_conversion(filter);
-    db.query(txn, &[filter], MAX_RESULTS)
+    let max_results = filter
+        .limit()
+        .map(|n| n.try_into().unwrap_or(i32::MAX))
+        .unwrap_or(MAX_RESULTS);
+
+    db.query(txn, &[filter], max_results)
         .map_err(DatabaseError::backend)
 }
 


### PR DESCRIPTION
### Description

Use the filter limit if it's exist otherwice fallback to the `MAX_RESULTS` constant

### Notes to the reviewers

N/A

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
