### PR TITLE
relay-builder: add prefix field to WritePolicyResult::Reject

### DIFF
--- a/crates/nostr-relay-builder/examples/policy.rs
+++ b/crates/nostr-relay-builder/examples/policy.rs
@@ -25,10 +25,7 @@ impl WritePolicy for AcceptKinds {
                 // Do nothing, keep processing the event
                 WritePolicyResult::Accept
             } else {
-                WritePolicyResult::reject(format!(
-                    "{}: kind not accepted",
-                    MachineReadablePrefix::Blocked
-                ))
+                WritePolicyResult::reject(MachineReadablePrefix::Blocked, "kind not accepted")
             }
         })
     }

--- a/crates/nostr-relay-builder/src/builder.rs
+++ b/crates/nostr-relay-builder/src/builder.rs
@@ -56,6 +56,8 @@ pub enum WritePolicyResult {
     Accept,
     /// Stop processing the event and reply with a OK message with a status.
     Reject {
+        /// The message prefix
+        prefix: MachineReadablePrefix,
         /// The rejection message to be sent.
         message: Cow<'static, str>,
         /// Indicates whether the operation was successful.
@@ -64,27 +66,29 @@ pub enum WritePolicyResult {
 }
 
 impl WritePolicyResult {
-    /// Stops processing and send a success message. Check [MachineReadablePrefix]
+    /// Stops processing and send a success message.
     #[inline]
-    pub fn ok_msg<S>(msg: S) -> Self
+    pub fn ok_msg<S>(prefix: MachineReadablePrefix, msg: S) -> Self
     where
         S: Into<Cow<'static, str>>,
     {
         Self::Reject {
             message: msg.into(),
             status: true,
+            prefix,
         }
     }
 
-    /// Stops processing and send a rejection message. Check [MachineReadablePrefix]
+    /// Stops processing and send a rejection message.
     #[inline]
-    pub fn reject<S>(msg: S) -> Self
+    pub fn reject<S>(prefix: MachineReadablePrefix, msg: S) -> Self
     where
         S: Into<Cow<'static, str>>,
     {
         Self::Reject {
             message: msg.into(),
             status: false,
+            prefix,
         }
     }
 }

--- a/crates/nostr-relay-builder/src/local/inner.rs
+++ b/crates/nostr-relay-builder/src/local/inner.rs
@@ -556,15 +556,18 @@ impl InnerLocalRelay {
 
                 // Check write policy
                 if let Some(policy) = self.write_policy.as_ref() {
-                    if let WritePolicyResult::Reject { message, status } =
-                        policy.admit_event(&event, addr).await
+                    if let WritePolicyResult::Reject {
+                        prefix,
+                        message,
+                        status,
+                    } = policy.admit_event(&event, addr).await
                     {
                         return send_msg(
                             ws_tx,
                             RelayMessage::Ok {
                                 event_id: event.id,
                                 status,
-                                message,
+                                message: Cow::Owned(format!("{prefix}: {message}")),
                             },
                         )
                         .await;


### PR DESCRIPTION
Fixes: https://github.com/rust-nostr/nostr/issues/1257
Related-to: https://github.com/rust-nostr/nostr/pull/1166

### Description

This adds a prefix to rejection messages, aligning with the same pattern used in `QueryPolicyResult`. The rejection format will be `{prefix}: {message}`.

### Notes to the reviewers

Changelog is not updated since `WritePolicyResult` is newly introduced and has not been part of any previous release.

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [ ] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
