### PR TITLE
nostr: remove `Nip19Event::from_event`

### DIFF
--- a/crates/nostr/CHANGELOG.md
+++ b/crates/nostr/CHANGELOG.md
@@ -70,6 +70,7 @@
 - Remove `once_cell` dependency (https://github.com/rust-nostr/nostr/pull/1267)
 - Remove `kind` field in `CommentTarget::Coordinate` variant (https://github.com/rust-nostr/nostr/pull/1294)
 - Remove `Timestamp::as_u64` (https://github.com/rust-nostr/nostr/pull/1295)
+- Remove `Nip19Event::from_event` (https://github.com/rust-nostr/nostr/pull/1296)
 
 ### Fixed
 

--- a/crates/nostr/src/nips/nip19.rs
+++ b/crates/nostr/src/nips/nip19.rs
@@ -410,12 +410,6 @@ impl Nip19Event {
         }
     }
 
-    /// Construct new NIP19 event from [`Event`].
-    #[deprecated(since = "0.44.0", note = "Use `from` instead.")]
-    pub fn from_event(event: &Event) -> Self {
-        Self::from(event)
-    }
-
     /// Add author
     #[inline]
     pub fn author(mut self, author: PublicKey) -> Self {


### PR DESCRIPTION
### Description

deprecated in 0688603ce9e9de60d85fb0d4f475751e2baa16a3

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
