### PR TITLE
perf: optimize event serialization

### DIFF
--- a/crates/nostr-relay-builder/src/local/inner.rs
+++ b/crates/nostr-relay-builder/src/local/inner.rs
@@ -332,7 +332,7 @@ impl InnerLocalRelay {
                                 if filter.match_event(&event, MatchEventOptions::new()) {
                                     send_msg(&mut tx, RelayMessage::Event{
                                         subscription_id: Cow::Borrowed(subscription_id),
-                                        event: Cow::Borrowed(&event)
+                                        event: Box::new(Cow::Borrowed(&event))
                                     }).await?;
 
                                     // Found a match, stop iterating the filters and continue with the next subscription
@@ -959,7 +959,7 @@ impl InnerLocalRelay {
             Some(
                 RelayMessage::Event {
                     subscription_id: Cow::Borrowed(subscription_id.as_ref()),
-                    event: Cow::Owned(event),
+                    event: Box::new(Cow::Owned(event)),
                 }
                 .as_json(),
             )

--- a/crates/nostr/src/event/builder.rs
+++ b/crates/nostr/src/event/builder.rs
@@ -4,6 +4,7 @@
 
 //! Event builder
 
+use alloc::boxed::Box;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use core::fmt;
@@ -1354,7 +1355,7 @@ impl EventBuilder {
         tags.extend_from_slice(&[
             Tag::event(job_request.id),
             Tag::public_key(job_request.pubkey),
-            Tag::from_standardized_without_cell(TagStandard::Request(job_request)),
+            Tag::from_standardized_without_cell(TagStandard::Request(Box::new(job_request))),
             Tag::from_standardized_without_cell(TagStandard::Amount { millisats, bolt11 }),
         ]);
 

--- a/crates/nostr/src/event/mod.rs
+++ b/crates/nostr/src/event/mod.rs
@@ -5,14 +5,17 @@
 
 //! Event
 
-use alloc::borrow::Cow;
-use alloc::string::String;
+use alloc::borrow::{Cow, ToOwned};
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
 use core::cmp::Ordering;
 use core::fmt;
 use core::hash::{Hash, Hasher};
+use core::str::FromStr;
 
 use secp256k1::schnorr::Signature;
 use secp256k1::{Message, Secp256k1, Verification};
+use serde::ser::SerializeStruct;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 pub mod borrow;
@@ -62,6 +65,9 @@ pub struct Event {
     pub content: String,
     /// Signature
     pub sig: Signature,
+    pub(crate) hex_id: Option<[u8; 64]>,
+    pub(crate) hex_pubkey: Option<[u8; 64]>,
+    pub(crate) hex_sig: Option<[u8; 128]>,
 }
 
 impl fmt::Debug for Event {
@@ -147,6 +153,9 @@ impl Event {
             tags: Tags::from_list(tags.into_iter().collect()),
             content: content.into(),
             sig,
+            hex_id: None,
+            hex_pubkey: None,
+            hex_sig: None,
         }
     }
 
@@ -300,8 +309,21 @@ impl TryFrom<&Event> for Metadata {
     }
 }
 
+/// Raw event to capture the incoming hex strings
+#[derive(Deserialize)]
+struct EventRaw<'a> {
+    pub id: Cow<'a, str>,
+    pub pubkey: Cow<'a, str>,
+    pub created_at: u64,
+    pub kind: u16,
+    pub tags: Vec<Vec<String>>,
+    pub content: Cow<'a, str>,
+    pub sig: Cow<'a, str>,
+}
+
 /// Struct used for de/serialization of [`Event`]
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Deserialize)]
+#[serde(from = "EventRaw<'a>", bound(deserialize = "'de: 'a"))]
 struct EventIntermediate<'a> {
     pub id: Cow<'a, EventId>,
     pub pubkey: Cow<'a, PublicKey>,
@@ -310,6 +332,82 @@ struct EventIntermediate<'a> {
     pub tags: Cow<'a, Tags>,
     pub content: Cow<'a, str>,
     pub sig: Cow<'a, Signature>,
+    #[serde(skip)]
+    pub hex_id: Option<[u8; 64]>,
+    #[serde(skip)]
+    pub hex_pubkey: Option<[u8; 64]>,
+    #[serde(skip)]
+    pub hex_sig: Option<[u8; 128]>,
+}
+
+impl<'a> From<EventRaw<'a>> for EventIntermediate<'a> {
+    fn from(raw: EventRaw<'a>) -> Self {
+        let mut hex_id = [0u8; 64];
+        let mut hex_pubkey = [0u8; 64];
+        let mut hex_sig = [0u8; 128];
+
+        hex_id.copy_from_slice(raw.id.as_bytes());
+        hex_pubkey.copy_from_slice(raw.pubkey.as_bytes());
+        hex_sig.copy_from_slice(raw.sig.as_bytes());
+
+        Self {
+            // Deserialize/Convert types here
+            id: Cow::Owned(EventId::from_hex(&raw.id).unwrap()),
+            pubkey: Cow::Owned(PublicKey::from_hex(&raw.pubkey).unwrap()),
+            created_at: Cow::Owned(Timestamp::from(raw.created_at)),
+            kind: Cow::Owned(Kind::from(raw.kind)),
+            tags: Cow::Owned(Tags::parse(&raw.tags).unwrap()),
+            content: raw.content,
+            sig: Cow::Owned(Signature::from_str(&raw.sig).unwrap()),
+            hex_id: Some(hex_id),
+            hex_pubkey: Some(hex_pubkey),
+            hex_sig: Some(hex_sig),
+        }
+    }
+}
+
+impl Serialize for EventIntermediate<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("Event", 7)?;
+
+        // 1. Serialize the hex fields as strings directly from our buffers
+        // We convert the [u8] hex bytes to a &str.
+        // This is safe because we only need the reference during this function call.
+        state.serialize_field(
+            "id",
+            &self
+                .hex_id
+                .map(|s| core::str::from_utf8(&s).unwrap().to_owned())
+                .unwrap_or_else(|| self.id.to_hex()),
+        )?;
+        state.serialize_field(
+            "pubkey",
+            &self
+                .hex_pubkey
+                .map(|s| core::str::from_utf8(&s).unwrap().to_owned())
+                .unwrap_or_else(|| self.pubkey.to_hex()),
+        )?;
+
+        // 2. Serialize the other fields normally
+        state.serialize_field("created_at", &self.created_at)?;
+        state.serialize_field("kind", &self.kind)?;
+        state.serialize_field("tags", &self.tags)?;
+        state.serialize_field("content", &self.content)?;
+
+        // 3. Serialize the signature hex
+        state.serialize_field(
+            "sig",
+            &self
+                .hex_sig
+                .map(|s| core::str::from_utf8(&s).unwrap().to_owned())
+                .unwrap_or_else(|| self.sig.to_string()),
+        )?;
+
+        state.end()
+    }
 }
 
 impl<'a> From<&'a Event> for EventIntermediate<'a> {
@@ -322,6 +420,9 @@ impl<'a> From<&'a Event> for EventIntermediate<'a> {
             tags: Cow::Borrowed(&e.tags),
             content: Cow::Borrowed(&e.content),
             sig: Cow::Borrowed(&e.sig),
+            hex_id: e.hex_id,
+            hex_pubkey: e.hex_pubkey,
+            hex_sig: e.hex_sig,
         }
     }
 }
@@ -351,6 +452,9 @@ impl<'de> Deserialize<'de> for Event {
             tags: inter.tags.into_owned(),
             content: inter.content.into_owned(),
             sig: inter.sig.into_owned(),
+            hex_id: inter.hex_id,
+            hex_pubkey: inter.hex_pubkey,
+            hex_sig: inter.hex_sig,
         })
     }
 }

--- a/crates/nostr/src/event/tag/standard.rs
+++ b/crates/nostr/src/event/tag/standard.rs
@@ -5,6 +5,7 @@
 //! Standardized tags
 
 use alloc::borrow::Cow;
+use alloc::boxed::Box;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use core::str::FromStr;
@@ -257,7 +258,7 @@ pub enum TagStandard {
         url: Url,
     },
     Encrypted,
-    Request(Event),
+    Request(Box<Event>),
     DataVendingMachineStatus {
         status: DataVendingMachineStatus,
         extra_info: Option<String>,
@@ -513,7 +514,7 @@ impl TagStandard {
                 #[cfg(feature = "nip98")]
                 TagKind::Method => Ok(Self::Method(HttpMethod::from_str(tag_1)?)),
                 TagKind::Payload => Ok(Self::Payload(Sha256Hash::from_str(tag_1)?)),
-                TagKind::Request => Ok(Self::Request(Event::from_json(tag_1)?)),
+                TagKind::Request => Ok(Self::Request(Box::new(Event::from_json(tag_1)?))),
                 TagKind::Word => Ok(Self::Word(tag_1.to_string())),
                 TagKind::Alt => Ok(Self::Alt(tag_1.to_string())),
                 TagKind::Dim => Ok(Self::Dim(ImageDimensions::from_str(tag_1)?)),

--- a/crates/nostr/src/message/relay.rs
+++ b/crates/nostr/src/message/relay.rs
@@ -6,6 +6,7 @@
 //! Relay messages
 
 use alloc::borrow::{Cow, ToOwned};
+use alloc::boxed::Box;
 use alloc::string::String;
 use alloc::vec::IntoIter;
 use core::fmt;
@@ -153,7 +154,7 @@ pub enum RelayMessage<'a> {
         /// Subscription ID
         subscription_id: Cow<'a, SubscriptionId>,
         /// Event
-        event: Cow<'a, Event>,
+        event: Box<Cow<'a, Event>>,
     },
     /// Ok
     ///
@@ -241,7 +242,7 @@ impl RelayMessage<'_> {
     pub fn event(subscription_id: SubscriptionId, event: Event) -> Self {
         Self::Event {
             subscription_id: Cow::Owned(subscription_id),
-            event: Cow::Owned(event),
+            event: Box::new(Cow::Owned(event)),
         }
     }
 

--- a/database/nostr-lmdb/src/store/ingester.rs
+++ b/database/nostr-lmdb/src/store/ingester.rs
@@ -95,7 +95,7 @@ enum IngesterOperation {
         tx: Option<oneshot::Sender<Result<(), Error>>>,
     },
     SaveEvent {
-        event: Event,
+        event: Box<Event>,
         tx: Option<oneshot::Sender<Result<SaveEventStatus, Error>>>,
     },
     Delete {
@@ -152,7 +152,7 @@ impl IngesterItem {
         let (tx, rx) = oneshot::channel();
         let item: Self = Self {
             operation: IngesterOperation::SaveEvent {
-                event,
+                event: Box::new(event),
                 tx: Some(tx),
             },
         };

--- a/database/nostr-ndb/src/lib.rs
+++ b/database/nostr-ndb/src/lib.rs
@@ -93,7 +93,7 @@ impl NostrDatabase for NdbDatabase {
         Box::pin(async move {
             let msg = RelayMessage::Event {
                 subscription_id: Cow::Owned(SubscriptionId::new("ndb")),
-                event: Cow::Borrowed(event),
+                event: Box::new(Cow::Borrowed(event)),
             };
             let json: String = msg.as_json();
             self.db

--- a/sdk/src/relay/api/stream_events.rs
+++ b/sdk/src/relay/api/stream_events.rs
@@ -136,7 +136,7 @@ impl Stream for SubscriptionActivityEventStream {
 
         match Pin::new(&mut self.rx).poll_recv(cx) {
             Poll::Ready(Some(activity)) => match activity {
-                SubscriptionActivity::ReceivedEvent(event) => Poll::Ready(Some(Ok(event))),
+                SubscriptionActivity::ReceivedEvent(event) => Poll::Ready(Some(Ok(*event))),
                 SubscriptionActivity::Closed(reason) => match reason {
                     SubscriptionAutoClosedReason::AuthenticationFailed => {
                         self.done = true;

--- a/sdk/src/relay/inner.rs
+++ b/sdk/src/relay/inner.rs
@@ -1267,7 +1267,7 @@ impl InnerRelay {
 
         Ok(Some(RelayMessage::Event {
             subscription_id: Cow::Owned(subscription_id),
-            event: Cow::Owned(event),
+            event: Box::new(Cow::Owned(event)),
         }))
     }
 
@@ -1559,9 +1559,9 @@ impl InnerRelay {
                                 if let Some(activity) = activity {
                                     // TODO: handle error?
                                     let _ = activity
-                                        .send(SubscriptionActivity::ReceivedEvent(
+                                        .send(SubscriptionActivity::ReceivedEvent(Box::new(
                                             event.into_owned(),
-                                        ))
+                                        )))
                                         .await;
                                 }
 
@@ -1698,7 +1698,7 @@ impl InnerRelay {
                                             // TODO: handle error?
                                             let _ = activity
                                                 .send(SubscriptionActivity::ReceivedEvent(
-                                                    event.into_owned(),
+                                                    Box::new(event.into_owned()),
                                                 ))
                                                 .await;
                                         }

--- a/sdk/src/relay/mod.rs
+++ b/sdk/src/relay/mod.rs
@@ -54,7 +54,7 @@ enum SubscriptionAutoClosedReason {
 #[derive(Debug)]
 enum SubscriptionActivity {
     /// Received an event
-    ReceivedEvent(Event),
+    ReceivedEvent(Box<Event>),
     /// Subscription closed
     Closed(SubscriptionAutoClosedReason),
 }


### PR DESCRIPTION
This PR optimizes event serialization performance by 76%. It trades memory for speed by storing the hex strings of event IDs, public keys, and signatures. During serialization, it directly uses these stored strings instead of recalculating them.

This change slightly increases deserialization time by approximately 10% (due to populating the cache), which is considered a worthwhile trade-off given the substantial serialization gains.





-- | -- |
--|--|
<img width="450" height="300" alt="image" src="https://github.com/user-attachments/assets/19e59acc-7b6a-4800-af1e-3e7bc9d29db0" />|<img width="450" height="300" alt="image" src="https://github.com/user-attachments/assets/7f2271f5-8c57-497a-821f-ec30d107d44d" />


Additional Statistics:
  | Lower bound | Estimate | Upper bound |  
-- | -- | -- | -- | --
Change in time | −76.089% | −75.940% | −75.799% | (p = 0.00 < 0.05)



### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [ ] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
