### PR TITLE
sdk: redesign notifications APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2856,6 +2856,7 @@ version = "0.44.0"
 dependencies = [
  "async-utility",
  "dialoguer",
+ "futures-core",
  "nostr",
  "nostr-sdk",
  "tokio",
@@ -3032,6 +3033,7 @@ dependencies = [
  "nostr-ndb",
  "nostr-relay-builder",
  "tokio",
+ "tokio-stream",
  "tracing",
  "tracing-subscriber",
 ]
@@ -5052,6 +5054,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/crates/nostr-relay-builder/src/local/inner.rs
+++ b/crates/nostr-relay-builder/src/local/inner.rs
@@ -223,7 +223,7 @@ impl InnerLocalRelay {
 
         // Create a notification future
         let fut = async {
-            while let Ok(notification) = notifications.recv().await {
+            while let Some(notification) = notifications.next().await {
                 // Notify about new events received by the sync
                 if let ClientNotification::Event { event, .. } = notification {
                     self.notify_event(*event);

--- a/crates/nwc/src/lib.rs
+++ b/crates/nwc/src/lib.rs
@@ -273,7 +273,7 @@ impl NostrWalletConnect {
     {
         let mut notifications = self.client.notifications();
 
-        while let Ok(notification) = notifications.recv().await {
+        while let Some(notification) = notifications.next().await {
             tracing::trace!("Received a client notification: {:?}", notification);
 
             match notification {

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -45,6 +45,7 @@
 - Remove `Client::batch_msgs` and `Relay::batch_msgs` (https://github.com/rust-nostr/nostr/pull/1240)
 - Change `Client::relay` output to return `Result<Output<Relay>>`
 - Remove `ClientOptions` in favor of `ClientBuilder` (https://github.com/rust-nostr/nostr/pull/1241)
+- Remove `Client::handle_notifications` and `Relay_handle_notifications` (https://github.com/rust-nostr/nostr/pull/1245)
 
 ### Changed
 
@@ -61,6 +62,7 @@
 - Redesign `Client::unsubscribe` and `Relay::unsubscribe` APIs (https://github.com/rust-nostr/nostr/pull/1238)
 - Redesign `Client::unsubscribe_all` and `Relay::unsubscribe_all` APIs (https://github.com/rust-nostr/nostr/pull/1239)
 - Redesign `Client::send_msg` and `Relay::send_msg` APIs (https://github.com/rust-nostr/nostr/pull/1240)
+- Redesign `Client::notifications` and `Relay::notifications` APIs (https://github.com/rust-nostr/nostr/pull/1245)
 
 ### Added
 

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -42,6 +42,7 @@ nostr = { workspace = true, features = ["std", "rand", "os-rng"] }
 nostr-database.workspace = true
 nostr-gossip.workspace = true
 tokio = { workspace = true, features = ["macros", "sync"] }
+tokio-stream = { version = "0.1", features = ["sync"] }
 tracing = { workspace = true, features = ["std"] }
 
 [dev-dependencies]

--- a/sdk/examples/tor.rs
+++ b/sdk/examples/tor.rs
@@ -34,21 +34,19 @@ async fn main() -> Result<()> {
     let filter: Filter = Filter::new().pubkey(keys.public_key()).limit(0);
     client.subscribe(filter).await?;
 
-    // Handle subscription notifications with `handle_notifications` method
-    client
-        .handle_notifications(|notification| async {
-            if let ClientNotification::Event { event, .. } = notification {
-                if event.kind == Kind::GiftWrap {
-                    let UnwrappedGift { rumor, .. } =
-                        UnwrappedGift::from_gift_wrap(&keys, &event).await?;
-                    println!("Rumor: {}", rumor.as_json());
-                } else {
-                    println!("{:?}", event);
-                }
+    let mut notifications = client.notifications();
+
+    while let Some(notification) = notifications.next().await {
+        if let ClientNotification::Event { event, .. } = notification {
+            if event.kind == Kind::GiftWrap {
+                let UnwrappedGift { rumor, .. } =
+                    UnwrappedGift::from_gift_wrap(&keys, &event).await?;
+                println!("Rumor: {}", rumor.as_json());
+            } else {
+                println!("{:?}", event);
             }
-            Ok(false) // Set to true to exit from the loop
-        })
-        .await?;
+        }
+    }
 
     Ok(())
 }

--- a/sdk/src/client/error.rs
+++ b/sdk/src/client/error.rs
@@ -30,8 +30,6 @@ pub enum Error {
     EventBuilder(event::builder::Error),
     /// Json error
     Json(serde_json::Error),
-    /// Notification Handler error
-    Handler(String),
     /// NIP59
     #[cfg(feature = "nip59")]
     NIP59(nip59::Error),
@@ -58,7 +56,6 @@ impl fmt::Display for Error {
             Self::Gossip(e) => e.fmt(f),
             Self::EventBuilder(e) => e.fmt(f),
             Self::Json(e) => e.fmt(f),
-            Self::Handler(e) => e.fmt(f),
             #[cfg(feature = "nip59")]
             Self::NIP59(e) => e.fmt(f),
             Self::SignerNotConfigured => f.write_str("signer not configured"),

--- a/sdk/src/relay/api/subscribe.rs
+++ b/sdk/src/relay/api/subscribe.rs
@@ -141,6 +141,7 @@ mod tests {
     use std::time::Duration;
 
     use async_utility::time;
+    use futures::StreamExt;
     use nostr::{Event, EventBuilder, EventId, Keys, Kind};
     use nostr_relay_builder::prelude::*;
 
@@ -180,13 +181,7 @@ mod tests {
         relay.subscribe(filter).await.unwrap();
 
         // Keep up the test
-        time::timeout(
-            Some(Duration::from_secs(10)),
-            relay.handle_notifications(|_| async { Ok(false) }),
-        )
-        .await
-        .unwrap()
-        .unwrap();
+        time::sleep(Duration::from_secs(5)).await;
 
         assert_eq!(relay.status(), RelayStatus::Banned);
 
@@ -235,28 +230,37 @@ mod tests {
         let sub_id = relay2.subscribe(filter).await.unwrap();
 
         // Listen for notifications
-        let fut = relay2.handle_notifications(|notification| async {
-            if let RelayNotification::Event {
-                subscription_id,
-                event,
-            } = notification
-            {
-                if subscription_id == sub_id {
-                    if event.id == event_id {
-                        return Ok(true);
+        let fut = async {
+            let mut notifications = relay2.notifications();
+
+            let mut received: bool = false;
+
+            while let Some(notification) = notifications.next().await {
+                if let RelayNotification::Event {
+                    subscription_id,
+                    event,
+                } = notification
+                {
+                    if subscription_id == sub_id {
+                        if event.id == event_id {
+                            received = true;
+                            break;
+                        } else {
+                            panic!("Unexpected event");
+                        }
                     } else {
-                        panic!("Unexpected event");
+                        panic!("Unexpected subscription ID");
                     }
-                } else {
-                    panic!("Unexpected subscription ID");
                 }
             }
-            Ok(false)
-        });
+
+            if !received {
+                panic!("No event received");
+            }
+        };
 
         tokio::time::timeout(Duration::from_secs(5), fut)
             .await
-            .unwrap()
             .unwrap();
     }
 }

--- a/sdk/src/relay/error.rs
+++ b/sdk/src/relay/error.rs
@@ -103,8 +103,6 @@ pub enum Error {
     },
     /// Event expired
     EventExpired,
-    /// Notification Handler error
-    Handler(String),
     /// Max latency exceeded
     MaximumLatencyExceeded {
         /// Max
@@ -176,7 +174,6 @@ impl fmt::Display for Error {
                 "Received event with too many tags: tags={size}, max_tags={max_size}"
             ),
             Self::EventExpired => f.write_str("event expired"),
-            Self::Handler(e) => f.write_str(e),
             Self::MaximumLatencyExceeded { max, current } => write!(
                 f,
                 "Maximum latency exceeded: max={}ms, current={}ms",

--- a/sdk/src/relay/status.rs
+++ b/sdk/src/relay/status.rs
@@ -127,11 +127,6 @@ impl RelayStatus {
     pub(crate) fn can_connect(&self) -> bool {
         matches!(self, Self::Initialized | Self::Terminated | Self::Sleeping)
     }
-
-    /// Check if relay can't reconnect again (status is `banned` or `shutdown`)
-    pub(super) fn is_permanently_disconnected(&self) -> bool {
-        matches!(self, Self::Banned | Self::Shutdown)
-    }
 }
 
 #[cfg(test)]
@@ -155,7 +150,6 @@ mod tests {
         assert!(!status.is_banned());
         assert!(!status.is_sleeping());
         assert!(!status.is_shutdown());
-        assert!(!status.is_permanently_disconnected());
         assert!(status.can_connect());
         let relay = AtomicRelayStatus::new(status);
         assert_eq!(relay.load(), RelayStatus::Initialized);
@@ -171,7 +165,6 @@ mod tests {
         assert!(!status.is_banned());
         assert!(!status.is_sleeping());
         assert!(!status.is_shutdown());
-        assert!(!status.is_permanently_disconnected());
         assert!(!status.can_connect());
         let relay = AtomicRelayStatus::new(status);
         assert_eq!(relay.load(), RelayStatus::Pending);
@@ -187,7 +180,6 @@ mod tests {
         assert!(!status.is_banned());
         assert!(!status.is_sleeping());
         assert!(!status.is_shutdown());
-        assert!(!status.is_permanently_disconnected());
         assert!(!status.can_connect());
         let relay = AtomicRelayStatus::new(status);
         assert_eq!(relay.load(), RelayStatus::Connecting);
@@ -203,7 +195,6 @@ mod tests {
         assert!(!status.is_banned());
         assert!(!status.is_sleeping());
         assert!(!status.is_shutdown());
-        assert!(!status.is_permanently_disconnected());
         assert!(!status.can_connect());
         let relay = AtomicRelayStatus::new(status);
         assert_eq!(relay.load(), RelayStatus::Connected);
@@ -219,7 +210,6 @@ mod tests {
         assert!(!status.is_banned());
         assert!(!status.is_sleeping());
         assert!(!status.is_shutdown());
-        assert!(!status.is_permanently_disconnected());
         assert!(!status.can_connect());
         let relay = AtomicRelayStatus::new(status);
         assert_eq!(relay.load(), RelayStatus::Disconnected);
@@ -235,7 +225,6 @@ mod tests {
         assert!(!status.is_banned());
         assert!(!status.is_sleeping());
         assert!(!status.is_shutdown());
-        assert!(!status.is_permanently_disconnected());
         assert!(status.can_connect());
         let relay = AtomicRelayStatus::new(status);
         assert_eq!(relay.load(), RelayStatus::Terminated);
@@ -251,7 +240,6 @@ mod tests {
         assert!(status.is_banned());
         assert!(!status.is_sleeping());
         assert!(!status.is_shutdown());
-        assert!(status.is_permanently_disconnected());
         assert!(!status.can_connect());
         let relay = AtomicRelayStatus::new(status);
         assert_eq!(relay.load(), RelayStatus::Banned);
@@ -267,7 +255,6 @@ mod tests {
         assert!(!status.is_banned());
         assert!(status.is_sleeping());
         assert!(!status.is_shutdown());
-        assert!(!status.is_permanently_disconnected());
         assert!(status.can_connect());
         let relay = AtomicRelayStatus::new(status);
         assert_eq!(relay.load(), RelayStatus::Sleeping);
@@ -283,7 +270,6 @@ mod tests {
         assert!(!status.is_banned());
         assert!(!status.is_sleeping());
         assert!(status.is_shutdown());
-        assert!(status.is_permanently_disconnected());
         assert!(!status.can_connect());
         let relay = AtomicRelayStatus::new(status);
         assert_eq!(relay.load(), RelayStatus::Shutdown);

--- a/sdk/src/stream.rs
+++ b/sdk/src/stream.rs
@@ -1,8 +1,10 @@
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use async_utility::futures_util::Stream;
+use futures::{Stream, StreamExt};
+use tokio::sync::broadcast;
 use tokio::sync::mpsc::Receiver;
+use tokio_stream::wrappers::BroadcastStream;
 
 /// Boxed stream
 #[cfg(not(target_arch = "wasm32"))]
@@ -11,7 +13,6 @@ pub type BoxedStream<T> = Pin<Box<dyn Stream<Item = T> + Send>>;
 #[cfg(target_arch = "wasm32")]
 pub type BoxedStream<T> = Pin<Box<dyn Stream<Item = T>>>;
 
-#[derive(Debug)]
 pub(crate) struct ReceiverStream<T> {
     inner: Receiver<T>,
 }
@@ -28,5 +29,40 @@ impl<T> Stream for ReceiverStream<T> {
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         self.inner.poll_recv(cx)
+    }
+}
+
+pub(crate) struct NotificationStream<T> {
+    inner: BroadcastStream<T>,
+}
+
+impl<T> NotificationStream<T>
+where
+    T: Clone + Send + 'static,
+{
+    #[inline]
+    pub(crate) fn new(inner: broadcast::Receiver<T>) -> Self {
+        Self {
+            inner: BroadcastStream::new(inner),
+        }
+    }
+}
+
+impl<T> Stream for NotificationStream<T>
+where
+    T: Clone + Send + 'static,
+{
+    type Item = T;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        loop {
+            match self.inner.poll_next_unpin(cx) {
+                Poll::Ready(Some(Ok(notification))) => return Poll::Ready(Some(notification)),
+                // Skip errors for now
+                Poll::Ready(Some(Err(..))) => continue,
+                Poll::Ready(None) => return Poll::Ready(None),
+                Poll::Pending => return Poll::Pending,
+            }
+        }
     }
 }

--- a/signer/nostr-connect/Cargo.toml
+++ b/signer/nostr-connect/Cargo.toml
@@ -21,6 +21,7 @@ tor = ["nostr-sdk/tor"]
 
 [dependencies]
 async-utility.workspace = true
+futures-core = "0.3"
 nostr = { workspace = true, features = ["std", "rand", "nip04", "nip44", "nip46"] }
 nostr-sdk.workspace = true
 tokio = { workspace = true, features = ["sync"] }


### PR DESCRIPTION
- Replace `broadcast::Receiver` with `Stream` for relay and client notifications
- Automatically terminates notification streams for `Relay` and `Client` on shutdown.
- Remove `Relay::handle_notifications` and `Client::handle_notifications`

Ref https://github.com/rust-nostr/nostr/issues/920