### PR TITLE
nostr: add the kind number to the kind doc

### DIFF
--- a/crates/nostr/CHANGELOG.md
+++ b/crates/nostr/CHANGELOG.md
@@ -60,6 +60,7 @@
 - Add support for `nevent` parsing in `EventId::from_bech32`
 - Add `MachineReadablePrefix::Custom` variant (https://github.com/rust-nostr/nostr/pull/1258)
 - Add `RelayMetadata::{is_read, is_write}` functions (https://github.com/rust-nostr/nostr/pull/1290)
+- Add the kind number in the kind doc (https://github.com/rust-nostr/nostr/pull/1293)
 
 ### Removed
 

--- a/crates/nostr/src/event/kind.rs
+++ b/crates/nostr/src/event/kind.rs
@@ -35,7 +35,7 @@ macro_rules! kind_variants {
         #[derive(Debug, Clone, Copy)]
         pub enum Kind {
             $(
-                #[doc = $doc0]
+                #[doc = concat!($doc0, " (kind: ", stringify!($value), ")")]
                 #[doc = ""]
                 #[doc = $doc1]
                 $name,


### PR DESCRIPTION
### Description

as in the title :)

<img width="530" height="652" alt="image" src="https://github.com/user-attachments/assets/6dba5fae-cde6-431f-9f0b-78044e655789" />

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
