### PR TITLE
sdk: box `RelayMessage` in `RelayNotification` and `ClientNotification`

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -53,6 +53,7 @@
 - Remove `EventBuilder::build_with_ctx` (https://github.com/rust-nostr/nostr/pull/1266)
 - Remove `Event::is_expired_with_supplier` (https://github.com/rust-nostr/nostr/pull/1266)
 - Remove `Timestamp::now_with_supplier` and `Timestamp::tweaked_with_supplier_and_rng` (https://github.com/rust-nostr/nostr/pull/1266)
+- Box `RelayMessage` in `RelayNotification` and `ClientNotification` (https://github.com/rust-nostr/nostr/pull/1299)
 
 ### Changed
 

--- a/sdk/src/client/notification.rs
+++ b/sdk/src/client/notification.rs
@@ -30,7 +30,7 @@ pub enum ClientNotification {
         /// The URL of the relay from which the message was received.
         relay_url: RelayUrl,
         /// The received relay message.
-        message: RelayMessage<'static>,
+        message: Box<RelayMessage<'static>>,
     },
     /// Shutdown
     ///

--- a/sdk/src/relay/api/sync.rs
+++ b/sdk/src/relay/api/sync.rs
@@ -348,7 +348,7 @@ pub(super) async fn sync(
 
         match notification {
             RelayNotification::Message { message } => {
-                let is_relevant: bool = match message {
+                let is_relevant: bool = match *message {
                     RelayMessage::NegMsg {
                         subscription_id,
                         message,
@@ -527,7 +527,7 @@ async fn check_negentropy_support(
     time::timeout(Some(opts.initial_timeout), async {
         while let Ok(notification) = temp_notifications.recv().await {
             if let RelayNotification::Message { message } = notification {
-                match message {
+                match *message {
                     RelayMessage::NegMsg {
                         subscription_id, ..
                     } => {

--- a/sdk/src/relay/inner.rs
+++ b/sdk/src/relay/inner.rs
@@ -1065,7 +1065,12 @@ impl InnerRelay {
                 }
 
                 // Send notification
-                self.send_notification(RelayNotification::Message { message }, true);
+                self.send_notification(
+                    RelayNotification::Message {
+                        message: Box::new(message),
+                    },
+                    true,
+                );
             }
             Ok(None) => (),
             Err(e) => tracing::error!(
@@ -1399,17 +1404,17 @@ impl InnerRelay {
         time::timeout(Some(timeout), async {
             while let Ok(notification) = notifications.recv().await {
                 match notification {
-                    RelayNotification::Message {
-                        message:
-                            RelayMessage::Ok {
-                                event_id,
-                                status,
-                                message,
-                            },
-                    } => {
-                        // Check if it can return
-                        if id == &event_id {
-                            return Ok((status, message.into_owned()));
+                    RelayNotification::Message { message } => {
+                        if let RelayMessage::Ok {
+                            event_id,
+                            status,
+                            message,
+                        } = *message
+                        {
+                            // Check if it can return
+                            if id == &event_id {
+                                return Ok((status, message.into_owned()));
+                            }
                         }
                     }
                     RelayNotification::RelayStatus { status } => {
@@ -1544,7 +1549,7 @@ impl InnerRelay {
                 }
 
                 match notification {
-                    RelayNotification::Message { message, .. } => match message {
+                    RelayNotification::Message { message, .. } => match *message {
                         RelayMessage::Event {
                             subscription_id,
                             event,
@@ -1681,22 +1686,22 @@ impl InnerRelay {
                 time::timeout(Some(duration), async {
                     while let Ok(notification) = notifications.recv().await {
                         match notification {
-                            RelayNotification::Message {
-                                message:
-                                    RelayMessage::Event {
-                                        subscription_id,
-                                        event,
-                                    },
-                            } => {
-                                if subscription_id.as_ref() == id {
-                                    // Send activity
-                                    if let Some(activity) = activity {
-                                        // TODO: handle error?
-                                        let _ = activity
-                                            .send(SubscriptionActivity::ReceivedEvent(
-                                                event.into_owned(),
-                                            ))
-                                            .await;
+                            RelayNotification::Message { message } => {
+                                if let RelayMessage::Event {
+                                    subscription_id,
+                                    event,
+                                } = *message
+                                {
+                                    if subscription_id.as_ref() == id {
+                                        // Send activity
+                                        if let Some(activity) = activity {
+                                            // TODO: handle error?
+                                            let _ = activity
+                                                .send(SubscriptionActivity::ReceivedEvent(
+                                                    event.into_owned(),
+                                                ))
+                                                .await;
+                                        }
                                     }
                                 }
                             }

--- a/sdk/src/relay/mod.rs
+++ b/sdk/src/relay/mod.rs
@@ -422,17 +422,16 @@ impl Relay {
         let mut notifications = self.inner.internal_notification_sender.subscribe();
         time::timeout(Some(timeout), async {
             while let Ok(notification) = notifications.recv().await {
-                if let RelayNotification::Message {
-                    message:
-                        RelayMessage::Count {
-                            subscription_id,
-                            count: c,
-                        },
-                } = notification
-                {
-                    if subscription_id.as_ref() == &id {
-                        count = c;
-                        break;
+                if let RelayNotification::Message { message } = notification {
+                    if let RelayMessage::Count {
+                        subscription_id,
+                        count: c,
+                    } = *message
+                    {
+                        if subscription_id.as_ref() == &id {
+                            count = c;
+                            break;
+                        }
                     }
                 }
             }

--- a/sdk/src/relay/notification.rs
+++ b/sdk/src/relay/notification.rs
@@ -15,7 +15,7 @@ pub enum RelayNotification {
     /// Received a [`RelayMessage`]. Includes messages wrapping events that were sent by this client.
     Message {
         /// Relay Message
-        message: RelayMessage<'static>,
+        message: Box<RelayMessage<'static>>,
     },
     /// Relay status changed
     RelayStatus {


### PR DESCRIPTION
### Description

The `RelayMessage` variant has a size of 248 bytes, which significantly inflates the size of the outer enums due to Rust's enum sizing rules (all variants must accommodate the largest variant).

By boxing `RelayMessage`, we reduce its inline footprint to 8 bytes (pointer size on 64-bit systems), decreasing overall memory usage and improving cache efficiency when working with collections of these notifications.

For example, when sending `ClientNotification` through our broadcast channel (default capacity 4096), the channel's total buffer size decreases from ~1376 KiB (4096 * 344 bytes) to ~512 KiB (4096 * 128 bytes).

This issue was reported by `clippy::large_enum_variant` lint.

### Notes to the reviewers

Since we cannot directly pattern match on a box, I used `if let` chains to match on the dereferenced message instead.

This also happens to be our first time using `if let` chains 🎉

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
