### PR TITLE
sdk: include success message in output when sending events

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -53,6 +53,7 @@
 - Remove `EventBuilder::build_with_ctx` (https://github.com/rust-nostr/nostr/pull/1266)
 - Remove `Event::is_expired_with_supplier` (https://github.com/rust-nostr/nostr/pull/1266)
 - Remove `Timestamp::now_with_supplier` and `Timestamp::tweaked_with_supplier_and_rng` (https://github.com/rust-nostr/nostr/pull/1266)
+- Change the `Output.success` to be hash map that contains the relay success message (https://github.com/rust-nostr/nostr/pull/1273)
 
 ### Changed
 

--- a/sdk/examples/gossip.rs
+++ b/sdk/examples/gossip.rs
@@ -39,8 +39,8 @@ async fn main() -> Result<()> {
     println!("Event ID: {}", output.to_bech32()?);
 
     println!("Sent to:");
-    for url in output.success.into_iter() {
-        println!("- {url}");
+    for (url, message) in output.success.into_iter() {
+        println!("- {url} (OK message: {message:?})");
     }
 
     println!("Not sent to:");

--- a/sdk/src/client/api/output.rs
+++ b/sdk/src/client/api/output.rs
@@ -2,7 +2,7 @@
 // Copyright (c) 2023-2025 Rust Nostr Developers
 // Distributed under the MIT software license
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::fmt::Debug;
 use std::ops::{Deref, DerefMut};
 
@@ -18,8 +18,8 @@ where
 {
     /// Value
     pub val: T,
-    /// Set of relays that success
-    pub success: HashSet<RelayUrl>,
+    /// Set of relays that success, with success messages
+    pub success: HashMap<RelayUrl, Option<String>>,
     /// Map of relays that failed, with related errors.
     pub failed: HashMap<RelayUrl, String>,
 }
@@ -53,7 +53,7 @@ where
     pub fn new(val: T) -> Self {
         Self {
             val,
-            success: HashSet::new(),
+            success: HashMap::new(),
             failed: HashMap::new(),
         }
     }

--- a/sdk/src/client/api/send_event.rs
+++ b/sdk/src/client/api/send_event.rs
@@ -478,9 +478,9 @@ mod tests {
         let output = client.send_event(&event).await.unwrap();
 
         assert_eq!(output.success.len(), 2);
-        assert!(output.success.contains(&url1));
-        assert!(output.success.contains(&url2));
-        assert!(!output.success.contains(&url3));
+        assert!(output.success.keys().any(|url| url == &url1));
+        assert!(output.success.keys().any(|url| url == &url2));
+        assert!(output.success.keys().all(|url| url != &url3));
         assert!(output.failed.is_empty());
         assert_eq!(output.val, event.id);
     }
@@ -506,8 +506,8 @@ mod tests {
         let output = client.send_event(&event).to([&url1]).await.unwrap();
 
         assert_eq!(output.success.len(), 1);
-        assert!(output.success.contains(&url1));
-        assert!(!output.success.contains(&url2));
+        assert!(output.success.keys().any(|url| url == &url1));
+        assert!(output.success.keys().all(|url| url != &url2));
         assert!(output.failed.is_empty());
         assert_eq!(output.val, event.id);
     }
@@ -547,9 +547,9 @@ mod tests {
         let output = client.send_event(&event).broadcast().await.unwrap();
 
         assert_eq!(output.success.len(), 2);
-        assert!(output.success.contains(&url1));
-        assert!(output.success.contains(&url2));
-        assert!(!output.success.contains(&url3));
+        assert!(output.success.keys().any(|url| url == &url1));
+        assert!(output.success.keys().any(|url| url == &url2));
+        assert!(output.success.keys().all(|url| url != &url3));
         assert!(output.failed.is_empty());
         assert_eq!(output.val, event.id);
     }
@@ -628,9 +628,9 @@ mod tests {
 
         // Verify output
         assert_eq!(output.success.len(), 2);
-        assert!(output.success.contains(&outbox_url));
-        assert!(output.success.contains(&public_url));
-        assert!(!output.success.contains(&discovery_url));
+        assert!(output.success.keys().any(|url| url == &outbox_url));
+        assert!(output.success.keys().any(|url| url == &public_url));
+        assert!(output.success.keys().all(|url| url != &discovery_url));
         assert!(output.failed.is_empty());
         assert_eq!(output.val, event.id);
 
@@ -716,9 +716,9 @@ mod tests {
 
         // Should be sent ONLY to Bob's discovered inbox
         assert_eq!(output.success.len(), 1);
-        assert!(output.success.contains(&inbox_url));
-        assert!(!output.success.contains(&public_url));
-        assert!(!output.success.contains(&discovery_url));
+        assert!(output.success.keys().any(|url| url == &inbox_url));
+        assert!(output.success.keys().all(|url| url != &public_url));
+        assert!(output.success.keys().all(|url| url != &discovery_url));
         assert!(output.failed.is_empty());
         assert_eq!(output.val, event.id);
 

--- a/sdk/src/client/api/send_msg.rs
+++ b/sdk/src/client/api/send_msg.rs
@@ -146,9 +146,9 @@ mod tests {
         let output = client.send_msg(msg).await.unwrap();
 
         assert_eq!(output.success.len(), 2);
-        assert!(output.success.contains(&url1));
-        assert!(output.success.contains(&url2));
-        assert!(!output.success.contains(&url3));
+        assert!(output.success.keys().any(|url| url == &url1));
+        assert!(output.success.keys().any(|url| url == &url2));
+        assert!(output.success.keys().all(|url| url != &url3));
         assert!(output.failed.is_empty());
     }
 
@@ -170,8 +170,8 @@ mod tests {
         let output = client.send_msg(msg).to([&url1]).await.unwrap();
 
         assert_eq!(output.success.len(), 1);
-        assert!(output.success.contains(&url1));
-        assert!(!output.success.contains(&url2));
+        assert!(output.success.keys().any(|url| url == &url1));
+        assert!(output.success.keys().all(|url| url != &url2));
         assert!(output.failed.is_empty());
     }
 }

--- a/sdk/src/pool/mod.rs
+++ b/sdk/src/pool/mod.rs
@@ -305,7 +305,7 @@ impl RelayPool {
         for (url, result) in urls.into_iter().zip(list.into_iter()) {
             match result {
                 Ok(..) => {
-                    output.success.insert(url);
+                    output.success.insert(url, None);
                 }
                 Err(e) => {
                     output.failed.insert(url, e.to_string());
@@ -459,7 +459,7 @@ impl RelayPool {
             match result {
                 Ok(()) => {
                     // Success, insert relay url in 'success' set result
-                    output.success.insert(url);
+                    output.success.insert(url, None);
                 }
                 Err(e) => {
                     output.failed.insert(url, e.to_string());
@@ -522,12 +522,12 @@ impl RelayPool {
 
         while let Some((url, result)) = futures.next().await {
             match result {
-                Ok(id) => {
+                Ok((id, message)) => {
                     // The ID must match
                     assert_eq!(id, event.id);
 
                     // Success, insert relay url in 'success' set result
-                    output.success.insert(url);
+                    output.success.insert(url, message);
                 }
                 Err(e) => {
                     output.failed.insert(url, e.to_string());
@@ -589,7 +589,7 @@ impl RelayPool {
             match result {
                 Ok(..) => {
                     // Success, insert relay url in 'success' set result
-                    output.success.insert(url);
+                    output.success.insert(url, None);
                 }
                 Err(e) => {
                     output.failed.insert(url, e.to_string());
@@ -624,7 +624,7 @@ impl RelayPool {
             match result {
                 Ok(true) => {
                     // Success, insert relay url in 'success' set result
-                    output.success.insert(url.clone());
+                    output.success.insert(url.clone(), None);
                 }
                 // Subscription isn't found or auto-closing: do nothing
                 Ok(false) => {}
@@ -661,7 +661,7 @@ impl RelayPool {
             match result {
                 Ok(()) => {
                     // Success, insert relay url in 'success' set result
-                    output.success.insert(url);
+                    output.success.insert(url, None);
                 }
                 Err(e) => {
                     output.failed.insert(url, e.to_string());
@@ -714,7 +714,7 @@ impl RelayPool {
             match result {
                 Ok(reconciliation) => {
                     // Success, insert relay url in 'success' set result
-                    output.success.insert(url.clone());
+                    output.success.insert(url.clone(), None);
                     output.merge_relay_summary(url, reconciliation);
                 }
                 Err(e) => {

--- a/sdk/src/relay/api/send_event.rs
+++ b/sdk/src/relay/api/send_event.rs
@@ -107,7 +107,7 @@ impl<'relay, 'event> IntoFuture for SendEvent<'relay, 'event>
 where
     'event: 'relay,
 {
-    type Output = Result<EventId, Error>;
+    type Output = Result<(EventId, Option<String>), Error>;
     type IntoFuture = BoxedFuture<'relay, Self::Output>;
 
     fn into_future(self) -> Self::IntoFuture {
@@ -122,7 +122,7 @@ where
 
             // Check status
             if status {
-                return Ok(self.event.id);
+                return Ok((self.event.id, Some(message).filter(|s| !s.is_empty())));
             }
 
             // If auth required, wait for authentication adn resend it
@@ -145,7 +145,7 @@ where
 
                     // Check status
                     return if status {
-                        Ok(self.event.id)
+                        Ok((self.event.id, Some(message).filter(|s| !s.is_empty())))
                     } else {
                         Err(Error::RelayMessage(message))
                     };


### PR DESCRIPTION
In this PR, I changed the `Output.success` field to be a hash map that contains the relay URL and the success message if available. Now when sending an event, we can inspect the success message.

## Example

<details>
  <summary>Click to show</summary>

```rust
use nostr::{event::EventBuilder, key::Keys};
use nostr_relay_builder::{LocalRelayBuilder, builder::LocalRelayBuilderNip42};
use nostr_sdk::client::Client;

#[tokio::main]
async fn main() {
    let relay1 = LocalRelayBuilder::default().build().unwrap();
    let relay2 = LocalRelayBuilder::default()
        .nip42(LocalRelayBuilderNip42::default())
        .build()
        .unwrap();
    relay1.run().await.unwrap();
    relay2.run().await.unwrap();

    let relay_url1 = relay1.url().await;
    let relay_url2 = relay2.url().await;
    let client = Client::new();

    let keys = Keys::generate();
    let event = EventBuilder::text_note("GM")
        .build(keys.public_key)
        .sign_with_keys(&keys)
        .unwrap();

    client.add_relay(&relay_url1).await.unwrap();
    client.add_relay(&relay_url2).await.unwrap();
    client.connect().await;

    client.send_event(&event).await.unwrap();
    let output = client.send_event(&event).await.unwrap();
    dbg!(output);
}
```

Output:
```
[src/main.rs:31:5] output = Output {
    val: EventId(d4454817934aa0165e4278bf57e11078fe715c85aca1b8dbd938737f9fe3c83e),
    success: {
        RelayUrl(
            "ws://127.0.0.1:63654",
        ): Some(
            "duplicate: already have this event",
        ),
    },
    failed: {
        RelayUrl(
            "ws://127.0.0.1:16903",
        ): "auth-required: you must auth",
    },
}
```

</details>


### Notes to the reviewers

Hi @yukibtc. While I have concerns about these changes, I respect our agreement. However, I believe we should create a specialized output type just for `SendEvent`, since it uniquely receives relay success messages. This avoids affecting all other `Output` usages unnecessarily. I'll prepare a PR with this alternative approach, and you can decide which version to merge.

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
