### PR TITLE
sdk: rename `AddRelay::add_connect` to `connect`

### DIFF
--- a/sdk/src/client/api/add.rs
+++ b/sdk/src/client/api/add.rs
@@ -129,7 +129,7 @@ impl<'client, 'url> AddRelay<'client, 'url> {
 
     /// Connect to the relay after adding it to the client
     #[inline]
-    pub fn and_connect(mut self) -> Self {
+    pub fn connect(mut self) -> Self {
         self.connect = true;
         self
     }

--- a/sdk/src/client/api/send_event.rs
+++ b/sdk/src/client/api/send_event.rs
@@ -301,7 +301,7 @@ async fn gossip_prepare_urls(
             client
                 .add_relay(url)
                 .capabilities(RelayCapabilities::GOSSIP)
-                .and_connect()
+                .connect()
                 .await?;
         }
 
@@ -354,7 +354,7 @@ async fn gossip_prepare_urls(
             client
                 .add_relay(url)
                 .capabilities(RelayCapabilities::GOSSIP)
-                .and_connect()
+                .connect()
                 .await?;
         }
 

--- a/sdk/src/client/api/stream_events.rs
+++ b/sdk/src/client/api/stream_events.rs
@@ -103,7 +103,7 @@ mod tests {
 
         let client = Client::default();
 
-        client.add_relay(&url).and_connect().await.unwrap();
+        client.add_relay(&url).connect().await.unwrap();
 
         let filter = Filter::new().kind(Kind::TextNote).limit(1);
         let id = SubscriptionId::generate();

--- a/sdk/src/client/gossip/updater.rs
+++ b/sdk/src/client/gossip/updater.rs
@@ -430,7 +430,7 @@ impl Client {
         for url in filters.keys() {
             self.add_relay(url)
                 .capabilities(RelayCapabilities::GOSSIP)
-                .and_connect()
+                .connect()
                 .await?;
         }
 

--- a/sdk/src/client/mod.rs
+++ b/sdk/src/client/mod.rs
@@ -1309,7 +1309,7 @@ mod tests {
         let relay: Relay = {
             let client: Client = Client::default();
 
-            client.add_relay(&url).and_connect().await.unwrap();
+            client.add_relay(&url).connect().await.unwrap();
 
             assert!(!client.is_shutdown());
 
@@ -1394,7 +1394,7 @@ mod tests {
 
         let client: Client = Client::default();
 
-        client.add_relay(&url).and_connect().await.unwrap();
+        client.add_relay(&url).connect().await.unwrap();
 
         // Shutdown after some time
         let c = client.clone();


### PR DESCRIPTION
I think `client.add_relay(&url).connect().await.unwrap();` is better than `client.add_relay(&url).and_connect().await.unwrap();`

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [ ] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
