### PR TITLE
sdk: add `AdmitPolicy::admit_auth` to control relay authentication

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -73,6 +73,7 @@
 - Add `Output::new` constructor and `Output::into_inner` method
 - Add idle timeout for negentropy sync (https://github.com/rust-nostr/nostr/pull/1131)
 - Add `GossipAllowedRelays` to `GossipOptions` to filter relays during selection (https://github.com/rust-nostr/nostr/pull/1128)
+- Add `AdmitPolicy::admit_auth` to control relay authentication (https://github.com/rust-nostr/nostr/pull/1218)
 
 ## v0.44.1 - 2025/11/09
 

--- a/sdk/src/client/middleware.rs
+++ b/sdk/src/client/middleware.rs
@@ -25,6 +25,18 @@ impl AdmitPolicy for AdmissionPolicyMiddleware {
         })
     }
 
+    fn admit_auth<'a>(
+        &'a self,
+        relay_url: &'a RelayUrl,
+    ) -> BoxedFuture<'a, Result<AdmitStatus, PolicyError>> {
+        Box::pin(async move {
+            match &self.external_policy {
+                Some(policy) => policy.admit_auth(relay_url).await,
+                None => Ok(AdmitStatus::Success),
+            }
+        })
+    }
+
     fn admit_event<'a>(
         &'a self,
         relay_url: &'a RelayUrl,

--- a/sdk/src/policy.rs
+++ b/sdk/src/policy.rs
@@ -84,6 +84,17 @@ pub trait AdmitPolicy: fmt::Debug + Send + Sync {
         Box::pin(async move { Ok(AdmitStatus::Success) })
     }
 
+    /// Admit authenticating to a relay
+    ///
+    /// <https://github.com/nostr-protocol/nips/blob/master/42.md>
+    fn admit_auth<'a>(
+        &'a self,
+        relay_url: &'a RelayUrl,
+    ) -> BoxedFuture<'a, Result<AdmitStatus, PolicyError>> {
+        let _ = relay_url;
+        Box::pin(async move { Ok(AdmitStatus::Success) })
+    }
+
     /// Admit [`Event`]
     ///
     /// Returns [`AdmitStatus::Success`] if the event is admitted, otherwise [`AdmitStatus::Rejected`].

--- a/sdk/src/relay/error.rs
+++ b/sdk/src/relay/error.rs
@@ -112,6 +112,11 @@ pub enum Error {
     },
     /// Auth failed
     AuthenticationFailed,
+    /// Auth not admitted
+    AuthenticationNotAdmitted {
+        /// Rejection reason
+        reason: Option<String>,
+    },
     /// Premature exit
     PrematureExit,
     /// An empty list of filters has been provided
@@ -181,6 +186,10 @@ impl fmt::Display for Error {
                 current.as_millis()
             ),
             Self::AuthenticationFailed => f.write_str("authentication failed"),
+            Self::AuthenticationNotAdmitted { reason } => match reason {
+                Some(reason) => write!(f, "authentication not admitted: {reason}"),
+                None => f.write_str("authentication not admitted"),
+            },
             Self::PrematureExit => f.write_str("premature exit"),
             Self::EmptyFilters => f.write_str("empty filters"),
         }

--- a/sdk/src/relay/inner.rs
+++ b/sdk/src/relay/inner.rs
@@ -1338,6 +1338,13 @@ impl InnerRelay {
     }
 
     async fn auth(&self, challenge: String) -> Result<(), Error> {
+        // Check if the relay can authenticate
+        if let Some(policy) = &self.state.admit_policy {
+            if let AdmitStatus::Rejected { reason } = policy.admit_auth(&self.url).await? {
+                return Err(Error::AuthenticationNotAdmitted { reason });
+            }
+        }
+
         // Get signer
         let signer = self.state.signer().ok_or(Error::SignerNotConfigured)?;
 


### PR DESCRIPTION
Closes https://github.com/rust-nostr/nostr/issues/739