### PR TITLE
sqlite: add relay-specific NIP-62 support

### DIFF
--- a/database/nostr-sqlite/src/builder.rs
+++ b/database/nostr-sqlite/src/builder.rs
@@ -2,6 +2,8 @@
 
 use std::path::{Path, PathBuf};
 
+use nostr::types::RelayUrl;
+
 use crate::error::Error;
 use crate::store::NostrSqlite;
 
@@ -25,6 +27,8 @@ pub struct NostrSqliteBuilder {
     pub(crate) process_nip62: bool,
     /// Whether to process event deletion request (NIP-09) events
     pub(crate) process_nip09: bool,
+    /// Relay URL for relay-specific request to vanish (NIP-62)
+    pub(crate) relay_url: Option<RelayUrl>,
 }
 
 impl NostrSqliteBuilder {
@@ -84,6 +88,13 @@ impl NostrSqliteBuilder {
         self
     }
 
+    /// Set the relay URL to handle relay-specific request to vanish
+    #[inline]
+    pub fn relay_url(mut self, relay_url: RelayUrl) -> Self {
+        self.relay_url = Some(relay_url);
+        self
+    }
+
     /// Build [`NostrSqlite`] database
     #[inline]
     pub async fn build(self) -> Result<NostrSqlite, Error> {
@@ -101,6 +112,7 @@ impl Default for NostrSqliteBuilder {
             db_type: Default::default(),
             process_nip62: true,
             process_nip09: true,
+            relay_url: None,
         }
     }
 }

--- a/database/nostr-sqlite/src/store.rs
+++ b/database/nostr-sqlite/src/store.rs
@@ -28,23 +28,11 @@ enum SqlSelectClause {
 #[derive(Debug, Clone, Default)]
 pub(crate) struct NostrSqliteOptions {
     /// Whether to process request to vanish (NIP-62) events
-    process_nip62: bool,
+    pub(crate) process_nip62: bool,
     /// Whether to process event deletion request (NIP-09) events
-    process_nip09: bool,
-}
-
-impl NostrSqliteOptions {
-    #[inline]
-    fn process_nip09(mut self, process_nip09: bool) -> Self {
-        self.process_nip09 = process_nip09;
-        self
-    }
-
-    #[inline]
-    fn process_nip62(mut self, process_nip62: bool) -> Self {
-        self.process_nip62 = process_nip62;
-        self
-    }
+    pub(crate) process_nip09: bool,
+    /// Relay URL for relay-specific request to vanish (NIP-62).
+    pub(crate) relay_url: Option<RelayUrl>,
 }
 
 /// Nostr SQLite database
@@ -110,9 +98,11 @@ impl NostrSqlite {
     }
 
     pub(crate) async fn from_builder(builder: NostrSqliteBuilder) -> Result<Self, Error> {
-        let options = NostrSqliteOptions::default()
-            .process_nip09(builder.process_nip09)
-            .process_nip62(builder.process_nip62);
+        let options = NostrSqliteOptions {
+            process_nip09: builder.process_nip09,
+            process_nip62: builder.process_nip62,
+            relay_url: builder.relay_url,
+        };
 
         match builder.db_type {
             DatabaseConnType::InMemory => Self::in_memory(options).await,
@@ -290,8 +280,12 @@ impl NostrSqlite {
         }
 
         if options.process_nip62 && event.kind == Kind::RequestToVanish {
-            // For now, handling `ALL_RELAYS` only
-            if let Some(TagStandard::AllRelays) = event.tags.find_standardized(TagKind::Relay) {
+            let is_targeted = event.tags.filter_standardized(TagKind::Relay).any(|tag| {
+                matches!(tag, TagStandard::AllRelays)
+                    || matches!(tag, TagStandard::Relay(relay) if Some(relay) == options.relay_url.as_ref())
+            });
+
+            if is_targeted {
                 Self::handle_request_to_vanish(&tx, &event.pubkey)?;
             }
         }


### PR DESCRIPTION
Add `NostrSqliteBuilder::relay_url` to enable relays to accept relay-specific NIP-62 events for local vanish requests.

Related-to: https://github.com/rust-nostr/nostr/issues/1288

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [ ] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
