### PR TITLE
nostr: replace `TryIntoUrl` trait with `RelayUrlArg` enum

### DIFF
--- a/crates/nostr-relay-builder/src/local/inner.rs
+++ b/crates/nostr-relay-builder/src/local/inner.rs
@@ -15,7 +15,7 @@ use atomic_destructor::AtomicDestroyer;
 use negentropy::{Id, Negentropy, NegentropyStorageVector};
 use nostr_database::prelude::*;
 use nostr_relay_pool::{
-    pool, Output, Reconciliation, RelayOptions, RelayPool, RelayPoolNotification, SyncOptions,
+    Output, Reconciliation, RelayOptions, RelayPool, RelayPoolNotification, SyncOptions,
 };
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::net::TcpListener;
@@ -199,7 +199,7 @@ impl InnerLocalRelay {
             .await
     }
 
-    pub(super) async fn sync_with<I, U>(
+    pub(super) async fn sync_with<'a, I, U>(
         &self,
         urls: I,
         filter: Filter,
@@ -207,8 +207,7 @@ impl InnerLocalRelay {
     ) -> Result<Output<Reconciliation>, Error>
     where
         I: IntoIterator<Item = U>,
-        U: TryIntoUrl,
-        pool::Error: From<<U as TryIntoUrl>::Err>,
+        U: Into<RelayUrlArg<'a>>,
     {
         // Construct a new pool
         let pool: RelayPool = RelayPool::default();

--- a/crates/nostr-relay-builder/src/local/mod.rs
+++ b/crates/nostr-relay-builder/src/local/mod.rs
@@ -8,7 +8,7 @@ use std::net::SocketAddr;
 
 use atomic_destructor::AtomicDestructor;
 use nostr_database::prelude::*;
-use nostr_relay_pool::{pool, Output, Reconciliation, SyncOptions};
+use nostr_relay_pool::{Output, Reconciliation, SyncOptions};
 use tokio::io::{AsyncRead, AsyncWrite};
 
 mod inner;
@@ -79,7 +79,7 @@ impl LocalRelay {
 
     /// Sync events with other relay(s).
     #[inline]
-    pub async fn sync_with<I, U>(
+    pub async fn sync_with<'a, I, U>(
         &self,
         urls: I,
         filter: Filter,
@@ -87,8 +87,7 @@ impl LocalRelay {
     ) -> Result<Output<Reconciliation>, Error>
     where
         I: IntoIterator<Item = U>,
-        U: TryIntoUrl,
-        pool::Error: From<<U as TryIntoUrl>::Err>,
+        U: Into<RelayUrlArg<'a>>,
     {
         self.inner.sync_with(urls, filter, opts).await
     }

--- a/crates/nostr/CHANGELOG.md
+++ b/crates/nostr/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Change the output and behavior of nip17::extract_relay_list and nip17::extract_owned_relay_list functions
 - Add `rand` feature (https://github.com/rust-nostr/nostr/pull/1167)
 - Add `os-rng` feature (https://github.com/rust-nostr/nostr/pull/1171)
+- Replace `TryIntoUrl` trait with `RelayUrlArg` enum (https://github.com/rust-nostr/nostr/pull/1217)
 
 ### Changed
 

--- a/crates/nostr/src/lib.rs
+++ b/crates/nostr/src/lib.rs
@@ -70,7 +70,7 @@ pub use self::nips::nip19::{FromBech32, ToBech32};
 #[doc(hidden)]
 pub use self::signer::{NostrSigner, SignerError};
 #[doc(hidden)]
-pub use self::types::{ImageDimensions, RelayUrl, Timestamp, TryIntoUrl, Url};
+pub use self::types::{ImageDimensions, RelayUrl, RelayUrlArg, Timestamp, Url};
 #[doc(hidden)]
 pub use self::util::JsonUtil;
 #[doc(hidden)]

--- a/crates/nwc/src/lib.rs
+++ b/crates/nwc/src/lib.rs
@@ -342,10 +342,9 @@ impl NostrWalletConnect {
     /// is disabled via [`RelayOptions::reconnect`].
     ///
     /// If the client is not bootstrapped, it will do nothing.
-    pub async fn reconnect_relay<U>(&self, url: U) -> Result<(), Error>
+    pub async fn reconnect_relay<'a, U>(&self, url: U) -> Result<(), Error>
     where
-        U: TryIntoUrl,
-        pool::Error: From<<U as TryIntoUrl>::Err>,
+        U: Into<RelayUrlArg<'a>>,
     {
         if !self.bootstrapped.load(Ordering::SeqCst) {
             return Ok(());

--- a/signer/nostr-connect/src/signer.rs
+++ b/signer/nostr-connect/src/signer.rs
@@ -41,7 +41,7 @@ pub struct NostrConnectRemoteSigner {
 
 impl NostrConnectRemoteSigner {
     /// Construct new remote signer
-    pub fn new<I, U>(
+    pub fn new<'a, I, U>(
         keys: NostrConnectKeys,
         urls: I,
         secret: Option<String>,
@@ -49,15 +49,16 @@ impl NostrConnectRemoteSigner {
     ) -> Result<Self, Error>
     where
         I: IntoIterator<Item = U>,
-        U: TryIntoUrl,
-        pool::Error: From<<U as TryIntoUrl>::Err>,
+        U: Into<RelayUrlArg<'a>>,
     {
         let mut relays = Vec::new();
         for relay in urls.into_iter() {
             relays.push(
                 relay
-                    .try_into_url()
-                    .map_err(|e| Error::Pool(pool::Error::from(e)))?,
+                    .into()
+                    .try_into_relay_url()
+                    .map_err(|e| Error::Pool(pool::Error::from(e)))?
+                    .into_owned(),
             );
         }
 


### PR DESCRIPTION
Refactor across multiple modules to simplify and standardize the handling of relay URLs using the new `RelayUrlArg` enum. This is required for redesign of new APIs (https://github.com/rust-nostr/nostr/pull/1211).