### PR TITLE
sdk: enhance SendEvent output to include relay success message

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -53,6 +53,7 @@
 - Remove `EventBuilder::build_with_ctx` (https://github.com/rust-nostr/nostr/pull/1266)
 - Remove `Event::is_expired_with_supplier` (https://github.com/rust-nostr/nostr/pull/1266)
 - Remove `Timestamp::now_with_supplier` and `Timestamp::tweaked_with_supplier_and_rng` (https://github.com/rust-nostr/nostr/pull/1266)
+- Enhance `SendEvent` output to include relay success message (https://github.com/rust-nostr/nostr/pull/1274)
 
 ### Changed
 

--- a/sdk/examples/gossip.rs
+++ b/sdk/examples/gossip.rs
@@ -39,8 +39,8 @@ async fn main() -> Result<()> {
     println!("Event ID: {}", output.to_bech32()?);
 
     println!("Sent to:");
-    for url in output.success.into_iter() {
-        println!("- {url}");
+    for (url, message) in output.success.into_iter() {
+        println!("- {url} (OK message: {message:?})");
     }
 
     println!("Not sent to:");

--- a/sdk/src/client/api/output.rs
+++ b/sdk/src/client/api/output.rs
@@ -81,3 +81,46 @@ impl Output<SubscriptionId> {
         self.deref()
     }
 }
+
+/// Result of sending an event to relays.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SendEventOutput {
+    /// ID of the sent event.
+    pub event_id: EventId,
+    /// Relays that accepted the event, with an optional OK message.
+    pub success: HashMap<RelayUrl, Option<String>>,
+    /// Relays that rejected the event, with related errors.
+    pub failed: HashMap<RelayUrl, String>,
+}
+
+impl SendEventOutput {
+    /// Creates an empty result for the given event ID.
+    #[must_use]
+    pub fn new(event_id: EventId) -> Self {
+        Self {
+            event_id,
+            success: HashMap::new(),
+            failed: HashMap::new(),
+        }
+    }
+
+    /// Returns a reference to the event ID.
+    #[inline]
+    pub fn id(&self) -> &EventId {
+        &self.event_id
+    }
+}
+
+impl Deref for SendEventOutput {
+    type Target = EventId;
+
+    fn deref(&self) -> &Self::Target {
+        &self.event_id
+    }
+}
+
+impl DerefMut for SendEventOutput {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.event_id
+    }
+}

--- a/sdk/src/client/mod.rs
+++ b/sdk/src/client/mod.rs
@@ -1215,7 +1215,7 @@ impl Client {
         &self,
         urls: I,
         event: &Event,
-    ) -> Result<Output<EventId>, Error>
+    ) -> Result<SendEventOutput, Error>
     where
         I: IntoIterator<Item = U>,
         U: Into<RelayUrlArg<'a>>,
@@ -1240,7 +1240,7 @@ impl Client {
     pub async fn send_event_builder(
         &self,
         builder: EventBuilder,
-    ) -> Result<Output<EventId>, Error> {
+    ) -> Result<SendEventOutput, Error> {
         let event: Event = self.sign_event_builder(builder).await?;
         self.send_event(&event).await
     }
@@ -1253,7 +1253,7 @@ impl Client {
         &self,
         urls: I,
         builder: EventBuilder,
-    ) -> Result<Output<EventId>, Error>
+    ) -> Result<SendEventOutput, Error>
     where
         I: IntoIterator<Item = U>,
         U: Into<RelayUrlArg<'a>>,

--- a/sdk/src/relay/api/send_event.rs
+++ b/sdk/src/relay/api/send_event.rs
@@ -107,7 +107,7 @@ impl<'relay, 'event> IntoFuture for SendEvent<'relay, 'event>
 where
     'event: 'relay,
 {
-    type Output = Result<EventId, Error>;
+    type Output = Result<(EventId, Option<String>), Error>;
     type IntoFuture = BoxedFuture<'relay, Self::Output>;
 
     fn into_future(self) -> Self::IntoFuture {
@@ -122,7 +122,7 @@ where
 
             // Check status
             if status {
-                return Ok(self.event.id);
+                return Ok((self.event.id, Some(message).filter(|s| !s.is_empty())));
             }
 
             // If auth required, wait for authentication adn resend it
@@ -145,7 +145,7 @@ where
 
                     // Check status
                     return if status {
-                        Ok(self.event.id)
+                        Ok((self.event.id, Some(message).filter(|s| !s.is_empty())))
                     } else {
                         Err(Error::RelayMessage(message))
                     };


### PR DESCRIPTION
Change `SendEvent` future output type from `Output` to new `SendEventOutput`

This affects `Client::send_event`, `Client::send_event_builder` and `Client::send_event_builder_to`. The new type is similar to the previous `Output` but also contains the relay's success message when available.

This allows access to the relay's response message for sent events.

Related-to: #1273 

## Example

<details>
  <summary>Click to show</summary>

```rust
use nostr::{event::EventBuilder, key::Keys};
use nostr_relay_builder::{LocalRelayBuilder, builder::LocalRelayBuilderNip42};
use nostr_sdk::client::Client;

#[tokio::main]
async fn main() {
    let relay1 = LocalRelayBuilder::default().build().unwrap();
    let relay2 = LocalRelayBuilder::default()
        .nip42(LocalRelayBuilderNip42::default())
        .build()
        .unwrap();
    relay1.run().await.unwrap();
    relay2.run().await.unwrap();

    let relay_url1 = relay1.url().await;
    let relay_url2 = relay2.url().await;
    let client = Client::new();

    let keys = Keys::generate();
    let event = EventBuilder::text_note("GM")
        .build(keys.public_key)
        .sign_with_keys(&keys)
        .unwrap();

    client.add_relay(&relay_url1).await.unwrap();
    client.add_relay(&relay_url2).await.unwrap();
    client.connect().await;

    client.send_event(&event).await.unwrap();
    let output = client.send_event(&event).await.unwrap();
    dbg!(output);
}
```

Output:
```
[src/main.rs:31:5] output = SendEventOutput {
    val: EventId(d4454817934aa0165e4278bf57e11078fe715c85aca1b8dbd938737f9fe3c83e),
    success: {
        RelayUrl(
            "ws://127.0.0.1:63654",
        ): Some(
            "duplicate: already have this event",
        ),
    },
    failed: {
        RelayUrl(
            "ws://127.0.0.1:16903",
        ): "auth-required: you must auth",
    },
}
```

</details>

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
