### PR TITLE
nostr: remove `Timestamp::as_u64`

### DIFF
--- a/crates/nostr/CHANGELOG.md
+++ b/crates/nostr/CHANGELOG.md
@@ -69,6 +69,7 @@
 - Remove nip47 `multi_*` methods following spec cleanup (https://github.com/nostr-protocol/nips/pull/2210)
 - Remove `once_cell` dependency (https://github.com/rust-nostr/nostr/pull/1267)
 - Remove `kind` field in `CommentTarget::Coordinate` variant (https://github.com/rust-nostr/nostr/pull/1294)
+- Remove `Timestamp::as_u64` (https://github.com/rust-nostr/nostr/pull/1295)
 
 ### Fixed
 

--- a/crates/nostr/src/types/time.rs
+++ b/crates/nostr/src/types/time.rs
@@ -115,12 +115,6 @@ impl Timestamp {
         self.0
     }
 
-    /// Get timestamp as [`u64`]
-    #[deprecated(since = "0.44.0", note = "Use `as_secs` instead")]
-    pub fn as_u64(&self) -> u64 {
-        self.as_secs()
-    }
-
     /// Check if timestamp is `0`
     #[inline]
     pub fn is_zero(&self) -> bool {


### PR DESCRIPTION
### Description

deprecated in https://github.com/rust-nostr/nostr/pull/1106

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
