### PR TITLE
nostr: typo `url` to `pkey`

### DIFF
--- a/crates/nostr/src/event/tag/standard.rs
+++ b/crates/nostr/src/event/tag/standard.rs
@@ -1534,8 +1534,8 @@ where
 {
     // Skip index 0 because is the tag kind
     let mut list: Vec<PublicKey> = Vec::with_capacity(tag.len().saturating_sub(1));
-    for url in tag.iter().skip(1) {
-        list.push(PublicKey::parse(url.as_ref())?);
+    for pkey in tag.iter().skip(1) {
+        list.push(PublicKey::parse(pkey.as_ref())?);
     }
     Ok(list)
 }


### PR DESCRIPTION
### Description

fix a typo in `extract_public_keys` function

### Notes to the reviewers

- N/A

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [ ] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
