### PR TITLE
nostr: parse `HEAD` string as `TagKind::Head`

### DIFF
--- a/crates/nostr/CHANGELOG.md
+++ b/crates/nostr/CHANGELOG.md
@@ -61,6 +61,7 @@
 - Remove unused generic in `EventBuilder::request_vanish` function (https://github.com/rust-nostr/nostr/pull/1181)
 - Add `a` tag of replaceable and addressable events in `EventBuilder::repost` (https://github.com/rust-nostr/nostr/pull/1184)
 - Handle legacy events with `mention` marker (https://github.com/rust-nostr/nostr/pull/1193)
+- Parse "HEAD" as `TagKing::Head` (https://github.com/rust-nostr/nostr/pull/1215)
 
 ## v0.44.2 - 2025/12/04
 

--- a/crates/nostr/src/event/tag/kind.rs
+++ b/crates/nostr/src/event/tag/kind.rs
@@ -444,6 +444,7 @@ impl<'a> From<&'a str> for TagKind<'a> {
             "request" => Self::Request,
             "response" => Self::Response,
             "runtime" => Self::Runtime,
+            "HEAD" => Self::Head,
             "server" => Self::Server,
             "size" => Self::Size,
             "starts" => Self::Starts,


### PR DESCRIPTION
### Description

Fixes #1214 

### Notes to the reviewers

- N/A

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
