### PR TITLE
nostr: add `RelayMetadata::{is_read, is_write}` functions

### DIFF
--- a/crates/nostr/CHANGELOG.md
+++ b/crates/nostr/CHANGELOG.md
@@ -31,7 +31,7 @@
 - Add `rand` feature (https://github.com/rust-nostr/nostr/pull/1167)
 - Add `os-rng` feature (https://github.com/rust-nostr/nostr/pull/1171)
 - Replace `TryIntoUrl` trait with `RelayUrlArg` enum (https://github.com/rust-nostr/nostr/pull/1217)
-- Remove `Copy` trait from `MachineReadablePrefix` enum
+- Remove `Copy` trait from `MachineReadablePrefix` enum (https://github.com/rust-nostr/nostr/pull/1258)
 
 ### Changed
 
@@ -58,7 +58,8 @@
 - Add `EventBuilder::blossom_server_list` function (https://github.com/rust-nostr/nostr/pull/1195)
 - Add support for `nprofile` parsing in `PublicKey::from_bech32` (https://github.com/rust-nostr/nostr/pull/1248)
 - Add support for `nevent` parsing in `EventId::from_bech32`
-- Add `MachineReadablePrefix::Custom` variant
+- Add `MachineReadablePrefix::Custom` variant (https://github.com/rust-nostr/nostr/pull/1258)
+- Add `RelayMetadata::{is_read, is_write}` functions (https://github.com/rust-nostr/nostr/pull/1290)
 
 ### Removed
 

--- a/crates/nostr/src/nips/nip65.rs
+++ b/crates/nostr/src/nips/nip65.rs
@@ -46,6 +46,18 @@ impl RelayMetadata {
             Self::Write => "write",
         }
     }
+
+    /// Check if is [RelayMetadata::Read]
+    #[inline]
+    pub fn is_read(&self) -> bool {
+        matches!(self, Self::Read)
+    }
+
+    /// Check if is [RelayMetadata::Write]
+    #[inline]
+    pub fn is_write(&self) -> bool {
+        matches!(self, Self::Write)
+    }
 }
 
 impl fmt::Display for RelayMetadata {


### PR DESCRIPTION
### Description

Just a helpful functions

### Notes to the reviewers

I added a missing PR URL in the CHANGELOG, I don't know how I missed it :)

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
