### PR TITLE
nostr: new MachineReadablePrefix::Custom variant

### DIFF
--- a/crates/nostr/CHANGELOG.md
+++ b/crates/nostr/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Add `rand` feature (https://github.com/rust-nostr/nostr/pull/1167)
 - Add `os-rng` feature (https://github.com/rust-nostr/nostr/pull/1171)
 - Replace `TryIntoUrl` trait with `RelayUrlArg` enum (https://github.com/rust-nostr/nostr/pull/1217)
+- Remove `Copy` trait from `MachineReadablePrefix` enum
 
 ### Changed
 
@@ -54,6 +55,7 @@
 - Add `Kind::BlossomServerList` variant (https://github.com/rust-nostr/nostr/pull/1195)
 - Add `EventBuilder::blossom_server_list` function (https://github.com/rust-nostr/nostr/pull/1195)
 - Add support for `nprofile` parsing in `PublicKey::from_bech32` (https://github.com/rust-nostr/nostr/pull/1248)
+- Add `MachineReadablePrefix::Custom` variant
 
 ### Removed
 

--- a/sdk/src/relay/inner.rs
+++ b/sdk/src/relay/inner.rs
@@ -1023,7 +1023,7 @@ impl InnerRelay {
                                 HandleClosedMsg::MarkAsClosed
                             }
                             Some(MachineReadablePrefix::Restricted) => HandleClosedMsg::Remove,
-                            None => {
+                            _ => {
                                 // Doesn't mach any prefix,
                                 // meaning that it probably closed without errors,
                                 // so remove it.


### PR DESCRIPTION
Related-to: #1257 

### Description

Create a new `SingleWord` struct that can hold either a single-word
static string slice (for constants) or a heap-allocated `String`.

- Remove the `Copy` trait from `MachineReadablePrefix` because `String`
does not implement it.
- Update `MachineReadablePrefix::parse` logic to properly handle the new
`Custom` variant.

### Notes to the reviewers

The `SingleWord::from_str` method is intended for use in constant
contexts, for example:

```rust
const PURGATORY_PREFIX: MachineReadablePrefix =
    MachineReadablePrefix::Custom(SingleWord::from_str("purgatory").unwrap());
```

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [x] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
