### PR TITLE
relay-builder: make the filter mutable in `QueryPolicy::admit_query`

### DIFF
--- a/crates/nostr-relay-builder/CHANGELOG.md
+++ b/crates/nostr-relay-builder/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Allow only a single `write` and `query` policy (https://github.com/rust-nostr/nostr/pull/1165)
 - Replace `PolicyResult` with `WritePolicyResult` and `QueryPolicyResult` (https://github.com/rust-nostr/nostr/pull/1166)
 - Remove `tor` feature (https://github.com/rust-nostr/nostr/pull/1253)
+- Make the filter mutable in `QueryPolicy::admit_query` (https://github.com/rust-nostr/nostr/pull/1302)
 
 ### Changes
 

--- a/crates/nostr-relay-builder/examples/policy.rs
+++ b/crates/nostr-relay-builder/examples/policy.rs
@@ -40,7 +40,7 @@ struct RejectAuthorLimit {
 impl QueryPolicy for RejectAuthorLimit {
     fn admit_query<'a>(
         &'a self,
-        query: &'a Filter,
+        query: &'a mut Filter,
         _addr: &'a SocketAddr,
     ) -> BoxedFuture<'a, QueryPolicyResult> {
         Box::pin(async move {

--- a/crates/nostr-relay-builder/src/builder.rs
+++ b/crates/nostr-relay-builder/src/builder.rs
@@ -158,7 +158,7 @@ pub trait QueryPolicy: fmt::Debug + Send + Sync {
     /// Check if the policy should accept a query
     fn admit_query<'a>(
         &'a self,
-        query: &'a Filter,
+        query: &'a mut Filter,
         addr: &'a SocketAddr,
     ) -> BoxedFuture<'a, QueryPolicyResult>;
 }

--- a/crates/nostr-relay-builder/src/local/inner.rs
+++ b/crates/nostr-relay-builder/src/local/inner.rs
@@ -900,7 +900,7 @@ impl InnerLocalRelay {
 
         // Check query policy
         if let Some(policy) = self.query_policy.as_ref() {
-            for filter in filters.iter() {
+            for filter in filters.iter_mut() {
                 if let QueryPolicyResult::Reject { prefix, message } =
                     policy.admit_query(filter, addr).await
                 {

--- a/crates/nostr-relay-builder/tests/plugins.rs
+++ b/crates/nostr-relay-builder/tests/plugins.rs
@@ -1,0 +1,72 @@
+// Copyright (c) 2022-2023 Yuki Kishimoto
+// Copyright (c) 2023-2025 Rust Nostr Developers
+// Distributed under the MIT software license
+
+use nostr::event::{EventBuilder, Tag};
+use nostr::filter::Filter;
+use nostr::key::Keys;
+use nostr::util::BoxedFuture;
+use nostr_memory::MemoryDatabase;
+use nostr_relay_builder::LocalRelay;
+use nostr_relay_builder::builder::{QueryPolicy, QueryPolicyResult};
+use nostr_sdk::client::Client;
+
+const UPDATE_TAG: &str = "updated";
+
+#[derive(Debug)]
+struct UpdateFilterPlugin;
+
+impl QueryPolicy for UpdateFilterPlugin {
+    fn admit_query<'a>(
+        &'a self,
+        query: &'a mut Filter,
+        _addr: &'a std::net::SocketAddr,
+    ) -> BoxedFuture<'a, QueryPolicyResult> {
+        Box::pin(async move {
+            *query = query.clone().hashtag(UPDATE_TAG);
+            QueryPolicyResult::Accept
+        })
+    }
+}
+
+#[tokio::test]
+async fn update_filter() {
+    let relay = LocalRelay::builder()
+        .database(MemoryDatabase::unbounded())
+        .query_policy(UpdateFilterPlugin)
+        .build();
+    relay.run().await.unwrap();
+
+    let keys = Keys::generate();
+    let client = Client::builder().signer(keys).build();
+
+    client
+        .add_relay(relay.url().await)
+        .and_connect()
+        .await
+        .unwrap();
+
+    // Event with our target tag
+    client
+        .send_event_builder(EventBuilder::text_note(":)").tag(Tag::hashtag(UPDATE_TAG)))
+        .await
+        .unwrap();
+
+    // This event has a random tag and should be filtered out in the REQ.
+    // It would only appear if the filter had not been updated correctly.
+    client
+        .send_event_builder(EventBuilder::text_note(":)").tag(Tag::hashtag("TEST")))
+        .await
+        .unwrap();
+
+    // Empty filter to get all events. It should be updated to have `UPDATE_TAG`
+    let events = client.fetch_events(Filter::new()).await.unwrap();
+
+    assert!(!events.is_empty(), "Should not be empty");
+    assert!(
+        events
+            .iter()
+            .all(|e| { e.tags.hashtags().all(|hashtag| hashtag == UPDATE_TAG) }),
+        "All tags should have the updated filter tag"
+    );
+}


### PR DESCRIPTION
Fixes: https://github.com/rust-nostr/nostr/issues/1301

### Description

Make the filter in `QueryPolicy::admit_query` mutable

### Notes to the reviewers

Some cool integration test. I'll work to have more later.

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
