### PR TITLE
perf: optimize event serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -636,6 +636,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "faster-hex"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7223ae2d2f179b803433d9c830478527e92b8117eab39460edae7f1614d9fb73"
+dependencies = [
+ "heapless",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -870,6 +879,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -885,6 +903,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -1550,6 +1578,7 @@ dependencies = [
  "cbc",
  "chacha20",
  "chacha20poly1305",
+ "faster-hex",
  "hex",
  "nostr-ots",
  "rand 0.9.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ tokio = { version = ">=1.37", default-features = false }
 tracing = { version = "0.1", default-features = false }
 tracing-subscriber = "0.3"
 universal-time = { version = "0.3", default-features = false }
+faster-hex = { version = "0.10.0", default-features = false }
 
 [profile.release]
 lto = true

--- a/crates/nostr/CHANGELOG.md
+++ b/crates/nostr/CHANGELOG.md
@@ -78,6 +78,7 @@
 - Add `a` tag of replaceable and addressable events in `EventBuilder::repost` (https://github.com/rust-nostr/nostr/pull/1184)
 - Handle legacy events with `mention` marker (https://github.com/rust-nostr/nostr/pull/1193)
 - Parse "HEAD" as `TagKing::Head` (https://github.com/rust-nostr/nostr/pull/1215)
+- Optimize event serialization by ~73% (https://github.com/rust-nostr/nostr/pull/1313)
 
 ## v0.44.2 - 2025/12/04
 

--- a/crates/nostr/Cargo.toml
+++ b/crates/nostr/Cargo.toml
@@ -86,6 +86,7 @@ serde_json.workspace = true
 unicode-normalization = { version = "0.1", default-features = false, optional = true }
 universal-time.workspace = true
 url = { version = "2.5", default-features = false, features = ["serde"] }
+faster-hex.workspace = true
 
 [dev-dependencies]
 reqwest = { workspace = true, features = ["rustls-tls"] }

--- a/crates/nostr/src/event/id.rs
+++ b/crates/nostr/src/event/id.rs
@@ -121,7 +121,16 @@ impl EventId {
     /// Get as hex string
     #[inline]
     pub fn to_hex(&self) -> String {
-        hex::encode(self.as_bytes())
+        // SAFETY: hex is a valid UTF-8
+        alloc::string::String::from_utf8(self.to_hex_slice().to_vec()).unwrap()
+    }
+
+    /// Get as hex slice
+    #[inline]
+    pub fn to_hex_slice(&self) -> [u8; Self::LEN * 2] {
+        let mut buf = [0u8; Self::LEN * 2];
+        faster_hex::hex_encode(&self.0, &mut buf).expect("Buffer size is correct");
+        buf
     }
 
     /// Check POW

--- a/crates/nostr/src/event/mod.rs
+++ b/crates/nostr/src/event/mod.rs
@@ -11,6 +11,7 @@ use core::cmp::Ordering;
 use core::fmt;
 use core::hash::{Hash, Hasher};
 
+use secp256k1::constants::SCHNORR_SIGNATURE_SIZE;
 use secp256k1::schnorr::Signature;
 use secp256k1::{Message, Secp256k1, Verification};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -300,15 +301,37 @@ impl TryFrom<&Event> for Metadata {
     }
 }
 
+#[inline]
+fn serialize_event_id<S: Serializer>(event_id: &EventId, s: S) -> Result<S::Ok, S::Error> {
+    s.serialize_str(core::str::from_utf8(&event_id.to_hex_slice()).unwrap())
+}
+
+#[inline]
+fn serialize_pubkey<S: Serializer>(pubkey: &PublicKey, s: S) -> Result<S::Ok, S::Error> {
+    s.serialize_str(core::str::from_utf8(&pubkey.to_hex_slice()).unwrap())
+}
+
+#[inline]
+fn serialize_sig<S: Serializer>(sig: &Signature, s: S) -> Result<S::Ok, S::Error> {
+    let mut hex_buf = [0u8; SCHNORR_SIGNATURE_SIZE * 2];
+    let hex_str = faster_hex::hex_encode(&Signature::serialize(sig), &mut hex_buf)
+        .expect("Buffer size is correct");
+
+    s.serialize_str(hex_str)
+}
+
 /// Struct used for de/serialization of [`Event`]
 #[derive(Serialize, Deserialize)]
 struct EventIntermediate<'a> {
+    #[serde(serialize_with = "serialize_event_id")]
     pub id: Cow<'a, EventId>,
+    #[serde(serialize_with = "serialize_pubkey")]
     pub pubkey: Cow<'a, PublicKey>,
     pub created_at: Cow<'a, Timestamp>,
     pub kind: Cow<'a, Kind>,
     pub tags: Cow<'a, Tags>,
     pub content: Cow<'a, str>,
+    #[serde(serialize_with = "serialize_sig")]
     pub sig: Cow<'a, Signature>,
 }
 

--- a/crates/nostr/src/key/public_key.rs
+++ b/crates/nostr/src/key/public_key.rs
@@ -134,7 +134,16 @@ impl PublicKey {
     /// Get public key as `hex` string
     #[inline]
     pub fn to_hex(&self) -> String {
-        hex::encode(self.as_bytes())
+        // SAFETY: hex is a valid UTF-8
+        alloc::string::String::from_utf8(self.to_hex_slice().to_vec()).unwrap()
+    }
+
+    /// Get public key as `hex` slice
+    #[inline]
+    pub fn to_hex_slice(&self) -> [u8; Self::LEN * 2] {
+        let mut buf = [0u8; Self::LEN * 2];
+        faster_hex::hex_encode(&self.buf, &mut buf).expect("Buffer size is correct");
+        buf
     }
 
     /// Get as bytes


### PR DESCRIPTION
This PR optimizes event serialization by ~73% by using `faster_hex` to compute the event ID, public key, and signature. It also writes the computed hex to the stack instead of the heap to reduce allocations.

Note:
This commit focuses on event serialization and does not change the hex implementation itself, which will be addressed in a subsequent PR.

benchmarks:
|      Benchmark      |  Before   |   After   |  Change  |
| :------------------ |  :-----   |   :----   |  :-----  |
| `serialize_event`   | 1.1584 µs | 310.87 ns | −73.241% |
| `deserialize_event` | 661.08 ns | 620.49 ns | −5.7141% |

|      --      |  --   | 
| :------------------ |  :-----   |
| <img width="450" height="300" alt="image" src="https://github.com/user-attachments/assets/7f3a951f-cc32-489e-bae0-cf8961a3c519" />  | <img width="450" height="300" alt="image" src="https://github.com/user-attachments/assets/143e7191-6d39-4249-ab83-1fc86fb25c1f" /> |

> Understanding this report:
> The plot on the left shows the probability of the function taking a certain amount of time. The red curve represents the saved measurements from the last time this benchmark was run, while the blue curve shows the measurements from this run. The lines represent the mean time per iteration.

> The plot on the right shows the two regressions. Again, the red line represents the previous measurement while the blue line shows the current measurement.

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
