### PR TITLE
memory: add relay-specific NIP-62 support

### DIFF
--- a/database/nostr-memory/src/builder.rs
+++ b/database/nostr-memory/src/builder.rs
@@ -2,6 +2,8 @@
 
 use core::num::NonZeroUsize;
 
+use nostr::types::RelayUrl;
+
 use crate::MemoryDatabase;
 
 /// Memory Database Builder
@@ -13,8 +15,10 @@ pub struct MemoryDatabaseBuilder {
     ///
     /// Defaults to `true`
     pub(crate) process_nip09: bool,
-    /// Whether to process request to vanish (NIP-62) events
+    /// Whether to process request to vanish (NIP-62) events.
     pub(crate) process_nip62: bool,
+    /// Relay URL for relay-specific request to vanish (NIP-62).
+    pub(crate) relay_url: Option<RelayUrl>,
 }
 
 impl Default for MemoryDatabaseBuilder {
@@ -23,6 +27,7 @@ impl Default for MemoryDatabaseBuilder {
             max_events: None,
             process_nip09: true,
             process_nip62: true,
+            relay_url: None,
         }
     }
 }
@@ -52,6 +57,13 @@ impl MemoryDatabaseBuilder {
     #[inline]
     pub fn process_nip62(mut self, process_nip62: bool) -> Self {
         self.process_nip62 = process_nip62;
+        self
+    }
+
+    /// Set the relay URL to handle relay-specific request to vanish
+    #[inline]
+    pub fn relay_url(mut self, relay_url: RelayUrl) -> Self {
+        self.relay_url = Some(relay_url);
         self
     }
 

--- a/database/nostr-memory/src/lib.rs
+++ b/database/nostr-memory/src/lib.rs
@@ -50,6 +50,7 @@ impl MemoryDatabase {
         let options = MemoryOptions {
             process_nip09: builder.process_nip09,
             process_nip62: builder.process_nip62,
+            relay_url: builder.relay_url,
         };
 
         Self {

--- a/database/nostr-memory/src/store.rs
+++ b/database/nostr-memory/src/store.rs
@@ -60,10 +60,11 @@ impl QueryByParamReplaceable {
 }
 
 /// Options for the memory database
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Default)]
 pub(crate) struct MemoryOptions {
     pub(crate) process_nip09: bool,
     pub(crate) process_nip62: bool,
+    pub(crate) relay_url: Option<RelayUrl>,
 }
 
 enum QueryPattern {
@@ -299,8 +300,12 @@ impl MemoryStore {
                 }
             }
         } else if self.options.process_nip62 && event.kind == Kind::RequestToVanish {
-            // For now, handling `ALL_RELAYS` only
-            if let Some(TagStandard::AllRelays) = event.tags.find_standardized(TagKind::Relay) {
+            let is_targeted = event.tags.filter_standardized(TagKind::Relay).any(|tag| {
+                matches!(tag, TagStandard::AllRelays)
+                    || matches!(tag, TagStandard::Relay(relay) if Some(relay) == self.options.relay_url.as_ref())
+            });
+
+            if is_targeted {
                 self.handle_request_to_vanish(&event.pubkey);
             }
         }
@@ -645,7 +650,7 @@ impl MemoryStore {
 
         // Reset helper to default
         *self = Self {
-            options: self.options,
+            options: self.options.clone(),
             ..Default::default()
         };
 


### PR DESCRIPTION
Add `MemoryDatabaseBuilder::relay_url` to enable relays to accept relay-specific NIP-62 events for local vanish requests.

Related-to: https://github.com/rust-nostr/nostr/issues/1288

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [ ] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
