### PR TITLE
sdk: align signer APIs with the other ones

### DIFF
--- a/sdk/examples/change-signer.rs
+++ b/sdk/examples/change-signer.rs
@@ -1,0 +1,109 @@
+use std::borrow::Cow;
+use std::sync::Arc;
+
+use nostr_sdk::prelude::*;
+use tokio::sync::RwLock;
+
+#[derive(Debug)]
+pub struct MySignerSwitcher {
+    signer: RwLock<Arc<dyn NostrSigner>>,
+}
+
+impl MySignerSwitcher {
+    pub fn new<T>(signer: T) -> Self
+    where
+        T: IntoNostrSigner,
+    {
+        Self {
+            signer: RwLock::new(signer.into_nostr_signer()),
+        }
+    }
+
+    async fn get(&self) -> Arc<dyn NostrSigner> {
+        self.signer.read().await.clone()
+    }
+
+    pub async fn switch<T>(&self, new: T)
+    where
+        T: IntoNostrSigner,
+    {
+        let mut signer = self.signer.write().await;
+        *signer = new.into_nostr_signer();
+    }
+}
+
+impl NostrSigner for MySignerSwitcher {
+    fn backend(&self) -> SignerBackend {
+        SignerBackend::Custom(Cow::Borrowed("custom"))
+    }
+
+    fn get_public_key(&self) -> BoxedFuture<Result<PublicKey, SignerError>> {
+        Box::pin(async move { Ok(self.get().await.get_public_key().await?) })
+    }
+
+    fn sign_event(
+        &self,
+        unsigned: UnsignedEvent,
+    ) -> BoxedFuture<std::result::Result<Event, SignerError>> {
+        Box::pin(async move { Ok(self.get().await.sign_event(unsigned).await?) })
+    }
+
+    fn nip04_encrypt<'a>(
+        &'a self,
+        public_key: &'a PublicKey,
+        content: &'a str,
+    ) -> BoxedFuture<'a, std::result::Result<String, SignerError>> {
+        Box::pin(async move { Ok(self.get().await.nip04_encrypt(public_key, content).await?) })
+    }
+
+    fn nip04_decrypt<'a>(
+        &'a self,
+        public_key: &'a PublicKey,
+        encrypted_content: &'a str,
+    ) -> BoxedFuture<'a, std::result::Result<String, SignerError>> {
+        Box::pin(async move {
+            Ok(self
+                .get()
+                .await
+                .nip04_decrypt(public_key, encrypted_content)
+                .await?)
+        })
+    }
+
+    fn nip44_encrypt<'a>(
+        &'a self,
+        public_key: &'a PublicKey,
+        content: &'a str,
+    ) -> BoxedFuture<'a, std::result::Result<String, SignerError>> {
+        Box::pin(async move { Ok(self.get().await.nip44_encrypt(public_key, content).await?) })
+    }
+
+    fn nip44_decrypt<'a>(
+        &'a self,
+        public_key: &'a PublicKey,
+        payload: &'a str,
+    ) -> BoxedFuture<'a, std::result::Result<String, SignerError>> {
+        Box::pin(async move { Ok(self.get().await.nip44_decrypt(public_key, payload).await?) })
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+
+    let keys = Keys::parse("nsec1ufnus6pju578ste3v90xd5m2decpuzpql2295m3sknqcjzyys9ls0qlc85")?;
+    let signer = Arc::new(MySignerSwitcher::new(keys));
+
+    let client = Client::builder().signer(signer.clone()).build();
+
+    let pk = client.signer().unwrap().get_public_key().await?;
+    println!("Public Key: {}", pk.to_bech32()?);
+
+    let new_keys = Keys::generate();
+    signer.switch(new_keys).await;
+
+    let pk = client.signer().unwrap().get_public_key().await?;
+    println!("Public Key: {}", pk.to_bech32()?);
+
+    Ok(())
+}

--- a/sdk/examples/nostr-connect.rs
+++ b/sdk/examples/nostr-connect.rs
@@ -31,7 +31,7 @@ async fn main() -> Result<()> {
     println!("\nBunker URI: {bunker_uri}\n");
 
     // Compose client
-    let client = Client::builder().signer(signer).build();
+    let client = Client::builder().signer(signer.clone()).build();
     client.add_relay("wss://relay.damus.io").await?;
     client.connect().await;
 
@@ -40,7 +40,6 @@ async fn main() -> Result<()> {
     let output = client.send_event_builder(builder).await?;
     println!("Published text note: {}\n", output.id());
 
-    let signer = client.signer().await?;
     let receiver =
         PublicKey::from_bech32("npub1drvpzev3syqt0kjrls50050uzf25gehpz9vgdw08hvex7e0vgfeq0eseet")?;
     let msg = EventBuilder::private_msg(&signer, receiver, "Hello from rust-nostr", []).await?;

--- a/sdk/src/client/error.rs
+++ b/sdk/src/client/error.rs
@@ -9,7 +9,6 @@ use nostr::serde_json;
 use nostr_database::prelude::*;
 use nostr_gossip::error::GossipError;
 
-use crate::shared::SharedStateError;
 use crate::{pool, relay};
 
 /// Client error
@@ -31,13 +30,13 @@ pub enum Error {
     EventBuilder(event::builder::Error),
     /// Json error
     Json(serde_json::Error),
-    /// Shared state error
-    SharedState(SharedStateError),
     /// Notification Handler error
     Handler(String),
     /// NIP59
     #[cfg(feature = "nip59")]
     NIP59(nip59::Error),
+    /// Signer not configured
+    SignerNotConfigured,
     /// Gossip is not configured
     GossipNotConfigured,
     /// Broken down filters for gossip are empty
@@ -59,10 +58,10 @@ impl fmt::Display for Error {
             Self::Gossip(e) => e.fmt(f),
             Self::EventBuilder(e) => e.fmt(f),
             Self::Json(e) => e.fmt(f),
-            Self::SharedState(e) => e.fmt(f),
             Self::Handler(e) => e.fmt(f),
             #[cfg(feature = "nip59")]
             Self::NIP59(e) => e.fmt(f),
+            Self::SignerNotConfigured => f.write_str("signer not configured"),
             Self::GossipNotConfigured => f.write_str("gossip not configured"),
             Self::GossipFiltersEmpty => {
                 f.write_str("gossip broken down filters are empty")
@@ -117,12 +116,6 @@ impl From<event::builder::Error> for Error {
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Self::Json(e)
-    }
-}
-
-impl From<SharedStateError> for Error {
-    fn from(e: SharedStateError) -> Self {
-        Self::SharedState(e)
     }
 }
 

--- a/sdk/src/client/mod.rs
+++ b/sdk/src/client/mod.rs
@@ -129,54 +129,12 @@ impl Client {
         }
     }
 
-    /// Auto authenticate to relays (default: true)
-    ///
-    /// <https://github.com/nostr-protocol/nips/blob/master/42.md>
-    #[inline]
-    pub fn automatic_authentication(&self, enable: bool) {
-        self.pool.state().automatic_authentication(enable);
-    }
-
-    /// Check if signer is configured
-    #[inline]
-    pub async fn has_signer(&self) -> bool {
-        self.pool.state().has_signer().await
-    }
-
     /// Get current nostr signer
     ///
-    /// # Errors
-    ///
-    /// Returns an error if the signer isn't set.
+    /// Returns `None` if no signer is configured.
     #[inline]
-    pub async fn signer(&self) -> Result<Arc<dyn NostrSigner>, Error> {
-        Ok(self.pool.state().signer().await?)
-    }
-
-    /// Set nostr signer
-    #[inline]
-    pub async fn set_signer<T>(&self, signer: T)
-    where
-        T: IntoNostrSigner,
-    {
-        self.pool.state().set_signer(signer).await;
-    }
-
-    /// Unset nostr signer
-    #[inline]
-    pub async fn unset_signer(&self) {
-        self.pool.state().unset_signer().await;
-    }
-
-    /// Retrieves the client's public key
-    ///
-    /// # Errors
-    ///
-    /// - If the signer isn't set.
-    /// - Error by the signer.
-    #[inline]
-    pub async fn public_key(&self) -> Result<PublicKey, Error> {
-        Ok(self.signer().await?.get_public_key().await?)
+    pub fn signer(&self) -> Option<&Arc<dyn NostrSigner>> {
+        self.pool.state().signer()
     }
 
     /// Get database
@@ -211,6 +169,16 @@ impl Client {
     #[inline]
     pub fn notifications(&self) -> broadcast::Receiver<ClientNotification> {
         self.pool.notifications()
+    }
+
+    /// Enable or disable automatic authenticate to relays
+    ///
+    /// This feature requires a configured signer!
+    ///
+    /// <https://github.com/nostr-protocol/nips/blob/master/42.md>
+    #[inline]
+    pub fn automatic_authentication(&self, enable: bool) {
+        self.pool.state().automatic_authentication(enable);
     }
 
     /// Get relays from the relay pool.
@@ -1197,8 +1165,8 @@ impl Client {
     ///
     /// This method requires a [`NostrSigner`].
     pub async fn sign_event_builder(&self, builder: EventBuilder) -> Result<Event, Error> {
-        let signer = self.signer().await?;
-        Ok(builder.sign(&signer).await?)
+        let signer = self.signer().ok_or(Error::SignerNotConfigured)?;
+        Ok(builder.sign(signer).await?)
     }
 
     /// Take an [`EventBuilder`], sign it by using the [`NostrSigner`] and broadcast to relays.

--- a/sdk/src/relay/api/send_event.rs
+++ b/sdk/src/relay/api/send_event.rs
@@ -117,7 +117,7 @@ where
             {
                 // Check if NIP42 auth is enabled and signer is set
                 if self.relay.inner.state.is_auto_authentication_enabled()
-                    && self.relay.inner.state.has_signer().await
+                    && self.relay.inner.state.has_signer()
                 {
                     // Wait that relay authenticate
                     wait_for_authentication(
@@ -174,7 +174,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_nip42_send_event() {
+    async fn test_nip42_send_event_without_signer() {
         // Mock relay
         let opts = LocalRelayBuilderNip42 {
             mode: LocalRelayBuilderNip42Mode::Write,
@@ -185,17 +185,32 @@ mod tests {
 
         let relay: Relay = Relay::new(url);
 
-        relay.inner.state.automatic_authentication(true);
-
         relay.connect();
 
-        // Signer
+        // Signer and event
         let keys = Keys::generate();
-
-        // Send as unauthenticated (MUST return error)
         let event = EventBuilder::text_note("Test")
             .sign_with_keys(&keys)
             .unwrap();
+
+        // Disable NIP42 auto auth
+        relay.inner.state.automatic_authentication(false);
+
+        // Auth disabled, so must fails as is unauthenticated
+        match relay.send_event(&event).await.unwrap_err() {
+            crate::relay::Error::RelayMessage(msg) => {
+                assert_eq!(
+                    MachineReadablePrefix::parse(&msg).unwrap(),
+                    MachineReadablePrefix::AuthRequired
+                );
+            }
+            e => panic!("Unexpected error: {e}"),
+        }
+
+        // Enable NIP42 auto auth
+        relay.inner.state.automatic_authentication(true);
+
+        // Send as unauthenticated (MUST return error)
         let err = relay.send_event(&event).await.unwrap_err();
         if let crate::relay::Error::RelayMessage(msg) = err {
             assert_eq!(
@@ -205,14 +220,46 @@ mod tests {
         } else {
             panic!("Unexpected error");
         }
+    }
 
-        // Set a signer
-        relay.inner.state.set_signer(keys.clone()).await;
+    #[tokio::test]
+    async fn test_nip42_send_event_with_signer() {
+        // Mock relay
+        let opts = LocalRelayBuilderNip42 {
+            mode: LocalRelayBuilderNip42Mode::Write,
+        };
+        let mock = LocalRelay::builder().nip42(opts).build();
+        mock.run().await.unwrap();
+        let url = mock.url().await;
 
-        // Send as authenticated
+        // Signer and event
+        let keys = Keys::generate();
         let event = EventBuilder::text_note("Test")
             .sign_with_keys(&keys)
             .unwrap();
+
+        let relay: Relay = Relay::builder(url).signer(keys).build();
+
+        relay.connect();
+
+        // Disable NIP42 auto auth
+        relay.inner.state.automatic_authentication(false);
+
+        // Auth disabled, so must fails as is unauthenticated
+        match relay.send_event(&event).await.unwrap_err() {
+            crate::relay::Error::RelayMessage(msg) => {
+                assert_eq!(
+                    MachineReadablePrefix::parse(&msg).unwrap(),
+                    MachineReadablePrefix::AuthRequired
+                );
+            }
+            e => panic!("Unexpected error: {e}"),
+        }
+
+        // Enable NIP42 auto auth
+        relay.inner.state.automatic_authentication(true);
+
+        // Send as authenticated
         assert!(relay.send_event(&event).await.is_ok());
     }
 }

--- a/sdk/src/relay/error.rs
+++ b/sdk/src/relay/error.rs
@@ -7,7 +7,6 @@ use nostr_database::DatabaseError;
 use tokio::sync::oneshot;
 
 use crate::policy::PolicyError;
-use crate::shared::SharedStateError;
 use crate::transport::error::TransportError;
 
 /// Relay error
@@ -19,8 +18,6 @@ pub enum Error {
     Policy(PolicyError),
     /// Database error
     Database(DatabaseError),
-    /// Shared state error
-    SharedState(SharedStateError),
     /// MessageHandle error
     MessageHandle(MessageHandleError),
     /// Event error
@@ -33,6 +30,8 @@ pub enum Error {
     Negentropy(negentropy::Error),
     /// Oneshot recv error
     OneshotRecv(oneshot::error::RecvError),
+    /// Signer not configured
+    SignerNotConfigured,
     /// Generic timeout
     Timeout,
     /// Not replied to ping
@@ -129,13 +128,13 @@ impl fmt::Display for Error {
             Self::Transport(e) => write!(f, "transport: {e}"),
             Self::Policy(e) => write!(f, "policy: {e}"),
             Self::Database(e) => write!(f, "database: {e}"),
-            Self::SharedState(e) => e.fmt(f),
             Self::MessageHandle(e) => e.fmt(f),
             Self::Event(e) => e.fmt(f),
             Self::EventBuilder(e) => e.fmt(f),
             Self::Hex(e) => e.fmt(f),
             Self::Negentropy(e) => e.fmt(f),
             Self::OneshotRecv(e) => e.fmt(f),
+            Self::SignerNotConfigured => f.write_str("signer not configured"),
             Self::Timeout => f.write_str("timeout"),
             Self::NotRepliedToPing => f.write_str("not replied to ping"),
             Self::CantParsePong => f.write_str("can't parse pong"),
@@ -206,12 +205,6 @@ impl From<PolicyError> for Error {
 impl From<DatabaseError> for Error {
     fn from(e: DatabaseError) -> Self {
         Self::Database(e)
-    }
-}
-
-impl From<SharedStateError> for Error {
-    fn from(e: SharedStateError) -> Self {
-        Self::SharedState(e)
     }
 }
 

--- a/sdk/src/relay/inner.rs
+++ b/sdk/src/relay/inner.rs
@@ -1324,11 +1324,11 @@ impl InnerRelay {
 
     async fn auth(&self, challenge: String) -> Result<(), Error> {
         // Get signer
-        let signer = self.state.signer().await?;
+        let signer = self.state.signer().ok_or(Error::SignerNotConfigured)?;
 
         // Construct event
         let event: Event = EventBuilder::auth(challenge, self.url.clone())
-            .sign(&signer)
+            .sign(signer)
             .await?;
 
         // Subscribe to notifications

--- a/sdk/src/shared.rs
+++ b/sdk/src/shared.rs
@@ -1,69 +1,35 @@
-// Copyright (c) 2022-2023 Yuki Kishimoto
-// Copyright (c) 2023-2025 Rust Nostr Developers
-// Distributed under the MIT software license
-
 use std::collections::hash_map::DefaultHasher;
-use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use lru::LruCache;
-use nostr::prelude::IntoNostrSigner;
 use nostr::{EventId, NostrSigner};
-use nostr_database::{IntoNostrDatabase, MemoryDatabase, NostrDatabase};
-use tokio::sync::{Mutex, RwLock};
+use nostr_database::NostrDatabase;
+use tokio::sync::Mutex;
 
 use crate::monitor::Monitor;
 use crate::policy::AdmitPolicy;
-use crate::transport::websocket::{DefaultWebsocketTransport, WebSocketTransport};
+use crate::transport::websocket::WebSocketTransport;
 
 // LruCache pre-allocate, so keep this at a reasonable value.
 // A good value may be <= 128k, considering that stored values are the 64-bit hashes of the event IDs.
 const MAX_VERIFICATION_CACHE_SIZE: usize = 128_000;
 
-#[derive(Debug)]
-pub enum SharedStateError {
-    SignerNotConfigured,
-}
-
-impl std::error::Error for SharedStateError {}
-
-impl fmt::Display for SharedStateError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::SignerNotConfigured => f.write_str("signer not configured"),
-        }
-    }
-}
-
 #[derive(Debug, Clone)]
-pub struct SharedState {
+pub(crate) struct SharedState {
     pub(crate) database: Arc<dyn NostrDatabase>,
     pub(crate) transport: Arc<dyn WebSocketTransport>,
-    signer: Arc<RwLock<Option<Arc<dyn NostrSigner>>>>,
+    signer: Option<Arc<dyn NostrSigner>>,
     nip42_auto_authentication: Arc<AtomicBool>,
     verification_cache: Arc<Mutex<LruCache<u64, ()>>>,
     pub(crate) admit_policy: Option<Arc<dyn AdmitPolicy>>,
     pub(crate) monitor: Option<Monitor>,
 }
 
-impl Default for SharedState {
-    fn default() -> Self {
-        Self::new(
-            MemoryDatabase::new().into_nostr_database(),
-            Arc::new(DefaultWebsocketTransport),
-            None,
-            None,
-            true,
-            None,
-        )
-    }
-}
-
 impl SharedState {
-    pub fn new(
+    pub(crate) fn new(
         database: Arc<dyn NostrDatabase>,
         transport: Arc<dyn WebSocketTransport>,
         signer: Option<Arc<dyn NostrSigner>>,
@@ -78,7 +44,7 @@ impl SharedState {
         Self {
             database,
             transport,
-            signer: Arc::new(RwLock::new(signer)),
+            signer,
             nip42_auto_authentication: Arc::new(AtomicBool::new(nip42_auto_authentication)),
             verification_cache: Arc::new(Mutex::new(LruCache::new(max_verification_cache_size))),
             admit_policy,
@@ -86,53 +52,27 @@ impl SharedState {
         }
     }
 
-    /// Check if auto authentication to relays is enabled
     #[inline]
-    pub fn is_auto_authentication_enabled(&self) -> bool {
+    pub(crate) fn is_auto_authentication_enabled(&self) -> bool {
         self.nip42_auto_authentication.load(Ordering::SeqCst)
     }
 
-    /// Auto authenticate to relays
-    ///
-    /// <https://github.com/nostr-protocol/nips/blob/master/42.md>
-    pub fn automatic_authentication(&self, enable: bool) {
+    pub(crate) fn automatic_authentication(&self, enable: bool) {
         self.nip42_auto_authentication
             .store(enable, Ordering::SeqCst);
     }
 
-    /// Get database
     #[inline]
-    pub fn database(&self) -> &Arc<dyn NostrDatabase> {
+    pub(crate) fn database(&self) -> &Arc<dyn NostrDatabase> {
         &self.database
     }
 
-    /// Check if signer is configured
-    pub async fn has_signer(&self) -> bool {
-        let signer = self.signer.read().await;
-        signer.is_some()
+    pub(crate) fn has_signer(&self) -> bool {
+        self.signer.is_some()
     }
 
-    /// Get current nostr signer
-    ///
-    /// Rise error if it not set.
-    pub async fn signer(&self) -> Result<Arc<dyn NostrSigner>, SharedStateError> {
-        let signer = self.signer.read().await;
-        signer.clone().ok_or(SharedStateError::SignerNotConfigured)
-    }
-
-    /// Set nostr signer
-    pub async fn set_signer<T>(&self, signer: T)
-    where
-        T: IntoNostrSigner,
-    {
-        let mut s = self.signer.write().await;
-        *s = Some(signer.into_nostr_signer());
-    }
-
-    /// Unset nostr signer
-    pub async fn unset_signer(&self) {
-        let mut s = self.signer.write().await;
-        *s = None;
+    pub(crate) fn signer(&self) -> Option<&Arc<dyn NostrSigner>> {
+        self.signer.as_ref()
     }
 
     pub(crate) async fn verified(&self, id: &EventId) -> bool {


### PR DESCRIPTION
Remove methods to set or unset a signer. These changes align the signer trait with the other ones (database, transport, policy, etc.). Who will need to switch signers in the same client can use the following solution:

```rust
#[derive(Debug)]
pub struct MySignerSwitcher {
    signer: RwLock<Arc<dyn NostrSigner>>
}

impl MySignerSwitcher {
    async fn get(&self) -> Arc<dyn NostrSigner> {
        self.signer.read().await.clone()
    }

    pub async fn switch(&self, new: Arc<dyn NostrSigner>) {
        let mut signer = self.signer.write().await;
        *signer = new;
    }
}

impl NostrSigner for MySignerSwitcher {
    fn backend(&self) -> SignerBackend {
        SignerBackend::Custom(Cow::Borrowed("custom"))
    }

    fn get_public_key(&self) -> BoxedFuture<Result<PublicKey, SignerError>> {
        Box::pin(async move { Ok(self.get().await.get_public_key().await?) })
    }

    fn sign_event(&self, unsigned: UnsignedEvent) -> BoxedFuture<std::result::Result<Event, SignerError>> {
        Box::pin(async move { Ok(self.get().await.sign_event(unsigned).await?)})
    }

    // ...
}
```

Ref https://github.com/rust-nostr/nostr/issues/920