### PR TITLE
nostr: add support for `nprofile` parsing in `PublicKey::from_bech32`

### DIFF
--- a/crates/nostr/CHANGELOG.md
+++ b/crates/nostr/CHANGELOG.md
@@ -53,6 +53,7 @@
 - Implement `fmt::Display` for `CoordinateBorrow` (https://github.com/rust-nostr/nostr/pull/1194)
 - Add `Kind::BlossomServerList` variant (https://github.com/rust-nostr/nostr/pull/1195)
 - Add `EventBuilder::blossom_server_list` function (https://github.com/rust-nostr/nostr/pull/1195)
+- Add support for `nprofile` parsing in `PublicKey::from_bech32` (https://github.com/rust-nostr/nostr/pull/1248)
 
 ### Removed
 


### PR DESCRIPTION
Closes https://gitworkshop.dev/yukikishimoto.com/nostr/issues/note15lpmzye5hxqwwzqf3wsclx62djtdevt7dugruc08m0c3d43vls6sz6jhn2