### PR TITLE
relay-builder: add convenience constructors for `LocalRelayBuilderNip42`

### DIFF
--- a/crates/nostr-relay-builder/src/builder.rs
+++ b/crates/nostr-relay-builder/src/builder.rs
@@ -196,6 +196,32 @@ pub struct LocalRelayBuilderNip42 {
     // pub allowed: HashSet<PublicKey>,
 }
 
+impl LocalRelayBuilderNip42 {
+    /// Creates a new instance configured for write-only.
+    #[inline]
+    pub fn write() -> Self {
+        Self {
+            mode: LocalRelayBuilderNip42Mode::Write,
+        }
+    }
+
+    /// Creates a new instance configured for read-only.
+    #[inline]
+    pub fn read() -> Self {
+        Self {
+            mode: LocalRelayBuilderNip42Mode::Read,
+        }
+    }
+
+    /// Creates a new instance configured for both read and write.
+    #[inline]
+    pub fn read_and_write() -> Self {
+        Self {
+            mode: LocalRelayBuilderNip42Mode::Both,
+        }
+    }
+}
+
 #[allow(missing_docs)]
 #[deprecated(since = "0.45.0", note = "Use `LocalRelayBuilder` instead")]
 pub type RelayBuilder = LocalRelayBuilder;


### PR DESCRIPTION
This commit introduces three constructors for `LocalRelayBuilderNip42` to simplify its instantiation:
- `LocalRelayBuilderNip42::write`: Configures a write-only instance
- `LocalRelayBuilderNip42::read`: Configures a read-only instance
- `LocalRelayBuilderNip42::read_and_write`: Configures an instance with both read and write

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [ ] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
