### PR TITLE
lmdb: add kinds index and a migration system

### DIFF
--- a/database/nostr-lmdb/CHANGELOG.md
+++ b/database/nostr-lmdb/CHANGELOG.md
@@ -39,6 +39,10 @@
 - Add `NostrLmdb::reindex` (https://github.com/rust-nostr/nostr/pull/1143)
 - Support NIP-62 `RequestToVanish` event kind (https://github.com/rust-nostr/nostr/pull/1210)
 
+### Fixed
+
+- Fix the performance of queries by kinds (https://github.com/rust-nostr/nostr/pull/1220)
+
 ## v0.44.0 - 2025/11/06
 
 ### Changed


### PR DESCRIPTION
Introduce `kc_index` (kind + created_at + id) to optimize queries by kind over large datasets. Implement database versioning and migration framework to build the index for existing events when upgrading from v1 to v2.

Fixes https://github.com/rust-nostr/nostr/issues/1219