### PR TITLE
sdk: remove all features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,6 @@ jobs:
           - nostr-keyring
           - nostr-keyring --features async
           - nostr-sdk
-          - nostr-sdk --features all-nips
-          - nostr-sdk --all-features
           - nostr-relay-builder
           - nostr-connect
           - nwc

--- a/contrib/scripts/check-crates.sh
+++ b/contrib/scripts/check-crates.sh
@@ -30,8 +30,6 @@ buildargs=(
     "-p nostr-keyring"
     "-p nostr-keyring --features async"
     "-p nostr-sdk"                                                # No default features
-    "-p nostr-sdk --features all-nips"                            # Only NIPs features
-    "-p nostr-sdk --all-features"                                 # All features
     "-p nostr-relay-builder"
     "-p nostr-connect"
     "-p nwc"

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -48,6 +48,7 @@
 - Remove `Client::handle_notifications` and `Relay_handle_notifications` (https://github.com/rust-nostr/nostr/pull/1245)
 - Remove `timeout` from `WebSocketTransport`
 - Remove `tor` feature (https://github.com/rust-nostr/nostr/pull/1253)
+- Remove `pow-multi-thread`, `all-nips`, `nip03`,`nip04`, `nip06`, `nip44`, `nip47`, `nip49`, `nip57`, `nip59`, `nip96` and `nip98`features (https://github.com/rust-nostr/nostr/pull/1254)
 
 ### Changed
 

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -15,21 +15,6 @@ keywords = ["nostr", "sdk"]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
-[features]
-default = []
-pow-multi-thread = ["nostr/pow-multi-thread"]
-all-nips = ["nostr/all-nips", "nip04", "nip06", "nip44", "nip47", "nip49", "nip57", "nip59", "nip96", "nip98"]
-nip03 = ["nostr/nip03"]
-nip04 = ["nostr/nip04"]
-nip06 = ["nostr/nip06"]
-nip44 = ["nostr/nip44"]
-nip47 = ["nostr/nip47"]
-nip49 = ["nostr/nip49"]
-nip57 = ["nostr/nip57"]
-nip59 = ["nostr/nip59"]
-nip96 = ["nostr/nip96"]
-nip98 = ["nostr/nip98"]
-
 [dependencies]
 async-utility.workspace = true
 async-wsocket = { workspace = true, features = ["socks"] }
@@ -45,6 +30,7 @@ tokio-stream = { version = "0.1", features = ["sync"] }
 tracing = { workspace = true, features = ["std"] }
 
 [dev-dependencies]
+nostr = { workspace = true, features = ["all-nips"] }
 nostr-connect.workspace = true
 nostr-lmdb.workspace = true
 nostr-ndb.workspace = true
@@ -70,18 +56,15 @@ name = "fetch-events"
 
 [[example]]
 name = "gossip"
-required-features = ["all-nips"]
 
 [[example]]
 name = "monitor"
 
 [[example]]
 name = "nostr-connect"
-required-features = ["nip59"]
 
 [[example]]
 name = "bot"
-required-features = ["all-nips"]
 
 [[example]]
 name = "nostrdb"
@@ -94,7 +77,6 @@ name = "subscriptions"
 
 [[example]]
 name = "tor"
-required-features = ["nip59"]
 
 [[example]]
 name = "lmdb"

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -77,23 +77,6 @@ AR="${LLVM_PATH}/bin/llvm-ar" CC="${LLVM_PATH}/bin/clang" cargo build --target w
 
 NOTE: Currently `nip03` feature not support WASM.
 
-## Crate Feature Flags
-
-The following crate feature flags are available:
-
-| Feature            | Default | Description                                                           |
-|--------------------|:-------:|-----------------------------------------------------------------------|
-| `pow-multi-thread` |   No    | Enable event POW mining using multi-threads                           |
-| `all-nips`         |   No    | Enable all NIPs                                                       |
-| `nip03`            |   No    | Enable NIP-03: OpenTimestamps Attestations for Events                 |
-| `nip04`            |   No    | Enable NIP-04: Encrypted Direct Message                               |
-| `nip06`            |   No    | Enable NIP-06: Basic key derivation from mnemonic seed phrase         |
-| `nip44`            |   No    | Enable NIP-44: Encrypted Payloads (Versioned)                         |
-| `nip47`            |   No    | Enable NIP-47: Nostr Wallet Connect                                   |
-| `nip49`            |   No    | Enable NIP-49: Private Key Encryption                                 |
-| `nip57`            |   No    | Enable NIP-57: Zaps                                                   |
-| `nip59`            |   No    | Enable NIP-59: Gift Wrap                                              |
-
 ## Changelog
 
 All notable changes to this library are documented in the [CHANGELOG.md](CHANGELOG.md).

--- a/sdk/src/client/error.rs
+++ b/sdk/src/client/error.rs
@@ -30,9 +30,6 @@ pub enum Error {
     EventBuilder(event::builder::Error),
     /// Json error
     Json(serde_json::Error),
-    /// NIP59
-    #[cfg(feature = "nip59")]
-    NIP59(nip59::Error),
     /// Signer not configured
     SignerNotConfigured,
     /// Gossip is not configured
@@ -56,8 +53,6 @@ impl fmt::Display for Error {
             Self::Gossip(e) => e.fmt(f),
             Self::EventBuilder(e) => e.fmt(f),
             Self::Json(e) => e.fmt(f),
-            #[cfg(feature = "nip59")]
-            Self::NIP59(e) => e.fmt(f),
             Self::SignerNotConfigured => f.write_str("signer not configured"),
             Self::GossipNotConfigured => f.write_str("gossip not configured"),
             Self::GossipFiltersEmpty => {
@@ -113,12 +108,5 @@ impl From<event::builder::Error> for Error {
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Self::Json(e)
-    }
-}
-
-#[cfg(feature = "nip59")]
-impl From<nip59::Error> for Error {
-    fn from(e: nip59::Error) -> Self {
-        Self::NIP59(e)
     }
 }


### PR DESCRIPTION
Remove `pow-multi-thread`, `all-nips`, `nip03`,`nip04`, `nip06`, `nip44`, `nip47`, `nip49`, `nip57`, `nip59`, `nip96` and `nip98`features.

These features were only re-exports of the corresponding features from the `nostr` crate and did not provide any additional functionality at the SDK level.

Who need these features can enable them directly on the `nostr` crate.