### PR TITLE
nostr: remove `kind` field in `CommentTarget::Coordinate` variant

### DIFF
--- a/crates/nostr/CHANGELOG.md
+++ b/crates/nostr/CHANGELOG.md
@@ -68,6 +68,7 @@
 - Remove `url-fork` dependency (https://github.com/rust-nostr/nostr/pull/1179)
 - Remove nip47 `multi_*` methods following spec cleanup (https://github.com/nostr-protocol/nips/pull/2210)
 - Remove `once_cell` dependency (https://github.com/rust-nostr/nostr/pull/1267)
+- Remove `kind` field in `CommentTarget::Coordinate` variant (https://github.com/rust-nostr/nostr/pull/1294)
 
 ### Fixed
 

--- a/crates/nostr/src/nips/nip22.rs
+++ b/crates/nostr/src/nips/nip22.rs
@@ -32,9 +32,6 @@ pub enum CommentTarget<'a> {
         address: Cow<'a, Coordinate>,
         /// Relay hint
         relay_hint: Option<Cow<'a, RelayUrl>>,
-        /// Kind
-        #[deprecated(since = "0.44.0", note = "Use `address.kind` instead")]
-        kind: Option<Kind>,
     },
     /// External content
     External {
@@ -71,8 +68,6 @@ impl<'a> CommentTarget<'a> {
         Self::Coordinate {
             address: coordinate,
             relay_hint,
-            #[allow(deprecated)]
-            kind: None,
         }
     }
 
@@ -98,9 +93,8 @@ impl<'a> CommentTarget<'a> {
                 relay_hint: Some(relay_hint),
             },
             #[allow(deprecated)]
-            Self::Coordinate { address, kind, .. } => Self::Coordinate {
+            Self::Coordinate { address, .. } => Self::Coordinate {
                 address,
-                kind,
                 relay_hint: Some(relay_hint),
             },
             _ => self,
@@ -261,8 +255,6 @@ fn extract_data(event: &Event, is_root: bool) -> Option<CommentTarget<'_>> {
         return Some(CommentTarget::Coordinate {
             address: Cow::Borrowed(address),
             relay_hint: relay_hint.map(Cow::Borrowed),
-            #[allow(deprecated)]
-            kind,
         });
     }
 


### PR DESCRIPTION
### Description

Remove `kind` field in `CommentTarget::Coordinate` variant, it deprecated in https://github.com/rust-nostr/nostr/pull/1035

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
