### PR TITLE
ci: fix mismatched_lifetime_syntaxes warning

### DIFF
--- a/crates/nostr/src/event/mod.rs
+++ b/crates/nostr/src/event/mod.rs
@@ -259,7 +259,7 @@ impl Event {
     /// Get the coordinate of this event
     ///
     /// Return a coordinate only if the event kind is `replaceable` or `addressable`.
-    pub fn coordinate(&self) -> Option<CoordinateBorrow> {
+    pub fn coordinate(&self) -> Option<CoordinateBorrow<'_>> {
         if self.kind.is_replaceable() || self.kind.is_addressable() {
             return Some(CoordinateBorrow {
                 kind: &self.kind,

--- a/crates/nostr/src/event/tag/mod.rs
+++ b/crates/nostr/src/event/tag/mod.rs
@@ -134,7 +134,7 @@ impl Tag {
 
     /// Get tag kind
     #[inline]
-    pub fn kind(&self) -> TagKind {
+    pub fn kind(&self) -> TagKind<'_> {
         // SAFETY: `buf` must not be empty, checked during parsing.
         let key: &str = &self.buf[0];
         TagKind::from(key)

--- a/crates/nostr/src/event/tag/standard.rs
+++ b/crates/nostr/src/event/tag/standard.rs
@@ -608,7 +608,7 @@ impl TagStandard {
     }
 
     /// Get tag kind
-    pub fn kind(&self) -> TagKind {
+    pub fn kind(&self) -> TagKind<'_> {
         match self {
             Self::Event { uppercase, .. } => TagKind::SingleLetter(SingleLetterTag {
                 character: Alphabet::E,

--- a/crates/nostr/src/key/mod.rs
+++ b/crates/nostr/src/key/mod.rs
@@ -278,15 +278,15 @@ impl FromStr for Keys {
 
 #[cfg(all(feature = "std", feature = "os-rng"))]
 impl NostrSigner for Keys {
-    fn backend(&self) -> SignerBackend {
+    fn backend(&self) -> SignerBackend<'_> {
         SignerBackend::Keys
     }
 
-    fn get_public_key(&self) -> BoxedFuture<Result<PublicKey, SignerError>> {
+    fn get_public_key(&self) -> BoxedFuture<'_, Result<PublicKey, SignerError>> {
         Box::pin(async { Ok(self.public_key) })
     }
 
-    fn sign_event(&self, unsigned: UnsignedEvent) -> BoxedFuture<Result<Event, SignerError>> {
+    fn sign_event(&self, unsigned: UnsignedEvent) -> BoxedFuture<'_, Result<Event, SignerError>> {
         Box::pin(async { unsigned.sign_with_keys(self).map_err(SignerError::backend) })
     }
 

--- a/crates/nostr/src/nips/nip22.rs
+++ b/crates/nostr/src/nips/nip22.rs
@@ -221,16 +221,16 @@ impl<'e> From<&'e Event> for CommentTarget<'_> {
 }
 
 /// Extract NIP22 root target
-pub fn extract_root(event: &Event) -> Option<CommentTarget> {
+pub fn extract_root(event: &Event) -> Option<CommentTarget<'_>> {
     extract_data(event, true)
 }
 
 /// Extract NIP22 parent target
-pub fn extract_parent(event: &Event) -> Option<CommentTarget> {
+pub fn extract_parent(event: &Event) -> Option<CommentTarget<'_>> {
     extract_data(event, false)
 }
 
-fn extract_data(event: &Event, is_root: bool) -> Option<CommentTarget> {
+fn extract_data(event: &Event, is_root: bool) -> Option<CommentTarget<'_>> {
     if event.kind != Kind::Comment {
         return None;
     }

--- a/crates/nostr/src/signer.rs
+++ b/crates/nostr/src/signer.rs
@@ -100,13 +100,13 @@ pub enum SignerBackend<'a> {
 /// Nostr signer abstraction
 pub trait NostrSigner: Any + Debug + Send + Sync {
     /// Signer backend
-    fn backend(&self) -> SignerBackend;
+    fn backend(&self) -> SignerBackend<'_>;
 
     /// Get signer public key
-    fn get_public_key(&self) -> BoxedFuture<Result<PublicKey, SignerError>>;
+    fn get_public_key(&self) -> BoxedFuture<'_, Result<PublicKey, SignerError>>;
 
     /// Sign an unsigned event
-    fn sign_event(&self, unsigned: UnsignedEvent) -> BoxedFuture<Result<Event, SignerError>>;
+    fn sign_event(&self, unsigned: UnsignedEvent) -> BoxedFuture<'_, Result<Event, SignerError>>;
 
     /// NIP04 encrypt (deprecate and unsecure)
     fn nip04_encrypt<'a>(
@@ -139,17 +139,17 @@ pub trait NostrSigner: Any + Debug + Send + Sync {
 
 impl NostrSigner for Arc<dyn NostrSigner> {
     #[inline]
-    fn backend(&self) -> SignerBackend {
+    fn backend(&self) -> SignerBackend<'_> {
         self.as_ref().backend()
     }
 
     #[inline]
-    fn get_public_key(&self) -> BoxedFuture<Result<PublicKey, SignerError>> {
+    fn get_public_key(&self) -> BoxedFuture<'_, Result<PublicKey, SignerError>> {
         self.as_ref().get_public_key()
     }
 
     #[inline]
-    fn sign_event(&self, unsigned: UnsignedEvent) -> BoxedFuture<Result<Event, SignerError>> {
+    fn sign_event(&self, unsigned: UnsignedEvent) -> BoxedFuture<'_, Result<Event, SignerError>> {
         self.as_ref().sign_event(unsigned)
     }
 

--- a/database/nostr-database/src/ext.rs
+++ b/database/nostr-database/src/ext.rs
@@ -16,7 +16,7 @@ pub trait NostrDatabaseExt: NostrDatabase {
     fn metadata(
         &self,
         public_key: PublicKey,
-    ) -> BoxedFuture<Result<Option<Metadata>, DatabaseError>> {
+    ) -> BoxedFuture<'_, Result<Option<Metadata>, DatabaseError>> {
         Box::pin(async move {
             let filter = Filter::new()
                 .author(public_key)
@@ -36,7 +36,7 @@ pub trait NostrDatabaseExt: NostrDatabase {
     fn contacts_public_keys(
         &self,
         public_key: PublicKey,
-    ) -> BoxedFuture<Result<HashSet<PublicKey>, DatabaseError>> {
+    ) -> BoxedFuture<'_, Result<HashSet<PublicKey>, DatabaseError>> {
         Box::pin(async move {
             let filter = Filter::new()
                 .author(public_key)
@@ -54,7 +54,7 @@ pub trait NostrDatabaseExt: NostrDatabase {
     fn contacts(
         &self,
         public_key: PublicKey,
-    ) -> BoxedFuture<Result<BTreeSet<Profile>, DatabaseError>> {
+    ) -> BoxedFuture<'_, Result<BTreeSet<Profile>, DatabaseError>> {
         Box::pin(async move {
             let filter = Filter::new()
                 .author(public_key)
@@ -91,7 +91,10 @@ pub trait NostrDatabaseExt: NostrDatabase {
     /// Get relays list for [PublicKey]
     ///
     /// <https://github.com/nostr-protocol/nips/blob/master/65.md>
-    fn relay_list(&self, public_key: PublicKey) -> BoxedFuture<Result<RelaysMap, DatabaseError>> {
+    fn relay_list(
+        &self,
+        public_key: PublicKey,
+    ) -> BoxedFuture<'_, Result<RelaysMap, DatabaseError>> {
         Box::pin(async move {
             // Query
             let filter: Filter = Filter::default()

--- a/database/nostr-database/src/flatbuffers/event_generated.rs
+++ b/database/nostr-database/src/flatbuffers/event_generated.rs
@@ -554,7 +554,7 @@ pub mod event_fbs {
     /// catch every error, or be maximally performant. For the
     /// previous, unchecked, behavior use
     /// `root_as_event_unchecked`.
-    pub fn root_as_event(buf: &[u8]) -> Result<Event, flatbuffers::InvalidFlatbuffer> {
+    pub fn root_as_event(buf: &[u8]) -> Result<Event<'_>, flatbuffers::InvalidFlatbuffer> {
         flatbuffers::root::<Event>(buf)
     }
     #[inline]
@@ -566,7 +566,7 @@ pub mod event_fbs {
     /// `size_prefixed_root_as_event_unchecked`.
     pub fn size_prefixed_root_as_event(
         buf: &[u8],
-    ) -> Result<Event, flatbuffers::InvalidFlatbuffer> {
+    ) -> Result<Event<'_>, flatbuffers::InvalidFlatbuffer> {
         flatbuffers::size_prefixed_root::<Event>(buf)
     }
     #[inline]
@@ -599,14 +599,14 @@ pub mod event_fbs {
     /// Assumes, without verification, that a buffer of bytes contains a Event and returns it.
     /// # Safety
     /// Callers must trust the given bytes do indeed contain a valid `Event`.
-    pub unsafe fn root_as_event_unchecked(buf: &[u8]) -> Event {
+    pub unsafe fn root_as_event_unchecked(buf: &[u8]) -> Event<'_> {
         flatbuffers::root_unchecked::<Event>(buf)
     }
     #[inline]
     /// Assumes, without verification, that a buffer of bytes contains a size prefixed Event and returns it.
     /// # Safety
     /// Callers must trust the given bytes do indeed contain a valid size prefixed `Event`.
-    pub unsafe fn size_prefixed_root_as_event_unchecked(buf: &[u8]) -> Event {
+    pub unsafe fn size_prefixed_root_as_event_unchecked(buf: &[u8]) -> Event<'_> {
         flatbuffers::size_prefixed_root_unchecked::<Event>(buf)
     }
     #[inline]

--- a/database/nostr-database/src/lib.rs
+++ b/database/nostr-database/src/lib.rs
@@ -209,16 +209,16 @@ pub trait NostrDatabase: Any + Debug + Send + Sync {
     /// Count the number of events found with [`Filter`].
     ///
     /// Use `Filter::new()` or `Filter::default()` to count all events.
-    fn count(&self, filter: Filter) -> BoxedFuture<Result<usize, DatabaseError>>;
+    fn count(&self, filter: Filter) -> BoxedFuture<'_, Result<usize, DatabaseError>>;
 
     /// Query stored events.
-    fn query(&self, filter: Filter) -> BoxedFuture<Result<Events, DatabaseError>>;
+    fn query(&self, filter: Filter) -> BoxedFuture<'_, Result<Events, DatabaseError>>;
 
     /// Get `negentropy` items
     fn negentropy_items(
         &self,
         filter: Filter,
-    ) -> BoxedFuture<Result<Vec<(EventId, Timestamp)>, DatabaseError>> {
+    ) -> BoxedFuture<'_, Result<Vec<(EventId, Timestamp)>, DatabaseError>> {
         Box::pin(async move {
             let events: Events = self.query(filter).await?;
             Ok(events.into_iter().map(|e| (e.id, e.created_at)).collect())
@@ -226,8 +226,8 @@ pub trait NostrDatabase: Any + Debug + Send + Sync {
     }
 
     /// Delete all events that match the [Filter]
-    fn delete(&self, filter: Filter) -> BoxedFuture<Result<(), DatabaseError>>;
+    fn delete(&self, filter: Filter) -> BoxedFuture<'_, Result<(), DatabaseError>>;
 
     /// Wipe all data
-    fn wipe(&self) -> BoxedFuture<Result<(), DatabaseError>>;
+    fn wipe(&self) -> BoxedFuture<'_, Result<(), DatabaseError>>;
 }

--- a/database/nostr-lmdb/src/lib.rs
+++ b/database/nostr-lmdb/src/lib.rs
@@ -187,18 +187,18 @@ impl NostrDatabase for NostrLmdb {
         })
     }
 
-    fn count(&self, filter: Filter) -> BoxedFuture<Result<usize, DatabaseError>> {
+    fn count(&self, filter: Filter) -> BoxedFuture<'_, Result<usize, DatabaseError>> {
         Box::pin(async move { self.db.count(filter).await.map_err(DatabaseError::backend) })
     }
 
-    fn query(&self, filter: Filter) -> BoxedFuture<Result<Events, DatabaseError>> {
+    fn query(&self, filter: Filter) -> BoxedFuture<'_, Result<Events, DatabaseError>> {
         Box::pin(async move { self.db.query(filter).await.map_err(DatabaseError::backend) })
     }
 
     fn negentropy_items(
         &self,
         filter: Filter,
-    ) -> BoxedFuture<Result<Vec<(EventId, Timestamp)>, DatabaseError>> {
+    ) -> BoxedFuture<'_, Result<Vec<(EventId, Timestamp)>, DatabaseError>> {
         Box::pin(async move {
             self.db
                 .negentropy_items(filter)
@@ -207,12 +207,12 @@ impl NostrDatabase for NostrLmdb {
         })
     }
 
-    fn delete(&self, filter: Filter) -> BoxedFuture<Result<(), DatabaseError>> {
+    fn delete(&self, filter: Filter) -> BoxedFuture<'_, Result<(), DatabaseError>> {
         Box::pin(async move { self.db.delete(filter).await.map_err(DatabaseError::backend) })
     }
 
     #[inline]
-    fn wipe(&self) -> BoxedFuture<Result<(), DatabaseError>> {
+    fn wipe(&self) -> BoxedFuture<'_, Result<(), DatabaseError>> {
         Box::pin(async move { self.db.wipe().await.map_err(DatabaseError::backend) })
     }
 }

--- a/database/nostr-lmdb/src/store/lmdb/mod.rs
+++ b/database/nostr-lmdb/src/store/lmdb/mod.rs
@@ -287,7 +287,7 @@ impl Lmdb {
     ///
     /// This should never block the current thread
     #[inline]
-    pub(crate) fn read_txn(&self) -> Result<RoTxn, Error> {
+    pub(crate) fn read_txn(&self) -> Result<RoTxn<'_>, Error> {
         Ok(self.env.read_txn()?)
     }
 
@@ -295,7 +295,7 @@ impl Lmdb {
     ///
     /// This blocks the current thread if there is another write txn
     #[inline]
-    pub(crate) fn write_txn(&self) -> Result<RwTxn, Error> {
+    pub(crate) fn write_txn(&self) -> Result<RwTxn<'_>, Error> {
         Ok(self.env.write_txn()?)
     }
 

--- a/database/nostr-memory/src/lib.rs
+++ b/database/nostr-memory/src/lib.rs
@@ -112,14 +112,14 @@ impl NostrDatabase for MemoryDatabase {
         })
     }
 
-    fn count(&self, filter: Filter) -> BoxedFuture<Result<usize, DatabaseError>> {
+    fn count(&self, filter: Filter) -> BoxedFuture<'_, Result<usize, DatabaseError>> {
         Box::pin(async move {
             let store = self.store.read().await;
             Ok(store.count(filter))
         })
     }
 
-    fn query(&self, filter: Filter) -> BoxedFuture<Result<Events, DatabaseError>> {
+    fn query(&self, filter: Filter) -> BoxedFuture<'_, Result<Events, DatabaseError>> {
         Box::pin(async move {
             let store = self.store.read().await;
             let mut events = Events::new(&filter);
@@ -131,14 +131,14 @@ impl NostrDatabase for MemoryDatabase {
     fn negentropy_items(
         &self,
         filter: Filter,
-    ) -> BoxedFuture<Result<Vec<(EventId, Timestamp)>, DatabaseError>> {
+    ) -> BoxedFuture<'_, Result<Vec<(EventId, Timestamp)>, DatabaseError>> {
         Box::pin(async move {
             let store = self.store.read().await;
             Ok(store.negentropy_items(filter))
         })
     }
 
-    fn delete(&self, filter: Filter) -> BoxedFuture<Result<(), DatabaseError>> {
+    fn delete(&self, filter: Filter) -> BoxedFuture<'_, Result<(), DatabaseError>> {
         Box::pin(async move {
             let mut store = self.store.write().await;
             store.delete(filter);
@@ -146,7 +146,7 @@ impl NostrDatabase for MemoryDatabase {
         })
     }
 
-    fn wipe(&self) -> BoxedFuture<Result<(), DatabaseError>> {
+    fn wipe(&self) -> BoxedFuture<'_, Result<(), DatabaseError>> {
         Box::pin(async move {
             let mut store = self.store.write().await;
             store.clear();

--- a/database/nostr-memory/src/store.rs
+++ b/database/nostr-memory/src/store.rs
@@ -516,7 +516,7 @@ impl MemoryStore {
         })
     }
 
-    fn internal_query(&self, filter: Filter) -> InternalQueryResult {
+    fn internal_query(&self, filter: Filter) -> InternalQueryResult<'_> {
         if filter.is_empty() {
             return InternalQueryResult::All;
         }

--- a/database/nostr-ndb/src/lib.rs
+++ b/database/nostr-ndb/src/lib.rs
@@ -135,7 +135,7 @@ impl NostrDatabase for NdbDatabase {
         })
     }
 
-    fn count(&self, filter: Filter) -> BoxedFuture<Result<usize, DatabaseError>> {
+    fn count(&self, filter: Filter) -> BoxedFuture<'_, Result<usize, DatabaseError>> {
         Box::pin(async move {
             let txn: Transaction = Transaction::new(&self.db).map_err(DatabaseError::backend)?;
             let res: Vec<QueryResult> = ndb_query(&self.db, &txn, &filter)?;
@@ -143,7 +143,7 @@ impl NostrDatabase for NdbDatabase {
         })
     }
 
-    fn query(&self, filter: Filter) -> BoxedFuture<Result<Events, DatabaseError>> {
+    fn query(&self, filter: Filter) -> BoxedFuture<'_, Result<Events, DatabaseError>> {
         Box::pin(async move {
             let txn: Transaction = Transaction::new(&self.db).map_err(DatabaseError::backend)?;
             let mut events: Events = Events::new(&filter);
@@ -160,7 +160,7 @@ impl NostrDatabase for NdbDatabase {
     fn negentropy_items(
         &self,
         filter: Filter,
-    ) -> BoxedFuture<Result<Vec<(EventId, Timestamp)>, DatabaseError>> {
+    ) -> BoxedFuture<'_, Result<Vec<(EventId, Timestamp)>, DatabaseError>> {
         Box::pin(async move {
             let txn: Transaction = Transaction::new(&self.db).map_err(DatabaseError::backend)?;
             let res: Vec<QueryResult> = ndb_query(&self.db, &txn, &filter)?;
@@ -171,12 +171,12 @@ impl NostrDatabase for NdbDatabase {
         })
     }
 
-    fn delete(&self, _filter: Filter) -> BoxedFuture<Result<(), DatabaseError>> {
+    fn delete(&self, _filter: Filter) -> BoxedFuture<'_, Result<(), DatabaseError>> {
         Box::pin(async move { Err(DatabaseError::NotSupported) })
     }
 
     #[inline]
-    fn wipe(&self) -> BoxedFuture<Result<(), DatabaseError>> {
+    fn wipe(&self) -> BoxedFuture<'_, Result<(), DatabaseError>> {
         Box::pin(async move { Err(DatabaseError::NotSupported) })
     }
 }

--- a/database/nostr-sqlite/src/model.rs
+++ b/database/nostr-sqlite/src/model.rs
@@ -56,7 +56,7 @@ pub(crate) struct EventTagDb<'a> {
     pub tag_value: &'a str,
 }
 
-pub(crate) fn extract_tags(event: &Event) -> impl Iterator<Item = EventTagDb> {
+pub(crate) fn extract_tags(event: &Event) -> impl Iterator<Item = EventTagDb<'_>> {
     event.tags.iter().filter_map(|tag| {
         if let (Some(kind), Some(content)) = (tag.single_letter_tag(), tag.content()) {
             Some(EventTagDb {

--- a/database/nostr-sqlite/src/store.rs
+++ b/database/nostr-sqlite/src/store.rs
@@ -517,7 +517,7 @@ impl NostrDatabase for NostrSqlite {
         })
     }
 
-    fn count(&self, filter: Filter) -> BoxedFuture<Result<usize, DatabaseError>> {
+    fn count(&self, filter: Filter) -> BoxedFuture<'_, Result<usize, DatabaseError>> {
         Box::pin(async move {
             let filter = with_limit(filter, EVENTS_QUERY_LIMIT);
             self.pool
@@ -533,7 +533,7 @@ impl NostrDatabase for NostrSqlite {
         })
     }
 
-    fn query(&self, filter: Filter) -> BoxedFuture<Result<Events, DatabaseError>> {
+    fn query(&self, filter: Filter) -> BoxedFuture<'_, Result<Events, DatabaseError>> {
         Box::pin(async move {
             let filter = with_limit(filter, EVENTS_QUERY_LIMIT);
             self.pool
@@ -558,7 +558,7 @@ impl NostrDatabase for NostrSqlite {
 
     // TODO: impl negentropy_items deserializing only ids and timestamps
 
-    fn delete(&self, filter: Filter) -> BoxedFuture<Result<(), DatabaseError>> {
+    fn delete(&self, filter: Filter) -> BoxedFuture<'_, Result<(), DatabaseError>> {
         Box::pin(async move {
             self.pool
                 .interact(move |conn| {
@@ -571,7 +571,7 @@ impl NostrDatabase for NostrSqlite {
         })
     }
 
-    fn wipe(&self) -> BoxedFuture<Result<(), DatabaseError>> {
+    fn wipe(&self) -> BoxedFuture<'_, Result<(), DatabaseError>> {
         Box::pin(async move {
             self.pool
                 .interact(move |conn| {

--- a/gossip/nostr-gossip-memory/src/store.rs
+++ b/gossip/nostr-gossip-memory/src/store.rs
@@ -419,7 +419,7 @@ impl NostrGossip for NostrGossipMemory {
         &self,
         list: GossipListKind,
         limit: NonZeroUsize,
-    ) -> BoxedFuture<Result<BTreeSet<OutdatedPublicKey>, GossipError>> {
+    ) -> BoxedFuture<'_, Result<BTreeSet<OutdatedPublicKey>, GossipError>> {
         Box::pin(async move { Ok(self.collect_outdated_public_keys(list, limit).await) })
     }
 

--- a/gossip/nostr-gossip-sqlite/src/store.rs
+++ b/gossip/nostr-gossip-sqlite/src/store.rs
@@ -620,7 +620,7 @@ impl NostrGossip for NostrGossipSqlite {
         &self,
         list: GossipListKind,
         limit: NonZeroUsize,
-    ) -> BoxedFuture<Result<BTreeSet<OutdatedPublicKey>, GossipError>> {
+    ) -> BoxedFuture<'_, Result<BTreeSet<OutdatedPublicKey>, GossipError>> {
         Box::pin(async move {
             self.get_outdated_public_keys(list, limit)
                 .await

--- a/gossip/nostr-gossip/src/lib.rs
+++ b/gossip/nostr-gossip/src/lib.rs
@@ -224,7 +224,7 @@ pub trait NostrGossip: Any + Debug + Send + Sync {
         &self,
         list: GossipListKind,
         limit: NonZeroUsize,
-    ) -> BoxedFuture<Result<BTreeSet<OutdatedPublicKey>, GossipError>>;
+    ) -> BoxedFuture<'_, Result<BTreeSet<OutdatedPublicKey>, GossipError>>;
 
     /// Get the best relays for a [`PublicKey`].
     fn get_best_relays<'a>(

--- a/sdk/examples/change-signer.rs
+++ b/sdk/examples/change-signer.rs
@@ -33,18 +33,18 @@ impl MySignerSwitcher {
 }
 
 impl NostrSigner for MySignerSwitcher {
-    fn backend(&self) -> SignerBackend {
+    fn backend(&self) -> SignerBackend<'_> {
         SignerBackend::Custom(Cow::Borrowed("custom"))
     }
 
-    fn get_public_key(&self) -> BoxedFuture<Result<PublicKey, SignerError>> {
+    fn get_public_key(&self) -> BoxedFuture<'_, Result<PublicKey, SignerError>> {
         Box::pin(async move { self.get().await.get_public_key().await })
     }
 
     fn sign_event(
         &self,
         unsigned: UnsignedEvent,
-    ) -> BoxedFuture<std::result::Result<Event, SignerError>> {
+    ) -> BoxedFuture<'_, std::result::Result<Event, SignerError>> {
         Box::pin(async move { self.get().await.sign_event(unsigned).await })
     }
 

--- a/sdk/src/client/mod.rs
+++ b/sdk/src/client/mod.rs
@@ -259,7 +259,7 @@ impl Client {
     /// - [`GetRelays::with_capabilities`]: return relays matching specific
     ///   [`RelayCapabilities`]
     #[inline]
-    pub fn relays(&self) -> GetRelays {
+    pub fn relays(&self) -> GetRelays<'_> {
         GetRelays::new(self)
     }
 
@@ -515,7 +515,7 @@ impl Client {
     ///
     /// - [`Connect::and_wait`]: wait for relays connections at most for the specified `timeout`
     #[inline]
-    pub fn connect(&self) -> Connect {
+    pub fn connect(&self) -> Connect<'_> {
         Connect::new(self)
     }
 
@@ -562,7 +562,7 @@ impl Client {
     ///
     /// - [`TryConnect::timeout`]: set a maximum timeout
     #[inline]
-    pub fn try_connect(&self) -> TryConnect {
+    pub fn try_connect(&self) -> TryConnect<'_> {
         TryConnect::new(self)
     }
 
@@ -775,7 +775,7 @@ impl Client {
 
     /// Unsubscribe from all REQs
     #[inline]
-    pub fn unsubscribe_all(&self) -> UnsubscribeAll {
+    pub fn unsubscribe_all(&self) -> UnsubscribeAll<'_> {
         UnsubscribeAll::new(self)
     }
 

--- a/sdk/src/events_tracker.rs
+++ b/sdk/src/events_tracker.rs
@@ -70,26 +70,26 @@ impl NostrDatabase for MemoryEventsTracker {
         Box::pin(async move { Ok(None) })
     }
 
-    fn count(&self, _filter: Filter) -> BoxedFuture<Result<usize, DatabaseError>> {
+    fn count(&self, _filter: Filter) -> BoxedFuture<'_, Result<usize, DatabaseError>> {
         Box::pin(async move { Ok(0) })
     }
 
-    fn query(&self, filter: Filter) -> BoxedFuture<Result<Events, DatabaseError>> {
+    fn query(&self, filter: Filter) -> BoxedFuture<'_, Result<Events, DatabaseError>> {
         Box::pin(async move { Ok(Events::new(&filter)) })
     }
 
     fn negentropy_items(
         &self,
         _filter: Filter,
-    ) -> BoxedFuture<Result<Vec<(EventId, Timestamp)>, DatabaseError>> {
+    ) -> BoxedFuture<'_, Result<Vec<(EventId, Timestamp)>, DatabaseError>> {
         Box::pin(async move { Ok(Vec::new()) })
     }
 
-    fn delete(&self, _filter: Filter) -> BoxedFuture<Result<(), DatabaseError>> {
+    fn delete(&self, _filter: Filter) -> BoxedFuture<'_, Result<(), DatabaseError>> {
         Box::pin(async move { Err(DatabaseError::NotSupported) })
     }
 
-    fn wipe(&self) -> BoxedFuture<Result<(), DatabaseError>> {
+    fn wipe(&self) -> BoxedFuture<'_, Result<(), DatabaseError>> {
         Box::pin(async move {
             let mut seen_event_ids = self.tracker.write().await;
             seen_event_ids.clear();

--- a/sdk/src/relay/mod.rs
+++ b/sdk/src/relay/mod.rs
@@ -331,7 +331,7 @@ impl Relay {
     /// By default, in case of disconnection (after a first successful connection),
     /// the connection task will automatically attempt to reconnect.
     /// This behavior can be disabled by changing [`RelayOptions::reconnect`] option.
-    pub fn try_connect(&self) -> TryConnect {
+    pub fn try_connect(&self) -> TryConnect<'_> {
         TryConnect::new(self)
     }
 
@@ -369,7 +369,7 @@ impl Relay {
 
     /// Subscribe to filters
     #[inline]
-    pub fn subscribe<F>(&self, filters: F) -> Subscribe
+    pub fn subscribe<F>(&self, filters: F) -> Subscribe<'_>
     where
         F: Into<Vec<Filter>>,
     {
@@ -386,13 +386,13 @@ impl Relay {
 
     /// Unsubscribe from all subscriptions
     #[inline]
-    pub fn unsubscribe_all(&self) -> UnsubscribeAll {
+    pub fn unsubscribe_all(&self) -> UnsubscribeAll<'_> {
         UnsubscribeAll::new(self)
     }
 
     /// Stream events from relay
     #[inline]
-    pub fn stream_events<F>(&self, filters: F) -> StreamEvents
+    pub fn stream_events<F>(&self, filters: F) -> StreamEvents<'_>
     where
         F: Into<Vec<Filter>>,
     {
@@ -401,7 +401,7 @@ impl Relay {
 
     /// Fetch events
     #[inline]
-    pub fn fetch_events<F>(&self, filters: F) -> FetchEvents
+    pub fn fetch_events<F>(&self, filters: F) -> FetchEvents<'_>
     where
         F: Into<Vec<Filter>>,
     {
@@ -448,7 +448,7 @@ impl Relay {
 
     /// Sync events with relays (negentropy reconciliation)
     #[inline]
-    pub fn sync(&self, filter: Filter) -> SyncEvents {
+    pub fn sync(&self, filter: Filter) -> SyncEvents<'_> {
         SyncEvents::new(self, filter)
     }
 }

--- a/signer/nostr-browser-signer-proxy/src/lib.rs
+++ b/signer/nostr-browser-signer-proxy/src/lib.rs
@@ -459,17 +459,17 @@ impl BrowserSignerProxy {
 }
 
 impl NostrSigner for BrowserSignerProxy {
-    fn backend(&self) -> SignerBackend {
+    fn backend(&self) -> SignerBackend<'_> {
         SignerBackend::BrowserExtension
     }
 
     #[inline]
-    fn get_public_key(&self) -> BoxedFuture<Result<PublicKey, SignerError>> {
+    fn get_public_key(&self) -> BoxedFuture<'_, Result<PublicKey, SignerError>> {
         Box::pin(async move { self._get_public_key().await.map_err(SignerError::backend) })
     }
 
     #[inline]
-    fn sign_event(&self, unsigned: UnsignedEvent) -> BoxedFuture<Result<Event, SignerError>> {
+    fn sign_event(&self, unsigned: UnsignedEvent) -> BoxedFuture<'_, Result<Event, SignerError>> {
         Box::pin(async move {
             self._sign_event(unsigned)
                 .await

--- a/signer/nostr-browser-signer/src/lib.rs
+++ b/signer/nostr-browser-signer/src/lib.rs
@@ -257,11 +257,11 @@ impl NostrSigner for BrowserSigner {
         SignerBackend::BrowserExtension
     }
 
-    fn get_public_key(&self) -> BoxedFuture<Result<PublicKey, SignerError>> {
+    fn get_public_key(&self) -> BoxedFuture<'_, Result<PublicKey, SignerError>> {
         Box::pin(async move { self._get_public_key().await.map_err(SignerError::backend) })
     }
 
-    fn sign_event(&self, unsigned: UnsignedEvent) -> BoxedFuture<Result<Event, SignerError>> {
+    fn sign_event(&self, unsigned: UnsignedEvent) -> BoxedFuture<'_, Result<Event, SignerError>> {
         Box::pin(async move {
             self._sign_event(unsigned)
                 .await

--- a/signer/nostr-connect/examples/handle-auth-url.rs
+++ b/signer/nostr-connect/examples/handle-auth-url.rs
@@ -10,7 +10,7 @@ use nostr_connect::prelude::*;
 struct MyAuthUrlHandler;
 
 impl AuthUrlHandler for MyAuthUrlHandler {
-    fn on_auth_url(&self, auth_url: Url) -> BoxedFuture<Result<()>> {
+    fn on_auth_url(&self, auth_url: Url) -> BoxedFuture<'_, Result<()>> {
         Box::pin(async move {
             println!("Opening auth url: {auth_url}");
             webbrowser::open(auth_url.as_str())?;

--- a/signer/nostr-connect/src/client.rs
+++ b/signer/nostr-connect/src/client.rs
@@ -73,7 +73,7 @@ impl NostrConnect {
     /// struct MyAuthUrlHandler;
     ///
     /// impl AuthUrlHandler for MyAuthUrlHandler {
-    ///     fn on_auth_url(&self, auth_url: Url) -> BoxedFuture<Result<()>> {
+    ///     fn on_auth_url(&self, auth_url: Url) -> BoxedFuture<'_, Result<()>> {
     ///         Box::pin(async move {
     ///         webbrowser::open(auth_url.as_str())?;
     ///             Ok(())
@@ -139,7 +139,7 @@ impl NostrConnect {
         Ok(remote_signer_public_key)
     }
 
-    async fn subscribe(&self) -> Result<BoxStream<ClientNotification>, Error> {
+    async fn subscribe(&self) -> Result<BoxStream<'_, ClientNotification>, Error> {
         let public_key: PublicKey = self.client_keys.public_key();
 
         let filter = Filter::new()
@@ -407,7 +407,7 @@ async fn get_remote_signer_public_key(
 /// Nostr Connect auth_url handler
 pub trait AuthUrlHandler: fmt::Debug + Send + Sync {
     /// Handle `auth_url` message
-    fn on_auth_url(&self, auth_url: Url) -> BoxedFuture<Result<()>>;
+    fn on_auth_url(&self, auth_url: Url) -> BoxedFuture<'_, Result<()>>;
 }
 
 #[doc(hidden)]
@@ -425,11 +425,11 @@ where
 }
 
 impl NostrSigner for NostrConnect {
-    fn backend(&self) -> SignerBackend {
+    fn backend(&self) -> SignerBackend<'_> {
         SignerBackend::NostrConnect
     }
 
-    fn get_public_key(&self) -> BoxedFuture<Result<PublicKey, SignerError>> {
+    fn get_public_key(&self) -> BoxedFuture<'_, Result<PublicKey, SignerError>> {
         Box::pin(async move {
             self._get_public_key()
                 .await
@@ -438,7 +438,7 @@ impl NostrSigner for NostrConnect {
         })
     }
 
-    fn sign_event(&self, unsigned: UnsignedEvent) -> BoxedFuture<Result<Event, SignerError>> {
+    fn sign_event(&self, unsigned: UnsignedEvent) -> BoxedFuture<'_, Result<Event, SignerError>> {
         Box::pin(async move {
             self._sign_event(unsigned)
                 .await


### PR DESCRIPTION


### Description

This warning was introduced in compiler version 1.89.0. This PR just fix it.

