### PR TITLE
lmdb: move build options out of `LmdbOptions`

### DIFF
--- a/database/nostr-lmdb/src/store/ingester.rs
+++ b/database/nostr-lmdb/src/store/ingester.rs
@@ -374,17 +374,17 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
-    use crate::store::lmdb::LmdbOptions;
     use crate::store::Store;
+    use crate::NostrLmdbBuilder;
 
     async fn setup_test_store() -> (Arc<Store>, TempDir) {
         let temp_dir = TempDir::new().expect("Failed to create temp directory");
-        let lmdb_options = LmdbOptions::default()
+        let builder = NostrLmdbBuilder::new(temp_dir.path())
             .map_size(1024 * 1024 * 10)
             .max_readers(10)
             .additional_dbs(50);
 
-        let store = Store::open(temp_dir.path(), lmdb_options)
+        let store = Store::from_builder(builder)
             .await
             .expect("Failed to open test store");
         (Arc::new(store), temp_dir)


### PR DESCRIPTION
Related-to: https://github.com/rust-nostr/nostr/pull/1268
Related-to: https://github.com/rust-nostr/nostr/issues/1261

### Description

Moves build-specific options out of the `LmdbOptions` struct to simplify maintenance and clarify responsibilities. `LmdbOptions` is intended for runtime configuration, while build options are only required during database construction. This change eliminates redundant option definitions between the builder and the runtime struct.

### Notes to the reviewers

The change is internal and does not affect the public API.

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [ ] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
