### PR TITLE
nostr: extract PoW mining into `PowAdapter` trait

### DIFF
--- a/crates/nostr-relay-builder/src/local/inner.rs
+++ b/crates/nostr-relay-builder/src/local/inner.rs
@@ -929,7 +929,11 @@ impl InnerLocalRelay {
             let keys = Keys::generate();
 
             for _ in 0..500 {
-                events.insert(EventBuilder::text_note("Test").sign_with_keys(&keys)?);
+                events.insert(
+                    EventBuilder::text_note("Test")
+                        .sign_with_keys(&keys)
+                        .await?,
+                );
             }
 
             events

--- a/crates/nostr/CHANGELOG.md
+++ b/crates/nostr/CHANGELOG.md
@@ -32,6 +32,12 @@
 - Add `os-rng` feature (https://github.com/rust-nostr/nostr/pull/1171)
 - Replace `TryIntoUrl` trait with `RelayUrlArg` enum (https://github.com/rust-nostr/nostr/pull/1217)
 - Remove `Copy` trait from `MachineReadablePrefix` enum (https://github.com/rust-nostr/nostr/pull/1258)
+- Make `EventBuilder::build` async to support asynchronous PoW computation (https://github.com/rust-nostr/nostr/pull/1314)
+- Propagate `async` to the following functions to accommodate the `EventBuilder::build` refactor (https://github.com/rust-nostr/nostr/pull/1314):
+  - `sign_with_keys` and `sign_with_ctx`
+  - `gift_wrap_from_seal`
+  - `nip47::Request::to_event`
+  - `anonymous_zap_request`, `private_zap_request`, and `private_zap_request_with_ctx`
 
 ### Changed
 
@@ -43,6 +49,7 @@
 - Make `Kind::from_u16` and `Kind::as_u16` const (https://github.com/rust-nostr/nostr/pull/1136)
 - Bump MSRV to 1.85.0 (https://github.com/rust-nostr/nostr/pull/1267)
 - `RelayUrl::is_local_addr` now works on `no_std` builds (https://github.com/rust-nostr/nostr/pull/1267)
+- Refactor NIP-13 PoW mining logic to utilize the new adapter pattern (https://github.com/rust-nostr/nostr/pull/1314)
 
 ### Added
 
@@ -61,6 +68,11 @@
 - Add `MachineReadablePrefix::Custom` variant (https://github.com/rust-nostr/nostr/pull/1258)
 - Add `RelayMetadata::{is_read, is_write}` functions (https://github.com/rust-nostr/nostr/pull/1290)
 - Add the kind number in the kind doc (https://github.com/rust-nostr/nostr/pull/1293)
+- Add `PowAdapter` trait for custom Proof of Work computation (https://github.com/rust-nostr/nostr/pull/1314)
+- Add `SingleThreadPow` and `MultiThreadPow` structs (https://github.com/rust-nostr/nostr/pull/1314)
+- Add `EventBuilder::pow_adapter` to set a custom PoW adapter (https://github.com/rust-nostr/nostr/pull/1314)
+- Expose `EventId::compute_id` as public API for mining (https://github.com/rust-nostr/nostr/pull/1314)
+- Impl `Index<usize>` and `IndexMut<usize>` for `Tags` (https://github.com/rust-nostr/nostr/pull/1314)
 
 ### Removed
 
@@ -71,6 +83,7 @@
 - Remove `kind` field in `CommentTarget::Coordinate` variant (https://github.com/rust-nostr/nostr/pull/1294)
 - Remove `Timestamp::as_u64` (https://github.com/rust-nostr/nostr/pull/1295)
 - Remove `Nip19Event::from_event` (https://github.com/rust-nostr/nostr/pull/1296)
+- Remove `Clone`, `Eq`, `PartialEq`, and `Hash` impls from `EventBuilder` (https://github.com/rust-nostr/nostr/pull/1314)
 
 ### Fixed
 

--- a/crates/nostr/README.md
+++ b/crates/nostr/README.md
@@ -20,7 +20,8 @@ You may be interested in:
 ```rust,no_run
 use nostr::prelude::*;
 
-fn main() -> Result<()> {
+#[tokio::main]
+async fn main() -> Result<()> {
     // Generate new random keys
     let keys = Keys::generate();
 
@@ -40,13 +41,20 @@ fn main() -> Result<()> {
         .lud16("pay@yukikishimoto.com")
         .custom_field("custom_field", "my value");
 
-    let event: Event = EventBuilder::metadata(&metadata).sign_with_keys(&keys)?;
+    let event: Event = EventBuilder::metadata(&metadata)
+        .sign_with_keys(&keys)
+        .await?;
 
     // New text note
-    let event: Event = EventBuilder::text_note("Hello from rust-nostr").sign_with_keys(&keys)?;
+    let event: Event = EventBuilder::text_note("Hello from rust-nostr")
+        .sign_with_keys(&keys)
+        .await?;
 
     // New POW text note
-    let event: Event = EventBuilder::text_note("POW text note from rust-nostr").pow(20).sign_with_keys(&keys)?;
+    let event: Event = EventBuilder::text_note("POW text note from rust-nostr")
+        .pow(20)
+        .sign_with_keys(&keys)
+        .await?;
 
     // Convert client message to JSON
     let json = ClientMessage::event(event).as_json();

--- a/crates/nostr/examples/nip09.rs
+++ b/crates/nostr/examples/nip09.rs
@@ -4,7 +4,8 @@
 
 use nostr::prelude::*;
 
-fn main() -> Result<()> {
+#[tokio::main]
+async fn main() -> Result<()> {
     let keys = Keys::parse("nsec1ufnus6pju578ste3v90xd5m2decpuzpql2295m3sknqcjzyys9ls0qlc85")?;
 
     let event_id =
@@ -14,7 +15,7 @@ fn main() -> Result<()> {
         .id(event_id)
         .reason("these posts were published by accident");
 
-    let event: Event = EventBuilder::delete(request).sign_with_keys(&keys)?;
+    let event: Event = EventBuilder::delete(request).sign_with_keys(&keys).await?;
     println!("{}", event.as_json());
 
     Ok(())

--- a/crates/nostr/examples/nip13.rs
+++ b/crates/nostr/examples/nip13.rs
@@ -4,7 +4,8 @@
 
 use nostr::prelude::*;
 
-fn main() -> Result<()> {
+#[tokio::main]
+async fn main() -> Result<()> {
     let keys = Keys::parse("6b911fd37cdf5c81d4c0adb1ab7fa822ed253ab0ad9aa18d77257c88b29b718e")?;
 
     let difficulty = 20; // leading zero bits
@@ -12,7 +13,8 @@ fn main() -> Result<()> {
 
     let event: Event = EventBuilder::text_note(msg_content)
         .pow(difficulty)
-        .sign_with_keys(&keys)?;
+        .sign_with_keys(&keys)
+        .await?;
 
     println!("{}", event.as_json());
 

--- a/crates/nostr/examples/nip15.rs
+++ b/crates/nostr/examples/nip15.rs
@@ -4,7 +4,8 @@
 
 use nostr::prelude::*;
 
-fn main() -> Result<()> {
+#[tokio::main]
+async fn main() -> Result<()> {
     let keys = Keys::parse("6b911fd37cdf5c81d4c0adb1ab7fa822ed253ab0ad9aa18d77257c88b29b718e")?;
 
     let shipping = ShippingMethod::new("123", 5.50).name("DHL");
@@ -13,7 +14,9 @@ fn main() -> Result<()> {
         .description("this is a test stall")
         .shipping(vec![shipping.clone()]);
 
-    let stall_event = EventBuilder::stall_data(stall).sign_with_keys(&keys)?;
+    let stall_event = EventBuilder::stall_data(stall)
+        .sign_with_keys(&keys)
+        .await?;
     println!("{}", stall_event.as_json());
 
     let product = ProductData::new("1", "123", "my test product", "USD")
@@ -23,7 +26,9 @@ fn main() -> Result<()> {
         .images(vec!["https://example.com/image.png".into()])
         .categories(vec!["test".into()]);
 
-    let product_event = EventBuilder::product_data(product).sign_with_keys(&keys)?;
+    let product_event = EventBuilder::product_data(product)
+        .sign_with_keys(&keys)
+        .await?;
     println!("{}", product_event.as_json());
 
     Ok(())

--- a/crates/nostr/examples/nip57.rs
+++ b/crates/nostr/examples/nip57.rs
@@ -4,7 +4,8 @@
 
 use nostr::prelude::*;
 
-fn main() -> Result<()> {
+#[tokio::main]
+async fn main() -> Result<()> {
     let keys = Keys::parse("6b911fd37cdf5c81d4c0adb1ab7fa822ed253ab0ad9aa18d77257c88b29b718e")?;
 
     let public_key =
@@ -12,13 +13,15 @@ fn main() -> Result<()> {
     let relays = [RelayUrl::parse("wss://relay.damus.io").unwrap()];
     let data = ZapRequestData::new(public_key, relays).message("Zap!");
 
-    let public_zap: Event = EventBuilder::public_zap_request(data.clone()).sign_with_keys(&keys)?;
+    let public_zap: Event = EventBuilder::public_zap_request(data.clone())
+        .sign_with_keys(&keys)
+        .await?;
     println!("Public zap request: {}", public_zap.as_json());
 
-    let anon_zap: Event = nip57::anonymous_zap_request(data.clone())?;
+    let anon_zap: Event = nip57::anonymous_zap_request(data.clone()).await?;
     println!("Anonymous zap request: {}", anon_zap.as_json());
 
-    let private_zap: Event = nip57::private_zap_request(data, &keys)?;
+    let private_zap: Event = nip57::private_zap_request(data, &keys).await?;
     println!("Private zap request: {}", private_zap.as_json());
 
     Ok(())

--- a/crates/nostr/src/event/builder.rs
+++ b/crates/nostr/src/event/builder.rs
@@ -5,15 +5,10 @@
 //! Event builder
 
 use alloc::string::{String, ToString};
+use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::fmt;
 use core::ops::Range;
-#[cfg(feature = "pow-multi-thread")]
-use std::sync::Arc;
-#[cfg(feature = "pow-multi-thread")]
-use std::sync::atomic::{AtomicBool, Ordering};
-#[cfg(feature = "pow-multi-thread")]
-use std::thread::{self, JoinHandle};
 
 #[cfg(all(feature = "std", feature = "os-rng"))]
 use rand::TryRngCore;
@@ -165,7 +160,7 @@ impl From<nip59::Error> for Error {
 }
 
 /// Event builder
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug)]
 pub struct EventBuilder {
     // Not expose the kind, tags and content.
     // These if changed may break the previously constructed events
@@ -173,6 +168,7 @@ pub struct EventBuilder {
     kind: Kind,
     tags: Tags,
     content: String,
+    pow_adapter: Option<Arc<dyn PowAdapter>>,
     /// Custom timestamp
     pub custom_created_at: Option<Timestamp>,
     /// POW difficulty
@@ -198,6 +194,7 @@ impl EventBuilder {
             kind,
             tags: Tags::new(),
             content: content.into(),
+            pow_adapter: None,
             custom_created_at: None,
             pow: None,
             allow_self_tagging: false,
@@ -250,6 +247,13 @@ impl EventBuilder {
         self
     }
 
+    /// Set a custom PoW adapter
+    #[inline]
+    pub fn pow_adapter(mut self, adapter: Arc<dyn PowAdapter>) -> Self {
+        self.pow_adapter = Some(adapter);
+        self
+    }
+
     /// Allow self-tagging
     ///
     /// When this mode is enabled, any `p` tags referencing the author’s public key will not be discarded.
@@ -266,153 +270,11 @@ impl EventBuilder {
         self
     }
 
-    /// Returns the [`EventId`] if the POW difficulty is satisfied.
-    fn check_nonce(
-        &mut self,
-        public_key: &PublicKey,
-        created_at: &Timestamp,
-        nonce: u128,
-        difficulty: u8,
-    ) -> Option<EventId> {
-        // Push POW tag
-        self.tags.push(Tag::pow(nonce, difficulty));
-
-        // Compute event ID
-        let id: EventId = EventId::new(
-            public_key,
-            created_at,
-            &self.kind,
-            &self.tags,
-            &self.content,
-        );
-
-        // Check POW difficulty
-        if id.check_pow(difficulty) {
-            Some(id)
-        } else {
-            // Remove tag if the nonce doesn't satisfy the difficulty requirement
-            self.tags.pop();
-            None
-        }
-    }
-
-    /// Mine PoW using single thread (fallback method)
-    fn mine_pow_single_thread(mut self, public_key: PublicKey, difficulty: u8) -> UnsignedEvent {
-        let mut nonce: u128 = 0;
-
-        loop {
-            nonce += 1;
-
-            let created_at: Timestamp = self.custom_created_at.unwrap_or_else(Timestamp::now);
-
-            // Check if the nonce satisfies the difficulty requirement
-            if let Some(id) = self.check_nonce(&public_key, &created_at, nonce, difficulty) {
-                return UnsignedEvent {
-                    id: Some(id),
-                    pubkey: public_key,
-                    created_at,
-                    kind: self.kind,
-                    tags: self.tags,
-                    content: self.content,
-                };
-            }
-        }
-    }
-
-    /// Mine PoW using multiple threads with std::thread
-    ///
-    /// Fallback to [`Self::mine_pow_single_thread`] if:
-    /// - the number of threads is `1`;
-    /// - thread spawning or coordination fails;
-    /// - no valid solution is found by any thread (rare edge case)
-    #[cfg(feature = "pow-multi-thread")]
-    fn mine_pow_multi_thread(self, public_key: PublicKey, difficulty: u8) -> UnsignedEvent {
-        // Get the number of available CPU cores
-        let num_threads = thread::available_parallelism()
-            .map(|n| n.get())
-            .unwrap_or(1);
-
-        // Single thread fallback
-        if num_threads == 1 {
-            return self.mine_pow_single_thread(public_key, difficulty);
-        }
-
-        let found: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
-
-        let mut handles: Vec<JoinHandle<Option<UnsignedEvent>>> = Vec::with_capacity(num_threads);
-
-        // Spawn threads
-        for thread_id in 0..num_threads {
-            let found: Arc<AtomicBool> = found.clone();
-
-            let mut builder: Self = self.clone();
-
-            // Create a timestamp
-            // TODO: move this into the thread loop
-            let created_at: Timestamp = self.custom_created_at.unwrap_or_else(Timestamp::now);
-
-            let handle: JoinHandle<Option<UnsignedEvent>> = thread::spawn(move || {
-                let mut nonce: u128 = thread_id as u128;
-
-                loop {
-                    // Check if another thread found the solution
-                    if found.load(Ordering::Relaxed) {
-                        break;
-                    }
-
-                    nonce += num_threads as u128;
-
-                    // Check if the nonce satisfies the difficulty requirement
-                    if let Some(id) =
-                        builder.check_nonce(&public_key, &created_at, nonce, difficulty)
-                    {
-                        // We found a valid nonce, signal other threads to stop and store the result
-                        found.store(true, Ordering::Relaxed);
-
-                        // Return the unsigned event
-                        return Some(UnsignedEvent {
-                            id: Some(id),
-                            pubkey: public_key,
-                            created_at,
-                            kind: builder.kind,
-                            tags: builder.tags,
-                            content: builder.content,
-                        });
-                    }
-                }
-
-                None
-            });
-
-            handles.push(handle);
-        }
-
-        // Wait for all threads to finish (non-blocking)
-        loop {
-            if found.load(Ordering::Relaxed) {
-                break;
-            }
-        }
-
-        // Find result
-        for handle in handles.into_iter() {
-            // NOTE: this shouldn't block the current thread,
-            // since above we've checked if the solution has been found
-            // (so all threads should be terminated).
-            if let Ok(Some(unsigned)) = handle.join() {
-                return unsigned;
-            }
-        }
-
-        // Single thread fallback
-        self.mine_pow_single_thread(public_key, difficulty)
-    }
-
     /// Build an unsigned event
     ///
     /// By default, this method removes any `p` tags that match the author's public key.
     /// To allow self-tagging, call [`EventBuilder::allow_self_tagging`] first.
-    pub fn build(mut self, public_key: PublicKey) -> UnsignedEvent {
+    pub async fn build(mut self, public_key: PublicKey) -> UnsignedEvent {
         // If self-tagging isn't allowed, discard all `p` tags that match the event author.
         if !self.allow_self_tagging {
             let public_key_hex: String = public_key.to_hex();
@@ -434,32 +296,39 @@ impl EventBuilder {
             self.tags.dedup();
         }
 
-        // Check if should be POW
-        match self.pow {
-            Some(difficulty) if difficulty > 0 => {
-                #[cfg(not(feature = "pow-multi-thread"))]
-                {
-                    self.mine_pow_single_thread(public_key, difficulty)
-                }
-                #[cfg(feature = "pow-multi-thread")]
-                {
-                    self.mine_pow_multi_thread(public_key, difficulty)
-                }
+        let mut unsigned: UnsignedEvent = UnsignedEvent {
+            id: None,
+            pubkey: public_key,
+            created_at: self.custom_created_at.unwrap_or_else(Timestamp::now),
+            kind: self.kind,
+            tags: self.tags,
+            content: self.content,
+        };
+
+        // Check if should be PoW
+        if let Some(pow) = self.pow.filter(|pow| pow != &0) {
+            // size = 0
+            let default_adapter = nip13::default_adapter();
+
+            unsigned = self
+                .pow_adapter
+                .as_deref()
+                .unwrap_or(&default_adapter)
+                .compute(unsigned, pow, self.custom_created_at)
+                .await;
+
+            #[cfg(debug_assertions)]
+            {
+                let nonce_tag = unsigned.tags.find(TagKind::Nonce);
+                assert!(unsigned.id.is_some());
+                assert!(nonce_tag.is_some());
+                assert!(nonce_tag.is_some_and(|t| t.as_slice()[2] == pow.to_string()));
             }
-            // No POW difficulty set OR difficulty == 0
-            _ => {
-                let mut unsigned: UnsignedEvent = UnsignedEvent {
-                    id: None,
-                    pubkey: public_key,
-                    created_at: self.custom_created_at.unwrap_or_else(Timestamp::now),
-                    kind: self.kind,
-                    tags: self.tags,
-                    content: self.content,
-                };
-                unsigned.ensure_id();
-                unsigned
-            }
+        } else {
+            unsigned.ensure_id();
         }
+
+        unsigned
     }
 
     /// Build, sign and return [`Event`]
@@ -474,7 +343,7 @@ impl EventBuilder {
         T: NostrSigner,
     {
         let public_key: PublicKey = signer.get_public_key().await?;
-        Ok(self.build(public_key).sign(signer).await?)
+        Ok(self.build(public_key).await.sign(signer).await?)
     }
 
     /// Build, sign and return [`Event`] using [`Keys`] signer
@@ -482,15 +351,16 @@ impl EventBuilder {
     /// Check [`EventBuilder::sign_with_ctx`] to learn more.
     #[inline]
     #[cfg(all(feature = "std", feature = "os-rng"))]
-    pub fn sign_with_keys(self, keys: &Keys) -> Result<Event, Error> {
+    pub async fn sign_with_keys(self, keys: &Keys) -> Result<Event, Error> {
         self.sign_with_ctx(&SECP256K1, &mut OsRng.unwrap_err(), keys)
+            .await
     }
 
     /// Build, sign and return [`Event`] using [`Keys`] signer
     ///
     /// Check [`EventBuilder::build`] to learn more.
     #[cfg(feature = "rand")]
-    pub fn sign_with_ctx<C, R>(
+    pub async fn sign_with_ctx<C, R>(
         self,
         secp: &Secp256k1<C>,
         rng: &mut R,
@@ -501,7 +371,7 @@ impl EventBuilder {
         R: RngCore + CryptoRng,
     {
         let pubkey: PublicKey = keys.public_key();
-        Ok(self.build(pubkey).sign_with_ctx(secp, rng, keys)?)
+        Ok(self.build(pubkey).await.sign_with_ctx(secp, rng, keys)?)
     }
 
     /// Profile metadata
@@ -998,7 +868,8 @@ impl EventBuilder {
     /// use nostr::prelude::*;
     ///
     /// # #[cfg(all(feature = "std", feature = "os-rng", feature = "nip57"))]
-    /// # fn main() {
+    /// # #[tokio::main]
+    /// # async fn main() {
     /// # let keys = Keys::generate();
     /// # let public_key = PublicKey::from_bech32(
     /// # "npub14f8usejl26twx0dhuxjh9cas7keav9vr0v8nvtwtrjqx3vycc76qqh9nsy",
@@ -1006,10 +877,10 @@ impl EventBuilder {
     /// # let relays = [RelayUrl::parse("wss://relay.damus.io").unwrap()];
     /// let data = ZapRequestData::new(public_key, relays).message("Zap!");
     ///
-    /// let anon_zap: Event = nip57::anonymous_zap_request(data.clone()).unwrap();
+    /// let anon_zap: Event = nip57::anonymous_zap_request(data.clone()).await.unwrap();
     /// println!("Anonymous zap request: {anon_zap:#?}");
     ///
-    /// let private_zap: Event = nip57::private_zap_request(data, &keys).unwrap();
+    /// let private_zap: Event = nip57::private_zap_request(data, &keys).await.unwrap();
     /// println!("Private zap request: {private_zap:#?}");
     /// # }
     ///
@@ -1448,7 +1319,7 @@ impl EventBuilder {
     ///
     /// <https://github.com/nostr-protocol/nips/blob/master/59.md>
     #[cfg(all(feature = "std", feature = "os-rng", feature = "nip59"))]
-    pub fn gift_wrap_from_seal<I>(
+    pub async fn gift_wrap_from_seal<I>(
         receiver: &PublicKey,
         seal: &Event,
         extra_tags: I,
@@ -1481,6 +1352,7 @@ impl EventBuilder {
             .tags(tags)
             .custom_created_at(Timestamp::tweaked(nip59::RANGE_RANDOM_TIMESTAMP_TWEAK))
             .sign_with_keys(&keys)
+            .await
     }
 
     /// Gift Wrap
@@ -1502,7 +1374,7 @@ impl EventBuilder {
             .await?
             .sign(signer)
             .await?;
-        Self::gift_wrap_from_seal(receiver, &seal, extra_tags)
+        Self::gift_wrap_from_seal(receiver, &seal, extra_tags).await
     }
 
     /// Private direct message relay list
@@ -1553,7 +1425,8 @@ impl EventBuilder {
         let public_key: PublicKey = signer.get_public_key().await?;
         let rumor: UnsignedEvent = Self::private_msg_rumor(receiver, message)
             .tags(rumor_extra_tags)
-            .build(public_key);
+            .build(public_key)
+            .await;
         Self::gift_wrap(signer, &receiver, rumor, []).await
     }
 
@@ -2009,9 +1882,9 @@ mod tests {
     #[cfg(all(feature = "std", feature = "os-rng"))]
     use crate::SecretKey;
 
-    #[test]
+    #[tokio::test]
     #[cfg(all(feature = "std", feature = "os-rng"))]
-    fn round_trip() {
+    async fn round_trip() {
         let keys = Keys::new(
             SecretKey::from_str("6b911fd37cdf5c81d4c0adb1ab7fa822ed253ab0ad9aa18d77257c88b29b718e")
                 .unwrap(),
@@ -2019,6 +1892,7 @@ mod tests {
 
         let event = EventBuilder::text_note("hello")
             .sign_with_keys(&keys)
+            .await
             .unwrap();
 
         let serialized = event.as_json();
@@ -2027,9 +1901,9 @@ mod tests {
         assert_eq!(event, deserialized);
     }
 
-    #[test]
+    #[tokio::test]
     #[cfg(all(feature = "std", feature = "os-rng"))]
-    fn test_self_tagging() {
+    async fn test_self_tagging() {
         let keys = Keys::parse("6b911fd37cdf5c81d4c0adb1ab7fa822ed253ab0ad9aa18d77257c88b29b718e")
             .unwrap();
 
@@ -2037,6 +1911,7 @@ mod tests {
         let event = EventBuilder::text_note("hello")
             .tag(Tag::public_key(keys.public_key()))
             .sign_with_keys(&keys)
+            .await
             .unwrap();
         assert!(event.tags.is_empty());
 
@@ -2045,6 +1920,7 @@ mod tests {
         let event = EventBuilder::text_note("hello 2")
             .tag(Tag::public_key(other.public_key()))
             .sign_with_keys(&keys)
+            .await
             .unwrap();
         assert_eq!(event.tags.len(), 1);
     }
@@ -2131,9 +2007,9 @@ mod tests {
         assert_eq!(Kind::BadgeDefinition, event_builder.kind);
     }
 
-    #[test]
+    #[tokio::test]
     #[cfg(all(feature = "std", feature = "os-rng"))]
-    fn test_badge_award_event_builder() {
+    async fn test_badge_award_event_builder() {
         let keys = Keys::generate();
         let pub_key = keys.public_key();
 
@@ -2187,6 +2063,7 @@ mod tests {
             EventBuilder::award_badge(&badge_definition_event, awarded_pubkeys)
                 .unwrap()
                 .sign_with_keys(&keys)
+                .await
                 .unwrap();
 
         assert_eq!(event_builder.kind, Kind::BadgeAward);
@@ -2194,9 +2071,9 @@ mod tests {
         assert_eq!(event_builder.tags, example_event.tags);
     }
 
-    #[test]
+    #[tokio::test]
     #[cfg(all(feature = "std", feature = "os-rng"))]
-    fn test_profile_badges() {
+    async fn test_profile_badges() {
         // The pubkey used for profile badges event
         let keys = Keys::generate();
         let pub_key = keys.public_key();
@@ -2213,11 +2090,13 @@ mod tests {
         let bravery_badge_event =
             EventBuilder::define_badge("bravery", None, None, None, None, Vec::new())
                 .sign_with_keys(&badge_one_keys)
+                .await
                 .unwrap();
         let bravery_badge_award =
             EventBuilder::award_badge(&bravery_badge_event, awarded_pubkeys.clone())
                 .unwrap()
                 .sign_with_keys(&badge_one_keys)
+                .await
                 .unwrap();
 
         // Badge 2
@@ -2227,11 +2106,13 @@ mod tests {
         let honor_badge_event =
             EventBuilder::define_badge("honor", None, None, None, None, Vec::new())
                 .sign_with_keys(&badge_two_keys)
+                .await
                 .unwrap();
         let honor_badge_award =
             EventBuilder::award_badge(&honor_badge_event, awarded_pubkeys.clone())
                 .unwrap()
                 .sign_with_keys(&badge_two_keys)
+                .await
                 .unwrap();
 
         let example_event_json = format!(
@@ -2260,15 +2141,16 @@ mod tests {
             EventBuilder::profile_badges(badge_definitions, badge_awards, &pub_key)
                 .unwrap()
                 .sign_with_keys(&keys)
+                .await
                 .unwrap();
 
         assert_eq!(profile_badges.kind, Kind::ProfileBadges);
         assert_eq!(profile_badges.tags, example_event.tags);
     }
 
-    #[test]
+    #[tokio::test]
     #[cfg(all(feature = "std", feature = "os-rng"))]
-    fn test_text_note_reply() {
+    async fn test_text_note_reply() {
         let json: &str = r###"{"kind":1,"created_at":1732718325,"content":"## rust-nostr v0.37 is out! 🦀\n\n### Summary\n\nAdd support to NIP17 relay list in SDK (when `gossip` option is enabled), add NIP22 and NIP73 support, \nfix Swift Package, many performance improvements and bug fixes and more!\n\nFrom this release all the rust features are be disabled by default (except `std` feature in `nostr` crate).\n\nFull changelog: https://rust-nostr.org/changelog\n\n### Contributors\n\nThanks to all contributors!\n\n* nostr:npub1zuuajd7u3sx8xu92yav9jwxpr839cs0kc3q6t56vd5u9q033xmhsk6c2uc \n* nostr:npub1q0uulk2ga9dwkp8hsquzx38hc88uqggdntelgqrtkm29r3ass6fq8y9py9 \n* nostr:npub1zfss807aer0j26mwp2la0ume0jqde3823rmu97ra6sgyyg956e0s6xw445 \n* nostr:npub1zwnx29tj2lnem8wvjcx7avm8l4unswlz6zatk0vxzeu62uqagcash7fhrf \n* nostr:npub1acxjpdrlk2vw320dxcy3prl87g5kh4c73wp0knullrmp7c4mc7nq88gj3j \n\n### Links\n\nhttps://rust-nostr.org\nhttps://rust-nostr.org/donate\n\n#rustnostr #nostr #rustlang #programming #rust #python #javascript #kotlin #swift #flutter","tags":[["t","rustnostr"],["t","nostr"],["t","rustlang"],["t","programming"],["t","rust"],["t","python"],["t","javascript"],["t","kotlin"],["t","swift"],["t","flutter"],["p","1739d937dc8c0c7370aa27585938c119e25c41f6c441a5d34c6d38503e3136ef","","mention"],["p","03f9cfd948e95aeb04f780382344f7c1cfc0210d9af3f4006bb6d451c7b08692","","mention"],["p","126103bfddc8df256b6e0abfd7f3797c80dcc4ea88f7c2f87dd4104220b4d65f","","mention"],["p","13a665157257e79d9dcc960deeb367fd79383be2d0babb3d861679a5701d463b","","mention"],["p","ee0d20b47fb298e8a9ed3609108fe7f2296bd71e8b82fb4f9ff8f61f62bbc7a6","","mention"]],"pubkey":"68d81165918100b7da43fc28f7d1fc12554466e1115886b9e7bb326f65ec4272","id":"8262a50cf7832351ae3f21c429e111bb31be0cf754ec437e015534bf5cc2eee8","sig":"7e81ff3dfb78ba59b09b48d5218331a3259c56f702a6b8e118938a219879d60e7062e90fc1b070a4c472988d1801ec55714388efc6a4a3876a8a957c5c7808b6"}"###;
         let root_event = Event::from_json(json).unwrap();
 
@@ -2278,6 +2160,7 @@ mod tests {
         let reply_keys = Keys::generate();
         let reply = EventBuilder::text_note_reply("Test reply", &root_event, None, None)
             .sign_with_keys(&reply_keys)
+            .await
             .unwrap();
         assert_eq!(reply.tags.public_keys().count(), 1); // Root author
         assert_eq!(
@@ -2295,6 +2178,7 @@ mod tests {
         let reply_of_reply =
             EventBuilder::text_note_reply("Test reply of reply", &reply, Some(&root_event), None)
                 .sign_with_keys(&other_keys)
+                .await
                 .unwrap();
         assert_eq!(reply_of_reply.tags.public_keys().count(), 2); // Reply + root author
 
@@ -2309,15 +2193,17 @@ mod tests {
         assert_eq!(ids.next().unwrap(), root_event.id);
     }
 
-    #[test]
+    #[tokio::test]
     #[cfg(all(feature = "std", feature = "os-rng"))]
-    fn replaceable_repost() {
+    async fn replaceable_repost() {
         let keys = Keys::generate();
         let replaceable = EventBuilder::mute_list(MuteList::default())
             .sign_with_keys(&keys)
+            .await
             .unwrap();
         let repost = EventBuilder::repost(&replaceable, None)
             .sign_with_keys(&keys)
+            .await
             .unwrap();
 
         assert_eq!(repost.kind, Kind::GenericRepost);
@@ -2334,15 +2220,17 @@ mod tests {
         );
     }
 
-    #[test]
+    #[tokio::test]
     #[cfg(all(feature = "std", feature = "os-rng"))]
-    fn addressable_repost() {
+    async fn addressable_repost() {
         let keys = Keys::generate();
         let addressable = EventBuilder::follow_set("lorem", [])
             .sign_with_keys(&keys)
+            .await
             .unwrap();
         let repost = EventBuilder::repost(&addressable, None)
             .sign_with_keys(&keys)
+            .await
             .unwrap();
 
         assert_eq!(repost.kind, Kind::GenericRepost);

--- a/crates/nostr/src/event/mod.rs
+++ b/crates/nostr/src/event/mod.rs
@@ -368,12 +368,13 @@ mod tests {
         assert_eq!(ev_ser.as_json(), sample_event);
     }
 
-    #[test]
+    #[tokio::test]
     #[cfg(all(feature = "std", feature = "os-rng"))]
-    fn test_custom_kind() {
+    async fn test_custom_kind() {
         let keys = Keys::generate();
         let e: Event = EventBuilder::new(Kind::Custom(123), "my content")
             .sign_with_keys(&keys)
+            .await
             .unwrap();
 
         let serialized = e.as_json();
@@ -384,21 +385,22 @@ mod tests {
         assert_eq!(Kind::Custom(123), deserialized.kind);
     }
 
-    #[test]
+    #[tokio::test]
     #[cfg(all(feature = "std", feature = "os-rng"))]
-    fn test_event_expired() {
+    async fn test_event_expired() {
         let my_keys = Keys::generate();
         let event = EventBuilder::text_note("my content")
             .tags([Tag::expiration(Timestamp::from(1600000000))])
             .sign_with_keys(&my_keys)
+            .await
             .unwrap();
 
         assert!(&event.is_expired());
     }
 
-    #[test]
+    #[tokio::test]
     #[cfg(all(feature = "std", feature = "os-rng"))]
-    fn test_event_not_expired() {
+    async fn test_event_not_expired() {
         let now = Timestamp::now();
         let expiry_date: u64 = now.as_secs() * 2;
 
@@ -406,17 +408,19 @@ mod tests {
         let event = EventBuilder::text_note("my content")
             .tags([Tag::expiration(Timestamp::from(expiry_date))])
             .sign_with_keys(&my_keys)
+            .await
             .unwrap();
 
         assert!(!&event.is_expired());
     }
 
-    #[test]
+    #[tokio::test]
     #[cfg(all(feature = "std", feature = "os-rng"))]
-    fn test_event_without_expiration_tag() {
+    async fn test_event_without_expiration_tag() {
         let my_keys = Keys::generate();
         let event = EventBuilder::text_note("my content")
             .sign_with_keys(&my_keys)
+            .await
             .unwrap();
         assert!(!&event.is_expired());
     }

--- a/crates/nostr/src/event/tag/list.rs
+++ b/crates/nostr/src/event/tag/list.rs
@@ -14,6 +14,7 @@ use core::cell::OnceCell;
 use core::cmp::Ordering;
 use core::fmt;
 use core::hash::{Hash, Hasher};
+use core::ops::{Index, IndexMut};
 use core::slice::Iter;
 #[cfg(feature = "std")]
 use std::collections::hash_map::{Entry, HashMap};
@@ -83,6 +84,20 @@ impl Ord for Tags {
 impl Hash for Tags {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.list.hash(state);
+    }
+}
+
+impl Index<usize> for Tags {
+    type Output = Tag;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        self.list.index(index)
+    }
+}
+
+impl IndexMut<usize> for Tags {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        self.list.index_mut(index)
     }
 }
 

--- a/crates/nostr/src/event/tag/mod.rs
+++ b/crates/nostr/src/event/tag/mod.rs
@@ -323,6 +323,7 @@ impl Tag {
     /// Compose `["nonce", "<nonce>", "<difficulty>"]` tag
     ///
     /// <https://github.com/nostr-protocol/nips/blob/master/13.md>
+    #[doc(alias = "nonce")]
     #[inline]
     pub fn pow(nonce: u128, difficulty: u8) -> Self {
         Self::from_standardized_without_cell(TagStandard::POW { nonce, difficulty })

--- a/crates/nostr/src/event/unsigned.rs
+++ b/crates/nostr/src/event/unsigned.rs
@@ -85,7 +85,8 @@ impl UnsignedEvent {
     }
 
     #[inline]
-    fn compute_id(&self) -> EventId {
+    /// Compute the event ID
+    pub fn compute_id(&self) -> EventId {
         EventId::new(
             &self.pubkey,
             &self.created_at,

--- a/crates/nostr/src/nips/nip09.rs
+++ b/crates/nostr/src/nips/nip09.rs
@@ -98,8 +98,8 @@ mod tests {
     use super::*;
     use crate::{Event, Keys, Tags};
 
-    #[test]
-    fn test_event_deletion_request() {
+    #[tokio::test]
+    async fn test_event_deletion_request() {
         let keys = Keys::generate();
 
         let event_id =
@@ -116,7 +116,11 @@ mod tests {
             .coordinate(coordinate)
             .reason("these posts were published by accident");
 
-        let event: Event = request.to_event_builder().sign_with_keys(&keys).unwrap();
+        let event: Event = request
+            .to_event_builder()
+            .sign_with_keys(&keys)
+            .await
+            .unwrap();
 
         assert_eq!(event.kind, Kind::EventDeletion);
         assert_eq!(event.content, "these posts were published by accident");
@@ -137,7 +141,11 @@ mod tests {
         // Event ID without reason
         let request = EventDeletionRequest::new().id(event_id);
 
-        let event: Event = request.to_event_builder().sign_with_keys(&keys).unwrap();
+        let event: Event = request
+            .to_event_builder()
+            .sign_with_keys(&keys)
+            .await
+            .unwrap();
 
         assert_eq!(event.kind, Kind::EventDeletion);
         assert!(event.content.is_empty());

--- a/crates/nostr/src/nips/nip13.rs
+++ b/crates/nostr/src/nips/nip13.rs
@@ -7,8 +7,19 @@
 //!
 //! <https://github.com/nostr-protocol/nips/blob/master/13.md>
 
+use alloc::boxed::Box;
 use alloc::string::String;
+use alloc::sync::Arc;
 use alloc::vec::Vec;
+use core::fmt;
+#[cfg(feature = "pow-multi-thread")]
+use std::{
+    sync::atomic::{AtomicBool, Ordering},
+    thread::{self, JoinHandle},
+};
+
+use crate::util::BoxedFuture;
+use crate::{Tag, Timestamp, UnsignedEvent};
 
 /// Gets the number of leading zero bits. Result is between 0 and 255.
 #[inline]
@@ -57,13 +68,199 @@ pub fn get_prefixes_for_difficulty(leading_zero_bits: u8) -> Vec<String> {
     r
 }
 
+/// A trait for custom Proof of Work computation.
+pub trait PowAdapter: fmt::Debug + Send + Sync {
+    /// Computes Proof of Work for an unsigned event to meet the target
+    /// difficulty.
+    fn compute(
+        &self,
+        unsigned_event: UnsignedEvent,
+        target_difficulty: u8,
+        custom_created_at: Option<Timestamp>,
+    ) -> BoxedFuture<'_, UnsignedEvent>;
+}
+
+impl<T> PowAdapter for Arc<T>
+where
+    T: PowAdapter,
+{
+    fn compute(
+        &self,
+        unsigned_event: UnsignedEvent,
+        target_difficulty: u8,
+        custom_created_at: Option<Timestamp>,
+    ) -> BoxedFuture<'_, UnsignedEvent> {
+        self.as_ref()
+            .compute(unsigned_event, target_difficulty, custom_created_at)
+    }
+}
+
+/// A single-threaded PoW miner implementation
+#[derive(Debug)]
+pub struct SingleThreadPow;
+
+impl PowAdapter for SingleThreadPow {
+    fn compute(
+        &self,
+        mut unsigned_event: UnsignedEvent,
+        target_difficulty: u8,
+        custom_created_at: Option<Timestamp>,
+    ) -> BoxedFuture<'_, UnsignedEvent> {
+        Box::pin(async move {
+            let mut nonce: u128 = 0;
+            unsigned_event.tags.push(Tag::pow(0, target_difficulty));
+            let pow_tag_index = unsigned_event.tags.len() - 1;
+
+            loop {
+                nonce += 1;
+
+                if nonce % 1024 == 0 {
+                    unsigned_event.created_at = custom_created_at.unwrap_or_else(Timestamp::now);
+                    // TODO: yield to not block the async runtime
+                    // REF: https://github.com/rust-nostr/nostr/issues/921
+                }
+
+                unsigned_event.tags[pow_tag_index] = Tag::pow(nonce, target_difficulty);
+
+                let event_id = unsigned_event.compute_id();
+                if get_leading_zero_bits(event_id.as_bytes()) == target_difficulty {
+                    unsigned_event.id = Some(event_id);
+                    return unsigned_event;
+                }
+            }
+        })
+    }
+}
+
+/// A multi-threaded Proof-of-Work miner.
+///
+/// Fallback to [`SingleThreadPow`] if:
+/// - the number of threads is `1`;
+/// - thread spawning or coordination fails;
+/// - no valid solution is found by any thread (rare edge case)
+#[derive(Debug)]
+#[cfg(feature = "pow-multi-thread")]
+pub struct MultiThreadPow;
+
+#[cfg(feature = "pow-multi-thread")]
+impl PowAdapter for MultiThreadPow {
+    fn compute(
+        &self,
+        unsigned_event: UnsignedEvent,
+        target_difficulty: u8,
+        custom_created_at: Option<Timestamp>,
+    ) -> BoxedFuture<'_, UnsignedEvent> {
+        Box::pin(async move {
+            // Get the number of available CPU cores
+
+            let num_threads = thread::available_parallelism()
+                .map(|n| n.get())
+                .unwrap_or(1);
+
+            // Single thread fallback
+            if num_threads == 1 {
+                return SingleThreadPow
+                    .compute(unsigned_event, target_difficulty, custom_created_at)
+                    .await;
+            }
+
+            let found: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
+            let mut handles: Vec<JoinHandle<Option<UnsignedEvent>>> =
+                Vec::with_capacity(num_threads);
+
+            // Spawn threads
+            for thread_id in 0..num_threads {
+                let found: Arc<AtomicBool> = found.clone();
+                let mut unsigned_event = unsigned_event.clone();
+
+                let handle: JoinHandle<Option<UnsignedEvent>> = thread::spawn(move || {
+                    let mut nonce: u128 = thread_id as u128;
+                    unsigned_event.tags.push(Tag::pow(0, target_difficulty));
+                    let pow_tag_index = unsigned_event.tags.len() - 1;
+
+                    loop {
+                        nonce += num_threads as u128;
+
+                        // FIXME: "Division is the most expensive integer
+                        // operation you can ask of your CPU"
+                        // https://research.swtch.com/divmult
+                        if (nonce / num_threads as u128) % 1024 == 0 {
+                            // Check if another thread found the solution
+                            if found.load(Ordering::Relaxed) {
+                                break;
+                            }
+                            unsigned_event.created_at =
+                                custom_created_at.unwrap_or_else(Timestamp::now);
+                        }
+
+                        unsigned_event.tags[pow_tag_index] = Tag::pow(nonce, target_difficulty);
+
+                        let event_id = unsigned_event.compute_id();
+                        if get_leading_zero_bits(event_id.as_bytes()) == target_difficulty {
+                            found.store(true, Ordering::Relaxed);
+                            unsigned_event.id = Some(event_id);
+                            return Some(unsigned_event);
+                        }
+                    }
+
+                    None
+                });
+
+                handles.push(handle);
+            }
+
+            // Wait for all threads to finish (non-blocking)
+            loop {
+                // TODO: yield to not block the async runtime
+                // REF: https://github.com/rust-nostr/nostr/issues/921
+                if found.load(Ordering::Relaxed) {
+                    break;
+                }
+            }
+
+            // Find result
+            for handle in handles.into_iter() {
+                // NOTE: this shouldn't block the current thread,
+                // since above we've checked if the solution has been found
+                // (so all threads should be terminated).
+                if let Ok(Some(unsigned)) = handle.join() {
+                    return unsigned;
+                }
+            }
+
+            // Single thread fallback
+            SingleThreadPow
+                .compute(unsigned_event, target_difficulty, custom_created_at)
+                .await
+        })
+    }
+}
+
+/// Returns the default single-threaded Proof-of-Work adapter.
+#[cfg(not(feature = "pow-multi-thread"))]
+#[inline]
+pub(crate) fn default_adapter() -> SingleThreadPow {
+    SingleThreadPow
+}
+
+/// Returns the default multi-threaded Proof-of-Work adapter.
+#[cfg(feature = "pow-multi-thread")]
+#[inline]
+pub(crate) fn default_adapter() -> MultiThreadPow {
+    MultiThreadPow
+}
+
 #[cfg(test)]
 pub mod tests {
     use core::str::FromStr;
+    #[cfg(feature = "std")]
+    use std::sync::Arc;
 
     use hashes::sha256::Hash as Sha256Hash;
 
     use super::*;
+    #[cfg(feature = "std")]
+    use crate::{EventBuilder, PublicKey, Tag, TagKind};
 
     #[test]
     fn check_get_leading_zeroes() {
@@ -434,5 +631,83 @@ pub mod tests {
                 "0000000000000000000000000000000000000000000000000000000000000001"
             ]
         );
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "std")]
+    async fn custom_adapter() {
+        #[derive(Debug)]
+        struct TestAdapter;
+
+        impl PowAdapter for TestAdapter {
+            fn compute(
+                &self,
+                mut unsigned_event: UnsignedEvent,
+                target_difficulty: u8,
+                _custom_created_at: Option<Timestamp>,
+            ) -> BoxedFuture<'_, UnsignedEvent> {
+                Box::pin(async move {
+                    unsigned_event.tags.push(Tag::pow(3490, target_difficulty));
+                    unsigned_event.ensure_id();
+
+                    unsigned_event
+                })
+            }
+        }
+
+        let pow_adapter = Arc::new(TestAdapter);
+
+        let unsigned = EventBuilder::text_note(
+            "Why must I find leading zero bits? Is there no beauty in the ones?",
+        )
+        .pow_adapter(pow_adapter.clone())
+        .pow(2)
+        .build(PublicKey::from_slice(&[0; 32]).unwrap())
+        .await;
+
+        let Some(nonce_tag) = unsigned.tags.find(TagKind::Nonce) else {
+            panic!("nonce tag should be exist")
+        };
+
+        assert_eq!(nonce_tag.as_slice()[1], "3490");
+        assert_eq!(nonce_tag.as_slice()[2], "2");
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "std")]
+    async fn single_adapter() {
+        let unsigned = EventBuilder::text_note(
+            "Proof of Work: The only workout my CPU gets since I stopped gaming",
+        )
+        .pow_adapter(Arc::new(SingleThreadPow))
+        .pow(2)
+        .build(PublicKey::from_slice(&[0; 32]).unwrap())
+        .await;
+
+        let Some(nonce_tag) = unsigned.tags.find(TagKind::Nonce) else {
+            panic!("nonce tag should be exist")
+        };
+
+        assert!(unsigned.id.is_some());
+        assert_eq!(nonce_tag.as_slice()[2], "2");
+        assert_eq!(get_leading_zero_bits(unsigned.id.unwrap()), 2)
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "pow-multi-thread")]
+    async fn threaded_adapter() {
+        let unsigned = EventBuilder::text_note("Wait, you guys are getting paid to find nonces? I'm just doing it for the leading zeros")
+            .pow_adapter(Arc::new(MultiThreadPow))
+            .pow(2)
+            .build(PublicKey::from_slice(&[0; 32]).unwrap())
+            .await;
+
+        let Some(nonce_tag) = unsigned.tags.find(TagKind::Nonce) else {
+            panic!("nonce tag should be exist")
+        };
+
+        assert!(unsigned.id.is_some());
+        assert_eq!(nonce_tag.as_slice()[2], "2");
+        assert_eq!(get_leading_zero_bits(unsigned.id.unwrap()), 2)
     }
 }

--- a/crates/nostr/src/nips/nip34.rs
+++ b/crates/nostr/src/nips/nip34.rs
@@ -516,8 +516,8 @@ mod tests {
     use super::*;
     use crate::{Event, Keys, Tags};
 
-    #[test]
-    fn test_git_repo_announcement() {
+    #[tokio::test]
+    async fn test_git_repo_announcement() {
         let repo = GitRepositoryAnnouncement {
             id: String::from("test"),
             name: Some(String::from("Test nostr repository")),
@@ -540,6 +540,7 @@ mod tests {
             .to_event_builder()
             .unwrap()
             .sign_with_keys(&keys)
+            .await
             .unwrap();
 
         assert_eq!(event.kind, Kind::GitRepoAnnouncement);
@@ -561,8 +562,8 @@ mod tests {
         assert_eq!(event.tags, tags);
     }
 
-    #[test]
-    fn test_git_issue() {
+    #[tokio::test]
+    async fn test_git_issue() {
         let pk =
             PublicKey::parse("npub1drvpzev3syqt0kjrls50050uzf25gehpz9vgdw08hvex7e0vgfeq0eseet")
                 .unwrap();
@@ -580,6 +581,7 @@ mod tests {
             .to_event_builder()
             .unwrap()
             .sign_with_keys(&keys)
+            .await
             .unwrap();
 
         assert_eq!(event.kind, Kind::GitIssue);
@@ -601,8 +603,8 @@ mod tests {
         assert_eq!(event.tags, tags);
     }
 
-    #[test]
-    fn test_git_patch() {
+    #[tokio::test]
+    async fn test_git_patch() {
         let pk =
             PublicKey::parse("npub1drvpzev3syqt0kjrls50050uzf25gehpz9vgdw08hvex7e0vgfeq0eseet")
                 .unwrap();
@@ -632,6 +634,7 @@ mod tests {
             .to_event_builder()
             .unwrap()
             .sign_with_keys(&keys)
+            .await
             .unwrap();
 
         assert_eq!(event.kind, Kind::GitPatch);

--- a/crates/nostr/src/nips/nip42.rs
+++ b/crates/nostr/src/nips/nip42.rs
@@ -51,21 +51,22 @@ mod tests {
     use super::*;
     use crate::{EventBuilder, Keys};
 
-    #[test]
-    fn test_valid_auth_event() {
+    #[tokio::test]
+    async fn test_valid_auth_event() {
         let keys = Keys::generate();
         let relay_url = RelayUrl::parse("wss://relay.damus.io").unwrap();
         let challenge = "1234567890";
 
         let event = EventBuilder::auth(challenge, relay_url.clone())
             .sign_with_keys(&keys)
+            .await
             .unwrap();
 
         assert!(is_valid_auth_event(&event, &relay_url, challenge));
     }
 
-    #[test]
-    fn test_invalid_auth_event() {
+    #[tokio::test]
+    async fn test_invalid_auth_event() {
         let keys = Keys::generate();
         let relay_url = RelayUrl::parse("wss://relay.damus.io").unwrap();
         let challenge = "1234567890";
@@ -73,18 +74,21 @@ mod tests {
         // Wrong challenge
         let event = EventBuilder::auth("abcd", relay_url.clone())
             .sign_with_keys(&keys)
+            .await
             .unwrap();
         assert!(!is_valid_auth_event(&event, &relay_url, challenge));
 
         // Wrong relay url
         let event = EventBuilder::auth(challenge, RelayUrl::parse("wss://example.com").unwrap())
             .sign_with_keys(&keys)
+            .await
             .unwrap();
         assert!(!is_valid_auth_event(&event, &relay_url, challenge));
 
         // Wrong kind
         let event = EventBuilder::text_note("abcd")
             .sign_with_keys(&keys)
+            .await
             .unwrap();
         assert!(!is_valid_auth_event(&event, &relay_url, challenge));
     }

--- a/crates/nostr/src/nips/nip47.rs
+++ b/crates/nostr/src/nips/nip47.rs
@@ -622,12 +622,13 @@ impl Request {
 
     /// Create request [Event]
     #[cfg(all(feature = "std", feature = "os-rng"))]
-    pub fn to_event(self, uri: &NostrWalletConnectUri) -> Result<Event, Error> {
+    pub async fn to_event(self, uri: &NostrWalletConnectUri) -> Result<Event, Error> {
         let encrypted = nip04::encrypt(&uri.secret, &uri.public_key, self.as_json())?;
         let keys: Keys = Keys::new(uri.secret.clone());
         Ok(EventBuilder::new(Kind::WalletConnectRequest, encrypted)
             .tag(Tag::public_key(uri.public_key))
-            .sign_with_keys(&keys)?)
+            .sign_with_keys(&keys)
+            .await?)
     }
 }
 

--- a/crates/nostr/src/nips/nip57.rs
+++ b/crates/nostr/src/nips/nip57.rs
@@ -259,7 +259,7 @@ impl From<ZapRequestData> for Vec<Tag> {
 
 /// Create **anonymous** zap request
 #[cfg(all(feature = "std", feature = "os-rng"))]
-pub fn anonymous_zap_request(data: ZapRequestData) -> Result<Event, Error> {
+pub async fn anonymous_zap_request(data: ZapRequestData) -> Result<Event, Error> {
     let keys = Keys::generate();
     let message: String = data.message.clone();
     let mut tags: Vec<Tag> = data.into();
@@ -268,19 +268,20 @@ pub fn anonymous_zap_request(data: ZapRequestData) -> Result<Event, Error> {
     }));
     Ok(EventBuilder::new(Kind::ZapRequest, message)
         .tags(tags)
-        .sign_with_keys(&keys)?)
+        .sign_with_keys(&keys)
+        .await?)
 }
 
 /// Create **private** zap request
 #[inline]
 #[cfg(all(feature = "std", feature = "os-rng"))]
-pub fn private_zap_request(data: ZapRequestData, keys: &Keys) -> Result<Event, Error> {
-    private_zap_request_with_ctx(&SECP256K1, &mut OsRng.unwrap_err(), data, keys)
+pub async fn private_zap_request(data: ZapRequestData, keys: &Keys) -> Result<Event, Error> {
+    private_zap_request_with_ctx(&SECP256K1, &mut OsRng.unwrap_err(), data, keys).await
 }
 
 /// Create **private** zap request
 #[cfg(feature = "rand")]
-pub fn private_zap_request_with_ctx<C, R>(
+pub async fn private_zap_request_with_ctx<C, R>(
     secp: &Secp256k1<C>,
     rng: &mut R,
     data: ZapRequestData,
@@ -303,7 +304,8 @@ where
     }
     let msg: String = EventBuilder::new(Kind::ZapPrivateMessage, &data.message)
         .tags(tags)
-        .sign_with_ctx(secp, rng, keys)?
+        .sign_with_ctx(secp, rng, keys)
+        .await?
         .as_json();
     let msg: String = encrypt_private_zap_message(rng, &secret_key, &data.public_key, msg)?;
 
@@ -316,7 +318,8 @@ where
     Ok(EventBuilder::new(Kind::ZapRequest, "")
         .tags(tags)
         .custom_created_at(created_at)
-        .sign_with_ctx(secp, rng, &private_zap_keys)?)
+        .sign_with_ctx(secp, rng, &private_zap_keys)
+        .await?)
 }
 
 /// Create NIP57 encryption key for **private** zap
@@ -429,15 +432,15 @@ fn decrypt_private_zap_message(key: [u8; 32], private_zap_event: &Event) -> Resu
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_encrypt_decrypt_private_zap_message() {
+    #[tokio::test]
+    async fn test_encrypt_decrypt_private_zap_message() {
         let alice_keys = Keys::generate();
         let bob_keys = Keys::generate();
 
         let relays = [RelayUrl::parse("wss://relay.damus.io").unwrap()];
         let msg = "Private Zap message!";
         let data = ZapRequestData::new(bob_keys.public_key(), relays).message(msg);
-        let private_zap = private_zap_request(data, &alice_keys).unwrap();
+        let private_zap = private_zap_request(data, &alice_keys).await.unwrap();
 
         let private_zap_msg = decrypt_sent_private_zap_message(
             alice_keys.secret_key(),

--- a/crates/nostr/src/nips/nip59.rs
+++ b/crates/nostr/src/nips/nip59.rs
@@ -182,7 +182,9 @@ mod tests {
                 .unwrap();
 
         // Compose Gift Wrap event
-        let rumor: UnsignedEvent = EventBuilder::text_note("Test").build(sender_keys.public_key);
+        let rumor: UnsignedEvent = EventBuilder::text_note("Test")
+            .build(sender_keys.public_key)
+            .await;
         let event: Event =
             EventBuilder::gift_wrap(&sender_keys, &receiver_keys.public_key(), rumor.clone(), [])
                 .await
@@ -218,8 +220,9 @@ mod tests {
 
         // Construct a rumor that lies about its pubkey but is still wrapped/signed
         // by `sender_keys`. This mimics a spoofing attempt the recipient must reject.
-        let rumor: UnsignedEvent =
-            EventBuilder::text_note("spoofed").build(impersonated_keys.public_key());
+        let rumor: UnsignedEvent = EventBuilder::text_note("spoofed")
+            .build(impersonated_keys.public_key())
+            .await;
 
         let gift_wrap: Event =
             EventBuilder::gift_wrap(&sender_keys, &receiver_keys.public_key(), rumor, [])

--- a/crates/nwc/src/lib.rs
+++ b/crates/nwc/src/lib.rs
@@ -133,7 +133,7 @@ impl NostrWalletConnect {
         tracing::debug!("Sending request '{}'", req.as_json());
 
         // Convert request to event
-        let event: Event = req.to_event(&self.uri)?;
+        let event: Event = req.to_event(&self.uri).await?;
 
         // Construct the filter to wait for the response
         let filter = Filter::new()

--- a/database/nostr-database-test-suite/src/lib.rs
+++ b/database/nostr-database-test-suite/src/lib.rs
@@ -39,8 +39,8 @@ macro_rules! database_unit_tests {
                 .collect()
         }
 
-        fn build_event(keys: &Keys, builder: EventBuilder) -> Event {
-            builder.sign_with_keys(keys).expect("Failed to build and sign event")
+        async fn build_event(keys: &Keys, builder: EventBuilder) -> Event {
+            builder.sign_with_keys(keys).await.expect("Failed to build and sign event")
         }
 
         // Return the number of added events
@@ -49,18 +49,18 @@ macro_rules! database_unit_tests {
             let keys_b = Keys::generate();
 
             let events = vec![
-                build_event(&keys_a, EventBuilder::text_note("Text Note A")),
-                build_event(&keys_b, EventBuilder::text_note("Text Note B")),
+                build_event(&keys_a, EventBuilder::text_note("Text Note A")).await,
+                build_event(&keys_b, EventBuilder::text_note("Text Note B")).await,
                 build_event(&keys_a, EventBuilder::metadata(
                     &Metadata::new().name("account-a").display_name("Account A"),
-                )),
+                )).await,
                 build_event(&keys_b, EventBuilder::metadata(
                     &Metadata::new().name("account-b").display_name("Account B"),
-                )),
+                )).await,
                 build_event(&keys_a, EventBuilder::new(Kind::Custom(33_333), "")
-                    .tag(Tag::identifier("my-id-a"))),
+                    .tag(Tag::identifier("my-id-a"))).await,
                 build_event(&keys_b, EventBuilder::new(Kind::Custom(33_333), "")
-                    .tag(Tag::identifier("my-id-b"))),
+                    .tag(Tag::identifier("my-id-b"))).await,
             ];
 
             // Store
@@ -82,7 +82,7 @@ macro_rules! database_unit_tests {
             builder: EventBuilder,
             keys: &Keys,
         ) -> (Event, SaveEventStatus) {
-            let event = builder.sign_with_keys(keys).expect("Failed to sign event");
+            let event = builder.sign_with_keys(keys).await.expect("Failed to sign event");
             let status = store.save_event(&event).await.expect("Failed to save event");
             (event, status)
         }
@@ -227,7 +227,7 @@ macro_rules! database_unit_tests {
             let event1 = EventBuilder::metadata(&metadata1)
                 .custom_created_at(Timestamp::from_secs(1000))
                 .sign_with_keys(&keys)
-                .expect("Failed to sign");
+                .await.expect("Failed to sign");
 
             store.save_event(&event1).await.expect("Failed to save event");
 
@@ -236,7 +236,7 @@ macro_rules! database_unit_tests {
             let event2 = EventBuilder::metadata(&metadata2)
                 .custom_created_at(Timestamp::from_secs(2000))
                 .sign_with_keys(&keys)
-                .expect("Failed to sign");
+                .await.expect("Failed to sign");
 
             store.save_event(&event2).await.expect("Failed to save event");
 
@@ -261,7 +261,7 @@ macro_rules! database_unit_tests {
                 .tag(Tag::identifier("test-id"))
                 .custom_created_at(Timestamp::from_secs(1000))
                 .sign_with_keys(&keys)
-                .expect("Failed to sign");
+                .await.expect("Failed to sign");
 
             store.save_event(&event1).await.expect("Failed to save event");
 
@@ -270,7 +270,7 @@ macro_rules! database_unit_tests {
                 .tag(Tag::identifier("test-id"))
                 .custom_created_at(Timestamp::from_secs(2000))
                 .sign_with_keys(&keys)
-                .expect("Failed to sign");
+                .await.expect("Failed to sign");
 
             store.save_event(&event2).await.expect("Failed to save event");
 
@@ -295,10 +295,10 @@ macro_rules! database_unit_tests {
             // Create events to delete
             let event1 = EventBuilder::text_note("To be deleted 1")
                 .sign_with_keys(&keys)
-                .expect("Failed to sign");
+                .await.expect("Failed to sign");
             let event2 = EventBuilder::text_note("To be deleted 2")
                 .sign_with_keys(&keys)
-                .expect("Failed to sign");
+                .await.expect("Failed to sign");
 
             store.save_event(&event1).await.expect("Failed to save event");
             store.save_event(&event2).await.expect("Failed to save event");
@@ -307,7 +307,7 @@ macro_rules! database_unit_tests {
             let deletion =
                 EventBuilder::delete(EventDeletionRequest::new().id(event1.id).id(event2.id))
                     .sign_with_keys(&keys)
-                    .expect("Failed to sign");
+                    .await.expect("Failed to sign");
 
             store.save_event(&deletion)
                 .await
@@ -340,7 +340,7 @@ macro_rules! database_unit_tests {
             // Create events to delete
             let event = EventBuilder::new(Kind::Custom(11_111), "To be deleted 1")
                 .sign_with_keys(&keys)
-                .expect("Failed to sign");
+                .await.expect("Failed to sign");
 
             let status = store.save_event(&event).await.expect("Failed to save event");
 
@@ -352,7 +352,7 @@ macro_rules! database_unit_tests {
             let deletion =
                 EventBuilder::delete(req)
                     .sign_with_keys(&keys)
-                    .expect("Failed to sign");
+                    .await.expect("Failed to sign");
 
             store.save_event(&deletion)
                 .await
@@ -632,7 +632,7 @@ macro_rules! database_unit_tests {
             let keys = Keys::generate();
 
             // Create and save an event
-            let event = build_event(&keys, EventBuilder::text_note("Test event"));
+            let event = build_event(&keys, EventBuilder::text_note("Test event")).await;
 
             let status = store.save_event(&event).await.expect("Failed to save event");
             assert_eq!(status, SaveEventStatus::Success);
@@ -656,7 +656,7 @@ macro_rules! database_unit_tests {
 
             // Create and save a Kind 5 deletion event
             let deletion_event = build_event(&keys, EventBuilder::new(Kind::EventDeletion, "")
-                .tag(Tag::event(event.id)));
+                .tag(Tag::event(event.id))).await;
 
             let del_status = store
                 .save_event(&deletion_event)
@@ -892,24 +892,24 @@ macro_rules! database_unit_tests {
 
             let event1 = EventBuilder::text_note("Hi 1")
                 .sign_with_keys(&to_vanish)
-                .unwrap();
+                .await.unwrap();
             let event2 = EventBuilder::text_note("Hi 2")
                 .sign_with_keys(&to_vanish)
-                .unwrap();
+                .await.unwrap();
             let replaceable = EventBuilder::contact_list([
                 Contact::new(Keys::generate().public_key),
                 Contact::new(Keys::generate().public_key),
             ])
             .sign_with_keys(&to_vanish)
-            .unwrap();
+            .await.unwrap();
             let addresable = EventBuilder::long_form_text_note("LONG")
                 .tag(Tag::identifier("lorem-ipsum".to_string()))
                 .sign_with_keys(&to_vanish)
-                .unwrap();
+                .await.unwrap();
             let dummy_gift_wrap = EventBuilder::new(Kind::GiftWrap, ":)")
                 .tag(Tag::public_key(to_vanish.public_key))
                 .sign_with_keys(&helper)
-                .unwrap();
+                .await.unwrap();
 
             store.save_event(&event1).await.unwrap();
             store.save_event(&event2).await.unwrap();
@@ -941,6 +941,7 @@ macro_rules! database_unit_tests {
             let request_to_vanish = EventBuilder::request_vanish(VanishTarget::AllRelays)
                 .unwrap()
                 .sign_with_keys(&to_vanish)
+                .await
                 .unwrap();
             store.save_event(&request_to_vanish).await.unwrap();
 

--- a/database/nostr-lmdb/src/store/filter.rs
+++ b/database/nostr-lmdb/src/store/filter.rs
@@ -174,16 +174,17 @@ mod tests {
 
     use super::*;
 
-    fn create_test_event(content: &str) -> Event {
+    async fn create_test_event(content: &str) -> Event {
         let keys = Keys::generate();
         EventBuilder::text_note(content)
             .sign_with_keys(&keys)
+            .await
             .unwrap()
     }
 
-    #[test]
-    fn test_search_match_in_content() {
-        let event = create_test_event("Hello World");
+    #[tokio::test]
+    async fn test_search_match_in_content() {
+        let event = create_test_event("Hello World").await;
         let event: EventBorrow = (&event).into();
 
         let mut filter = DatabaseFilter::from(Filter::new());
@@ -200,12 +201,13 @@ mod tests {
         assert!(!filter.match_event(&event));
     }
 
-    #[test]
-    fn test_search_match_in_tags() {
+    #[tokio::test]
+    async fn test_search_match_in_tags() {
         let keys = Keys::generate();
         let event = EventBuilder::text_note("content")
             .tag(Tag::parse(["title", "Search userfacing tags"]).unwrap())
             .sign_with_keys(&keys)
+            .await
             .unwrap();
         let event: EventBorrow = (&event).into();
 
@@ -218,9 +220,9 @@ mod tests {
         assert!(!filter.match_event(&event));
     }
 
-    #[test]
-    fn test_search_empty_query() {
-        let event = create_test_event("test");
+    #[tokio::test]
+    async fn test_search_empty_query() {
+        let event = create_test_event("test").await;
         let event: EventBorrow = (&event).into();
         let mut filter = DatabaseFilter::from(Filter::new());
 
@@ -228,18 +230,18 @@ mod tests {
         assert!(!filter.match_event(&event));
     }
 
-    #[test]
-    fn test_search_no_query() {
-        let event = create_test_event("test");
+    #[tokio::test]
+    async fn test_search_no_query() {
+        let event = create_test_event("test").await;
         let event: EventBorrow = (&event).into();
         let filter = DatabaseFilter::from(Filter::new());
 
         assert!(filter.match_event(&event));
     }
 
-    #[test]
-    fn test_search_partial_match() {
-        let event = create_test_event("nostr protocol");
+    #[tokio::test]
+    async fn test_search_partial_match() {
+        let event = create_test_event("nostr protocol").await;
         let event: EventBorrow = (&event).into();
         let mut filter = DatabaseFilter::from(Filter::new());
 

--- a/database/nostr-lmdb/src/store/ingester.rs
+++ b/database/nostr-lmdb/src/store/ingester.rs
@@ -398,6 +398,7 @@ mod tests {
         // Create a mix of valid and duplicate events
         let event1 = EventBuilder::text_note("Event 1")
             .sign_with_keys(&keys)
+            .await
             .expect("Failed to sign event");
 
         // Save event1 first
@@ -409,10 +410,12 @@ mod tests {
         // Now try to save a batch with duplicate and new events
         let event2 = EventBuilder::text_note("Event 2")
             .sign_with_keys(&keys)
+            .await
             .expect("Failed to sign event");
 
         let event3 = EventBuilder::text_note("Event 3")
             .sign_with_keys(&keys)
+            .await
             .expect("Failed to sign event");
 
         let futures = vec![
@@ -454,6 +457,7 @@ mod tests {
         for i in 0..10 {
             let event = EventBuilder::text_note(format!("Event to delete {}", i))
                 .sign_with_keys(&keys)
+                .await
                 .expect("Failed to sign event");
             store
                 .save_event(&event)
@@ -465,10 +469,12 @@ mod tests {
         // Now create a mixed batch of saves and deletes
         let new_event1 = EventBuilder::text_note("New event 1")
             .sign_with_keys(&keys)
+            .await
             .expect("Failed to sign event");
 
         let new_event2 = EventBuilder::text_note("New event 2")
             .sign_with_keys(&keys)
+            .await
             .expect("Failed to sign event");
 
         // Execute mixed operations concurrently

--- a/database/nostr-lmdb/src/store/lmdb/mod.rs
+++ b/database/nostr-lmdb/src/store/lmdb/mod.rs
@@ -1409,16 +1409,17 @@ mod tests {
 
     use super::*;
 
-    fn create_test_event(kind: u16, created_at: u64) -> Event {
+    async fn create_test_event(kind: u16, created_at: u64) -> Event {
         let keys = Keys::generate();
         EventBuilder::new(Kind::from(kind), "test content")
             .custom_created_at(Timestamp::from_secs(created_at))
             .sign_with_keys(&keys)
+            .await
             .unwrap()
     }
 
-    #[test]
-    fn test_migration_v1_to_v2() {
+    #[tokio::test]
+    async fn test_migration_v1_to_v2() {
         // Create a temporary directory for the test database
         let temp_dir = TempDir::new().unwrap();
         let lmdb_builder = NostrLmdbBuilder::new(temp_dir.path())
@@ -1433,10 +1434,10 @@ mod tests {
             let mut fbb = FlatBufferBuilder::new();
 
             // Insert some test events with different kinds
-            let event1 = create_test_event(1, 1000);
-            let event2 = create_test_event(1, 1001);
-            let event3 = create_test_event(3, 1002);
-            let event4 = create_test_event(5, 1003);
+            let event1 = create_test_event(1, 1000).await;
+            let event2 = create_test_event(1, 1001).await;
+            let event3 = create_test_event(3, 1002).await;
+            let event4 = create_test_event(5, 1003).await;
 
             lmdb.store(&mut txn, &mut fbb, &event1).unwrap();
             lmdb.store(&mut txn, &mut fbb, &event2).unwrap();

--- a/database/nostr-sqlite/src/store.rs
+++ b/database/nostr-sqlite/src/store.rs
@@ -892,6 +892,7 @@ mod tests {
             .tag(Tag::parse(["name", "delta-token"]).unwrap())
             .tag(Tag::identifier("epsilon-token"))
             .sign_with_keys(&keys)
+            .await
             .unwrap();
 
         assert!(db.save_event(&event).await.unwrap().is_success());

--- a/gossip/nostr-gossip-test-suite/src/lib.rs
+++ b/gossip/nostr-gossip-test-suite/src/lib.rs
@@ -104,7 +104,7 @@ macro_rules! gossip_unit_tests {
                     },
                 ))
                 .sign_with_keys(&keys)
-                .unwrap();
+                .await.unwrap();
 
             store.process(&event, None).await.unwrap();
 
@@ -131,7 +131,7 @@ macro_rules! gossip_unit_tests {
             for i in 0..5 {
                 let event = EventBuilder::text_note(format!("Test {i}"))
                     .sign_with_keys(&keys)
-                    .unwrap();
+                    .await.unwrap();
 
                 store.process(&event, Some(&relay_url)).await.unwrap();
             }

--- a/sdk/src/client/api/send_event.rs
+++ b/sdk/src/client/api/send_event.rs
@@ -472,6 +472,7 @@ mod tests {
         let keys = Keys::generate();
         let event = EventBuilder::text_note("Broadcast test")
             .sign_with_keys(&keys)
+            .await
             .unwrap();
 
         // Send event (broadcast to all WRITE relays by default)
@@ -500,6 +501,7 @@ mod tests {
         let keys = Keys::generate();
         let event = EventBuilder::text_note("Targeted test")
             .sign_with_keys(&keys)
+            .await
             .unwrap();
 
         // Send only to relay 1
@@ -541,6 +543,7 @@ mod tests {
         let keys = Keys::generate();
         let event = EventBuilder::text_note("Force to all test")
             .sign_with_keys(&keys)
+            .await
             .unwrap();
 
         // Force send to all WRITE instead of using gossip
@@ -572,6 +575,7 @@ mod tests {
         let keys_a = Keys::generate();
         let relay_list = EventBuilder::relay_list([(outbox_url.clone(), None)])
             .sign_with_keys(&keys_a)
+            .await
             .unwrap();
         let res = discovery_mock.add_event(relay_list).await.unwrap();
         assert!(res.is_success());
@@ -621,6 +625,7 @@ mod tests {
         // - Send the event to the outbox and public relay
         let event = EventBuilder::text_note("Gossip test")
             .sign_with_keys(&keys_a)
+            .await
             .unwrap();
 
         // Send event using default config (must be sent to gossip)
@@ -654,6 +659,7 @@ mod tests {
         let keys = Keys::generate();
         let event = EventBuilder::text_note("Broadcast test")
             .sign_with_keys(&keys)
+            .await
             .unwrap();
 
         // Send event
@@ -678,6 +684,7 @@ mod tests {
         let bob_keys = Keys::generate();
         let relay_list = EventBuilder::nip17_relay_list([inbox_url.clone()])
             .sign_with_keys(&bob_keys)
+            .await
             .unwrap();
         let res = discovery_mock.add_event(relay_list).await.unwrap();
         assert!(res.is_success());
@@ -711,6 +718,7 @@ mod tests {
         let event = EventBuilder::new(Kind::GiftWrap, "payload")
             .tag(Tag::public_key(bob_keys.public_key))
             .sign_with_keys(&Keys::generate())
+            .await
             .unwrap();
         let output = client.send_event(&event).to_nip17().await.unwrap();
 
@@ -741,6 +749,7 @@ mod tests {
         let event = EventBuilder::new(Kind::GiftWrap, "payload")
             .tag(Tag::public_key(bob_keys.public_key))
             .sign_with_keys(&Keys::generate())
+            .await
             .unwrap();
 
         // Send event

--- a/sdk/src/client/gossip/resolver.rs
+++ b/sdk/src/client/gossip/resolver.rs
@@ -329,7 +329,7 @@ mod tests {
         ("wss://relay.snort.social", Some(RelayMetadata::Read)),
     ];
 
-    fn build_relay_list_event(
+    async fn build_relay_list_event(
         secret_key: &str,
         relays: Vec<(&str, Option<RelayMetadata>)>,
     ) -> Event {
@@ -337,17 +337,16 @@ mod tests {
         let list = relays
             .into_iter()
             .filter_map(|(url, m)| Some((RelayUrl::parse(url).ok()?, m)));
-        EventBuilder::relay_list(list)
-            .sign_with_keys(&keys)
-            .unwrap()
+        let event = EventBuilder::relay_list(list).sign_with_keys(&keys).await;
+        event.unwrap()
     }
 
     async fn setup() -> GossipRelayResolver {
         let db = NostrGossipMemory::unbounded();
 
         let events = vec![
-            build_relay_list_event(SECRET_KEY_A, KEY_A_RELAYS.to_vec()),
-            build_relay_list_event(SECRET_KEY_B, KEY_B_RELAYS.to_vec()),
+            build_relay_list_event(SECRET_KEY_A, KEY_A_RELAYS.to_vec()).await,
+            build_relay_list_event(SECRET_KEY_B, KEY_B_RELAYS.to_vec()).await,
         ];
 
         for event in events {

--- a/sdk/src/relay/api/fetch_events.rs
+++ b/sdk/src/relay/api/fetch_events.rs
@@ -118,6 +118,7 @@ mod tests {
         for i in 0..num_events {
             let event = EventBuilder::text_note(i.to_string())
                 .sign_with_keys(&keys)
+                .await
                 .unwrap();
             relay.send_event(&event).await.unwrap();
         }
@@ -185,6 +186,7 @@ mod tests {
         // Send an event
         let event = EventBuilder::text_note("Test")
             .sign_with_keys(&keys)
+            .await
             .unwrap();
         relay.send_event(&event).await.unwrap();
 
@@ -241,6 +243,7 @@ mod tests {
         // Send an event
         let event = EventBuilder::text_note("Test")
             .sign_with_keys(&keys)
+            .await
             .unwrap();
         relay.send_event(&event).await.unwrap();
 
@@ -321,6 +324,7 @@ mod tests {
             // Build and send event
             let event = EventBuilder::metadata(&Metadata::new().name("Test"))
                 .sign_with_keys(&keys)
+                .await
                 .unwrap();
             r.send_event(&event).await.unwrap();
         });
@@ -352,6 +356,7 @@ mod tests {
                 // Build and send event
                 let event = EventBuilder::text_note("Additional")
                     .sign_with_keys(&keys)
+                    .await
                     .unwrap();
                 r.send_event(&event).await.unwrap();
             }
@@ -383,6 +388,7 @@ mod tests {
                 // Build and send event
                 let event = EventBuilder::text_note("Additional")
                     .sign_with_keys(&keys)
+                    .await
                     .unwrap();
                 r.send_event(&event).await.unwrap();
 

--- a/sdk/src/relay/api/send_event.rs
+++ b/sdk/src/relay/api/send_event.rs
@@ -183,6 +183,7 @@ mod tests {
         let keys = Keys::generate();
         let event = EventBuilder::text_note("Test")
             .sign_with_keys(&keys)
+            .await
             .unwrap();
         relay.send_event(&event).await.unwrap();
     }
@@ -205,6 +206,7 @@ mod tests {
         let keys = Keys::generate();
         let event = EventBuilder::text_note("Test")
             .sign_with_keys(&keys)
+            .await
             .unwrap();
 
         // Disable NIP42 auto auth
@@ -250,6 +252,7 @@ mod tests {
         let keys = Keys::generate();
         let event = EventBuilder::text_note("Test")
             .sign_with_keys(&keys)
+            .await
             .unwrap();
 
         let relay: Relay = Relay::builder(url).signer(keys).build();

--- a/sdk/src/relay/api/subscribe.rs
+++ b/sdk/src/relay/api/subscribe.rs
@@ -218,7 +218,10 @@ mod tests {
 
         // Event
         let kind = Kind::Custom(22_222); // Ephemeral kind
-        let event: Event = EventBuilder::new(kind, "").sign_with_keys(&keys).unwrap();
+        let event: Event = EventBuilder::new(kind, "")
+            .sign_with_keys(&keys)
+            .await
+            .unwrap();
 
         let event_id: EventId = event.id;
 

--- a/sdk/src/relay/api/sync.rs
+++ b/sdk/src/relay/api/sync.rs
@@ -638,12 +638,15 @@ mod tests {
         let local_events = [
             EventBuilder::text_note("Local 1")
                 .sign_with_keys(&Keys::generate())
+                .await
                 .unwrap(),
             EventBuilder::text_note("Local 2")
                 .sign_with_keys(&Keys::generate())
+                .await
                 .unwrap(),
             EventBuilder::new(Kind::Custom(123), "Local 123")
                 .sign_with_keys(&Keys::generate())
+                .await
                 .unwrap(),
         ];
 
@@ -669,12 +672,15 @@ mod tests {
             local_events[0].clone(),
             EventBuilder::text_note("Test 2")
                 .sign_with_keys(&Keys::generate())
+                .await
                 .unwrap(),
             EventBuilder::text_note("Test 3")
                 .sign_with_keys(&Keys::generate())
+                .await
                 .unwrap(),
             EventBuilder::new(Kind::Custom(123), "Test 4")
                 .sign_with_keys(&Keys::generate())
+                .await
                 .unwrap(),
         ];
 

--- a/sdk/src/relay/mod.rs
+++ b/sdk/src/relay/mod.rs
@@ -966,6 +966,7 @@ mod tests {
         // Test wake up when sending an event
         let event = EventBuilder::text_note("text wake-up")
             .sign_with_keys(&Keys::generate())
+            .await
             .unwrap();
         relay.send_event(&event).await.unwrap();
         assert_eq!(relay.status(), RelayStatus::Connected);

--- a/signer/nostr-browser-signer-proxy/examples/browser-signer-proxy.rs
+++ b/signer/nostr-browser-signer-proxy/examples/browser-signer-proxy.rs
@@ -38,7 +38,9 @@ async fn main() -> Result<()> {
     // Build a gift wrap
     let receiver =
         PublicKey::parse("npub1drvpzev3syqt0kjrls50050uzf25gehpz9vgdw08hvex7e0vgfeq0eseet")?;
-    let rumor = EventBuilder::new(Kind::Custom(123), "test").build(public_key);
+    let rumor = EventBuilder::new(Kind::Custom(123), "test")
+        .build(public_key)
+        .await;
     let gift_wrap = EventBuilder::gift_wrap(&proxy, &receiver, rumor, []).await?;
     println!("Gift wrap: {}", gift_wrap.as_json());
 

--- a/signer/nostr-browser-signer-proxy/examples/custom_html.rs
+++ b/signer/nostr-browser-signer-proxy/examples/custom_html.rs
@@ -56,7 +56,9 @@ async fn main() -> Result<()> {
     // Build a gift wrap
     let receiver =
         PublicKey::parse("npub1drvpzev3syqt0kjrls50050uzf25gehpz9vgdw08hvex7e0vgfeq0eseet")?;
-    let rumor = EventBuilder::new(Kind::Custom(123), "test").build(public_key);
+    let rumor = EventBuilder::new(Kind::Custom(123), "test")
+        .build(public_key)
+        .await;
     let gift_wrap = EventBuilder::gift_wrap(&proxy, &receiver, rumor, []).await?;
     println!("Gift wrap: {}", gift_wrap.as_json());
 

--- a/signer/nostr-connect/src/client.rs
+++ b/signer/nostr-connect/src/client.rs
@@ -225,7 +225,8 @@ impl NostrConnect {
         let req_id = msg.id().to_string();
         let event: Event =
             EventBuilder::nostr_connect(&self.client_keys, remote_signer_public_key, msg)?
-                .sign_with_keys(&self.client_keys)?;
+                .sign_with_keys(&self.client_keys)
+                .await?;
 
         let mut notifications = self.client.notifications();
 

--- a/signer/nostr-connect/src/signer.rs
+++ b/signer/nostr-connect/src/signer.rs
@@ -113,7 +113,8 @@ impl NostrConnectRemoteSigner {
 
         let msg: NostrConnectMessage = NostrConnectMessage::request(&req);
         let event: Event = EventBuilder::nostr_connect(&self.keys.signer, public_key, msg)?
-            .sign_with_keys(&self.keys.signer)?;
+            .sign_with_keys(&self.keys.signer)
+            .await?;
         self.client.send_event(&event).await?;
         Ok(())
     }
@@ -317,7 +318,8 @@ impl NostrConnectRemoteSigner {
                                     event.pubkey,
                                     msg,
                                 )?
-                                .sign_with_keys(&self.keys.signer)?;
+                                .sign_with_keys(&self.keys.signer)
+                                .await?;
                                 self.client.send_event(&event).await?;
                             }
                         }


### PR DESCRIPTION
Move single-threaded and multi-threaded PoW mining logic out of `EventBuilder` and into a new `PowAdapter` trait in the `nip13` module. This allows users to inject custom PoW computation strategies via the new `EventBuilder::pow_adapter` method.

As a consequence of adding `Arc<dyn PowAdapter>` to `EventBuilder`, the `Clone`, `Eq`, `PartialEq`, and `Hash` trait implementations have been removed, and `EventBuilder::build` is now async.

Fixes: https://github.com/rust-nostr/nostr/issues/1309

### Notes to the reviewers

Even though `EventBuilder::build` is now async, the default (`SingleThreadPow`
and `MultiThreadPow`) PoW miners will still block the async runtime.
`MultiThreadPow` uses a busy-wait loop that doesn't yield, which will freeze
the executor thread and starve other tasks. This will need to be wrapped in
`spawn_blocking` in a future (ref #921).

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
