### PR TITLE
memory: option to disable nip09

### DIFF
--- a/database/nostr-memory/src/builder.rs
+++ b/database/nostr-memory/src/builder.rs
@@ -6,10 +6,14 @@ use crate::error::Error;
 use crate::MemoryDatabase;
 
 /// Memory Database Builder
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct MemoryDatabaseBuilder {
     /// Max number of events to store in memory. If None, there is no limit.
-    pub max_events: Option<NonZeroUsize>,
+    pub(crate) max_events: Option<NonZeroUsize>,
+    /// Whether to process event deletion request (NIP-09) events.
+    ///
+    /// Defaults to `true`
+    pub(crate) process_nip09: bool,
 }
 
 impl MemoryDatabaseBuilder {
@@ -22,9 +26,27 @@ impl MemoryDatabaseBuilder {
         self
     }
 
+    /// Whether to process event deletion request (NIP-09) events.
+    ///
+    /// Defaults to `true`
+    #[inline]
+    pub fn process_nip09(mut self, process_nip09: bool) -> Self {
+        self.process_nip09 = process_nip09;
+        self
+    }
+
     /// Build the in-memory database.
     #[inline]
     pub fn build(self) -> Result<MemoryDatabase, Error> {
         MemoryDatabase::from_builder(self)
+    }
+}
+
+impl Default for MemoryDatabaseBuilder {
+    fn default() -> Self {
+        Self {
+            max_events: None,
+            process_nip09: true,
+        }
     }
 }

--- a/database/nostr-memory/src/lib.rs
+++ b/database/nostr-memory/src/lib.rs
@@ -20,7 +20,7 @@ mod store;
 
 use self::builder::MemoryDatabaseBuilder;
 use self::error::Error;
-use self::store::{DatabaseEventResult, MemoryStore};
+use self::store::{DatabaseEventResult, MemoryOptions, MemoryStore};
 
 /// Memory Database (RAM)
 #[derive(Debug)]
@@ -48,14 +48,14 @@ impl MemoryDatabase {
     }
 
     // TODO: at the moment we are not using the Result, but will be needed in the future and we want to avoid breaking changes.
+    #[inline]
     fn from_builder(builder: MemoryDatabaseBuilder) -> Result<Self, Error> {
-        let store: MemoryStore = match builder.max_events {
-            Some(max) => MemoryStore::bounded(max),
-            None => MemoryStore::unbounded(),
-        };
+        let options = MemoryOptions::default()
+            .max_events(builder.max_events)
+            .process_nip09(builder.process_nip09);
 
         Ok(Self {
-            store: RwLock::new(store),
+            store: RwLock::new(MemoryStore::new(options)),
         })
     }
 }


### PR DESCRIPTION
Related-to: https://github.com/rust-nostr/nostr/issues/1261

### Description

an option to disable event deletion

### Notes to the reviewers

An internal struct called `MemoryOptions` like `LmdbOptions`

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [ ] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
