### PR TITLE
lmdb: add relay-specific NIP-62 support

### DIFF
--- a/database/nostr-lmdb/CHANGELOG.md
+++ b/database/nostr-lmdb/CHANGELOG.md
@@ -40,6 +40,7 @@
 - Add `NostrLmdb::reindex` (https://github.com/rust-nostr/nostr/pull/1143)
 - Support NIP-62 `RequestToVanish` event kind (https://github.com/rust-nostr/nostr/pull/1210)
 - Options to enable and disable NIP-09 and NIP-62 (https://github.com/rust-nostr/nostr/pull/1268)
+- Relay specific request to vanish (NIP-62) (https://github.com/rust-nostr/nostr/pull/1316)
 
 ## v0.44.1 - 2026/01/29
 

--- a/database/nostr-lmdb/src/lib.rs
+++ b/database/nostr-lmdb/src/lib.rs
@@ -58,6 +58,8 @@ pub struct NostrLmdbBuilder {
     ///
     /// Defaults to `true`
     pub process_nip09: bool,
+    /// Relay URL for relay-specific request to vanish (NIP-62)
+    pub relay_url: Option<RelayUrl>,
 }
 
 impl NostrLmdbBuilder {
@@ -73,6 +75,7 @@ impl NostrLmdbBuilder {
             additional_dbs: 0,
             process_nip62: true,
             process_nip09: true,
+            relay_url: None,
         }
     }
 
@@ -115,6 +118,13 @@ impl NostrLmdbBuilder {
     /// Defaults to `true`
     pub fn process_nip09(mut self, process_nip09: bool) -> Self {
         self.process_nip09 = process_nip09;
+        self
+    }
+
+    /// Set the relay URL to handle relay-specific request to vanish
+    #[inline]
+    pub fn relay_url(mut self, relay_url: RelayUrl) -> Self {
+        self.relay_url = Some(relay_url);
         self
     }
 

--- a/database/nostr-lmdb/src/store/lmdb/mod.rs
+++ b/database/nostr-lmdb/src/store/lmdb/mod.rs
@@ -70,12 +70,14 @@ impl QueryFilterPattern {
 }
 
 /// LMDB options
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub(crate) struct LmdbOptions {
     /// Whether to process request to vanish (NIP-62) events
     pub(crate) process_nip62: bool,
     /// Whether to process event deletion request (NIP-09) events
     pub(crate) process_nip09: bool,
+    /// Relay URL for relay-specific request to vanish (NIP-62).
+    pub(crate) relay_url: Option<RelayUrl>,
 }
 
 #[derive(Debug, Clone)]
@@ -192,6 +194,7 @@ impl Lmdb {
         let options = LmdbOptions {
             process_nip62: builder.process_nip62,
             process_nip09: builder.process_nip09,
+            relay_url: builder.relay_url,
         };
 
         let lmdb = Self {
@@ -503,8 +506,12 @@ impl Lmdb {
 
         // Handle request to vanish
         if self.options.process_nip62 && event.kind == Kind::RequestToVanish {
-            // For now, handling `ALL_RELAYS` only
-            if let Some(TagStandard::AllRelays) = event.tags.find_standardized(TagKind::Relay) {
+            let is_targeted = event.tags.filter_standardized(TagKind::Relay).any(|tag| {
+                matches!(tag, TagStandard::AllRelays)
+                    || matches!(tag, TagStandard::Relay(relay) if Some(relay) == self.options.relay_url.as_ref())
+            });
+
+            if is_targeted {
                 self.handle_request_to_vanish(txn, &event.pubkey)?;
             }
         }


### PR DESCRIPTION
Add `NostrLmdbBuilder::relay_url` to enable relays to accept relay-specific NIP-62 events for local vanish requests.

Related-to: https://github.com/rust-nostr/nostr/issues/1288

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [ ] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
