### PR TITLE
contrib(coverage): install stable before `rust-cache`

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -22,23 +22,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - run: rustup toolchain install stable
+
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2.7.8
 
       - name: Install deps
         run: sudo apt update && sudo apt install -y libdbus-1-dev pkg-config
 
-      - name: Install stable toolchain
-        run: rustup toolchain install stable
-
       - name: Install cargo-llvm-cov
         run: cargo +stable install cargo-llvm-cov
 
       - name: Generate HTML coverage report
-        run: cargo llvm-cov --all-features --workspace --html
+        run: cargo +stable llvm-cov --all-features --workspace --html
 
       - name: Generate coverage data
-        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+        run: cargo +stable llvm-cov --all-features --workspace --lcov --output-path lcov.info
 
       - name: Upload artifact
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
### Description

ref: https://github.com/rust-nostr/nostr/pull/1303#discussion_r2989955097

### Notes to the reviewers

> ```yml
> # selecting a toolchain either by action or manual `rustup` calls should happen
> # before the plugin, as the cache uses the current rustc version as its cache key
> - run: rustup toolchain install stable --profile minimal
> ```
> https://github.com/Swatinem/rust-cache

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [ ] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
