### PR TITLE
relay-builder: check port availability with actual relay IP

### DIFF
--- a/crates/nostr-relay-builder/CHANGELOG.md
+++ b/crates/nostr-relay-builder/CHANGELOG.md
@@ -44,6 +44,10 @@
 - Add `LocalRelay::sync_with` method (https://github.com/rust-nostr/nostr/pull/1146)
 - Reject expired events and ensure they are not sent to clients (https://github.com/rust-nostr/nostr/pull/1183)
 
+### Fixed
+
+- Check port availability with actual relay IP (https://github.com/rust-nostr/nostr/pull/1207)
+
 ## v0.44.0 - 2025/11/06
 
 ### Breaking change

--- a/crates/nostr-relay-builder/src/local/inner.rs
+++ b/crates/nostr-relay-builder/src/local/inner.rs
@@ -117,7 +117,7 @@ impl InnerLocalRelay {
     async fn addr(&self) -> &SocketAddr {
         self.addr
             .get_or_init(|| async {
-                let port: u16 = util::find_available_port().await;
+                let port: u16 = util::find_available_port(self.ip).await;
                 SocketAddr::new(self.ip, port)
             })
             .await

--- a/crates/nostr-relay-builder/src/local/util.rs
+++ b/crates/nostr-relay-builder/src/local/util.rs
@@ -2,25 +2,23 @@
 // Copyright (c) 2023-2025 Rust Nostr Developers
 // Distributed under the MIT software license
 
-use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+use std::net::{IpAddr, SocketAddr};
 
 use nostr::rand::rngs::OsRng;
 use nostr::rand::{Rng, TryRngCore};
 use tokio::net::TcpListener;
 
-pub async fn find_available_port() -> u16 {
+pub async fn find_available_port(ip: IpAddr) -> u16 {
     let mut rng = OsRng.unwrap_err();
     loop {
         let port: u16 = rng.random_range(1024..=u16::MAX);
-        if port_is_available(port).await {
+        if port_is_available(ip, port).await {
             return port;
         }
     }
 }
 
 #[inline]
-pub async fn port_is_available(port: u16) -> bool {
-    TcpListener::bind(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port)))
-        .await
-        .is_ok()
+pub async fn port_is_available(ip: IpAddr, port: u16) -> bool {
+    TcpListener::bind(SocketAddr::new(ip, port)).await.is_ok()
 }


### PR DESCRIPTION


Fixes: https://github.com/rust-nostr/nostr/issues/1206

### Description

The `local::util::port_is_available` function incorrectly checked port availability on `127.0.0.1` instead of the actual assigned relay IP.

### Notes to the reviewers

N/A

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
