### PR TITLE
nostr: PoW adapters

### DIFF
--- a/crates/nostr/CHANGELOG.md
+++ b/crates/nostr/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Add `os-rng` feature (https://github.com/rust-nostr/nostr/pull/1171)
 - Replace `TryIntoUrl` trait with `RelayUrlArg` enum (https://github.com/rust-nostr/nostr/pull/1217)
 - Remove `Copy` trait from `MachineReadablePrefix` enum (https://github.com/rust-nostr/nostr/pull/1258)
+- Remove `EventBuilder::pow` in favor of `UnsignedEvent::mine` and `UnsignedEvent::mine_async` (https://github.com/rust-nostr/nostr/pull/1334)
 
 ### Changed
 
@@ -68,6 +69,8 @@
 - Add `MachineReadablePrefix::Custom` variant (https://github.com/rust-nostr/nostr/pull/1258)
 - Add `RelayMetadata::{is_read, is_write}` functions (https://github.com/rust-nostr/nostr/pull/1290)
 - Add the kind number in the kind doc (https://github.com/rust-nostr/nostr/pull/1293)
+- Add `PowAdapter` and `AsyncPowAdapter` traits (https://github.com/rust-nostr/nostr/pull/1334)
+- Add `UnsignedEvent::mine` and `UnsignedEvent::mine_async` (https://github.com/rust-nostr/nostr/pull/1334)
 
 ### Removed
 

--- a/crates/nostr/README.md
+++ b/crates/nostr/README.md
@@ -18,6 +18,8 @@ You may be interested in:
 ## Getting started
 
 ```rust,no_run
+use std::num::NonZeroU8;
+
 use nostr::prelude::*;
 
 fn main() -> Result<()> {
@@ -46,7 +48,10 @@ fn main() -> Result<()> {
     let event: Event = EventBuilder::text_note("Hello from rust-nostr").sign_with_keys(&keys)?;
 
     // New POW text note
-    let event: Event = EventBuilder::text_note("POW text note from rust-nostr").pow(20).sign_with_keys(&keys)?;
+    let difficulty: NonZeroU8 = NonZeroU8::new(16).unwrap();
+    let unsigned: UnsignedEvent = EventBuilder::text_note("POW text note from rust-nostr").build(keys.public_key);
+    let unsigned: UnsignedEvent = unsigned.mine(SingleThreadPow, difficulty)?;
+    let event: Event = unsigned.sign_with_keys(&keys)?;
 
     // Convert client message to JSON
     let json = ClientMessage::event(event).as_json();

--- a/crates/nostr/examples/nip13.rs
+++ b/crates/nostr/examples/nip13.rs
@@ -2,17 +2,27 @@
 // Copyright (c) 2023-2025 Rust Nostr Developers
 // Distributed under the MIT software license
 
+use std::num::NonZeroU8;
+
 use nostr::prelude::*;
 
 fn main() -> Result<()> {
     let keys = Keys::parse("6b911fd37cdf5c81d4c0adb1ab7fa822ed253ab0ad9aa18d77257c88b29b718e")?;
 
-    let difficulty = 20; // leading zero bits
+    let difficulty = NonZeroU8::new(20).unwrap(); // leading zero bits
     let msg_content = "This is a Nostr message with embedded proof-of-work";
 
-    let event: Event = EventBuilder::text_note(msg_content)
-        .pow(difficulty)
-        .sign_with_keys(&keys)?;
+    // Build unsigned event
+    let unsigned: UnsignedEvent = EventBuilder::text_note(msg_content).build(keys.public_key);
+
+    // Compute POW
+    #[cfg(not(feature = "pow-multi-thread"))]
+    let unsigned = unsigned.mine(SingleThreadPow, difficulty)?;
+    #[cfg(feature = "pow-multi-thread")]
+    let unsigned = unsigned.mine(MultiThreadPow, difficulty)?;
+
+    // Sign event
+    let event: Event = unsigned.sign_with_keys(&keys)?;
 
     println!("{}", event.as_json());
 

--- a/crates/nostr/src/event/builder.rs
+++ b/crates/nostr/src/event/builder.rs
@@ -8,12 +8,6 @@ use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use core::fmt;
 use core::ops::Range;
-#[cfg(feature = "pow-multi-thread")]
-use std::sync::Arc;
-#[cfg(feature = "pow-multi-thread")]
-use std::sync::atomic::{AtomicBool, Ordering};
-#[cfg(feature = "pow-multi-thread")]
-use std::thread::{self, JoinHandle};
 
 #[cfg(all(feature = "std", feature = "os-rng"))]
 use rand::TryRngCore;
@@ -174,8 +168,6 @@ pub struct EventBuilder {
     content: String,
     /// Custom timestamp
     pub custom_created_at: Option<Timestamp>,
-    /// POW difficulty
-    pub pow: Option<u8>,
     /// Allow self-tagging
     ///
     /// If enabled, the `p` tags that match the signing keypair will not be discarded.
@@ -198,7 +190,6 @@ impl EventBuilder {
             tags: Tags::new(),
             content: content.into(),
             custom_created_at: None,
-            pow: None,
             allow_self_tagging: false,
             dedup_tags: false,
         }
@@ -238,17 +229,6 @@ impl EventBuilder {
         self
     }
 
-    /// Set POW difficulty
-    ///
-    /// Only values `> 0` are accepted!
-    #[inline]
-    pub fn pow(mut self, difficulty: u8) -> Self {
-        if difficulty > 0 {
-            self.pow = Some(difficulty);
-        }
-        self
-    }
-
     /// Allow self-tagging
     ///
     /// When this mode is enabled, any `p` tags referencing the author’s public key will not be discarded.
@@ -263,148 +243,6 @@ impl EventBuilder {
     pub fn dedup_tags(mut self) -> Self {
         self.dedup_tags = true;
         self
-    }
-
-    /// Returns the [`EventId`] if the POW difficulty is satisfied.
-    fn check_nonce(
-        &mut self,
-        public_key: &PublicKey,
-        created_at: &Timestamp,
-        nonce: u128,
-        difficulty: u8,
-    ) -> Option<EventId> {
-        // Push POW tag
-        self.tags.push(Tag::pow(nonce, difficulty));
-
-        // Compute event ID
-        let id: EventId = EventId::new(
-            public_key,
-            created_at,
-            &self.kind,
-            &self.tags,
-            &self.content,
-        );
-
-        // Check POW difficulty
-        if id.check_pow(difficulty) {
-            Some(id)
-        } else {
-            // Remove tag if the nonce doesn't satisfy the difficulty requirement
-            self.tags.pop();
-            None
-        }
-    }
-
-    /// Mine PoW using single thread (fallback method)
-    fn mine_pow_single_thread(mut self, public_key: PublicKey, difficulty: u8) -> UnsignedEvent {
-        let mut nonce: u128 = 0;
-
-        loop {
-            nonce += 1;
-
-            let created_at: Timestamp = self.custom_created_at.unwrap_or_else(Timestamp::now);
-
-            // Check if the nonce satisfies the difficulty requirement
-            if let Some(id) = self.check_nonce(&public_key, &created_at, nonce, difficulty) {
-                return UnsignedEvent {
-                    id: Some(id),
-                    pubkey: public_key,
-                    created_at,
-                    kind: self.kind,
-                    tags: self.tags,
-                    content: self.content,
-                };
-            }
-        }
-    }
-
-    /// Mine PoW using multiple threads with std::thread
-    ///
-    /// Fallback to [`Self::mine_pow_single_thread`] if:
-    /// - the number of threads is `1`;
-    /// - thread spawning or coordination fails;
-    /// - no valid solution is found by any thread (rare edge case)
-    #[cfg(feature = "pow-multi-thread")]
-    fn mine_pow_multi_thread(self, public_key: PublicKey, difficulty: u8) -> UnsignedEvent {
-        // Get the number of available CPU cores
-        let num_threads = thread::available_parallelism()
-            .map(|n| n.get())
-            .unwrap_or(1);
-
-        // Single thread fallback
-        if num_threads == 1 {
-            return self.mine_pow_single_thread(public_key, difficulty);
-        }
-
-        let found: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
-
-        let mut handles: Vec<JoinHandle<Option<UnsignedEvent>>> = Vec::with_capacity(num_threads);
-
-        // Spawn threads
-        for thread_id in 0..num_threads {
-            let found: Arc<AtomicBool> = found.clone();
-
-            let mut builder: Self = self.clone();
-
-            // Create a timestamp
-            // TODO: move this into the thread loop
-            let created_at: Timestamp = self.custom_created_at.unwrap_or_else(Timestamp::now);
-
-            let handle: JoinHandle<Option<UnsignedEvent>> = thread::spawn(move || {
-                let mut nonce: u128 = thread_id as u128;
-
-                loop {
-                    // Check if another thread found the solution
-                    if found.load(Ordering::Relaxed) {
-                        break;
-                    }
-
-                    nonce += num_threads as u128;
-
-                    // Check if the nonce satisfies the difficulty requirement
-                    if let Some(id) =
-                        builder.check_nonce(&public_key, &created_at, nonce, difficulty)
-                    {
-                        // We found a valid nonce, signal other threads to stop and store the result
-                        found.store(true, Ordering::Relaxed);
-
-                        // Return the unsigned event
-                        return Some(UnsignedEvent {
-                            id: Some(id),
-                            pubkey: public_key,
-                            created_at,
-                            kind: builder.kind,
-                            tags: builder.tags,
-                            content: builder.content,
-                        });
-                    }
-                }
-
-                None
-            });
-
-            handles.push(handle);
-        }
-
-        // Wait for all threads to finish (non-blocking)
-        loop {
-            if found.load(Ordering::Relaxed) {
-                break;
-            }
-        }
-
-        // Find result
-        for handle in handles.into_iter() {
-            // NOTE: this shouldn't block the current thread,
-            // since above we've checked if the solution has been found
-            // (so all threads should be terminated).
-            if let Ok(Some(unsigned)) = handle.join() {
-                return unsigned;
-            }
-        }
-
-        // Single thread fallback
-        self.mine_pow_single_thread(public_key, difficulty)
     }
 
     /// Build an unsigned event
@@ -433,31 +271,15 @@ impl EventBuilder {
             self.tags.dedup();
         }
 
-        // Check if should be POW
-        match self.pow {
-            Some(difficulty) if difficulty > 0 => {
-                #[cfg(not(feature = "pow-multi-thread"))]
-                {
-                    self.mine_pow_single_thread(public_key, difficulty)
-                }
-                #[cfg(feature = "pow-multi-thread")]
-                {
-                    self.mine_pow_multi_thread(public_key, difficulty)
-                }
-            }
-            // No POW difficulty set OR difficulty == 0
-            _ => {
-                let mut unsigned: UnsignedEvent = UnsignedEvent {
-                    id: None,
-                    pubkey: public_key,
-                    created_at: self.custom_created_at.unwrap_or_else(Timestamp::now),
-                    kind: self.kind,
-                    tags: self.tags,
-                    content: self.content,
-                };
-                unsigned.ensure_id();
-                unsigned
-            }
+        // Construct unsigned event
+        UnsignedEvent {
+            // Not compute event ID, as the user may want POW, so would be an unnecessary computation.
+            id: None,
+            pubkey: public_key,
+            created_at: self.custom_created_at.unwrap_or_else(Timestamp::now),
+            kind: self.kind,
+            tags: self.tags,
+            content: self.content,
         }
     }
 

--- a/crates/nostr/src/event/unsigned.rs
+++ b/crates/nostr/src/event/unsigned.rs
@@ -5,6 +5,7 @@
 //! Unsigned Event
 
 use alloc::string::String;
+use core::num::NonZeroU8;
 
 #[cfg(all(feature = "std", feature = "os-rng"))]
 use rand::TryRngCore;
@@ -18,6 +19,7 @@ use secp256k1::{Message, Secp256k1, Signing, Verification};
 use super::error::Error;
 #[cfg(feature = "std")]
 use crate::SECP256K1;
+use crate::nips::nip13::{AsyncPowAdapter, PowAdapter};
 #[cfg(feature = "rand")]
 use crate::util;
 use crate::{Event, EventId, JsonUtil, Keys, Kind, NostrSigner, PublicKey, Tag, Tags, Timestamp};
@@ -84,8 +86,9 @@ impl UnsignedEvent {
         self.id.unwrap()
     }
 
+    /// Compute the event ID
     #[inline]
-    fn compute_id(&self) -> EventId {
+    pub fn compute_id(&self) -> EventId {
         EventId::new(
             &self.pubkey,
             &self.created_at,
@@ -105,6 +108,24 @@ impl UnsignedEvent {
         }
 
         Ok(())
+    }
+
+    /// Mine an unsigned event synchronously
+    #[inline]
+    pub fn mine<T>(self, adapter: T, difficulty: NonZeroU8) -> Result<Self, T::Error>
+    where
+        T: PowAdapter,
+    {
+        adapter.compute(self, difficulty)
+    }
+
+    /// Mine an unsigned event asynchronously
+    #[inline]
+    pub async fn mine_async<T>(self, adapter: T, difficulty: NonZeroU8) -> Result<Self, T::Error>
+    where
+        T: AsyncPowAdapter,
+    {
+        adapter.compute(self, difficulty).await
     }
 
     /// Sign an unsigned event

--- a/crates/nostr/src/nips/nip13/blocking_wrapper.rs
+++ b/crates/nostr/src/nips/nip13/blocking_wrapper.rs
@@ -1,0 +1,122 @@
+use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll, Waker};
+use std::thread;
+
+use crate::UnsignedEvent;
+
+type Work = dyn FnOnce(Arc<AtomicBool>) -> Option<UnsignedEvent> + Send + 'static;
+
+#[derive(Default)]
+struct PowState {
+    // - Some(v) = thread done, v is the result
+    // - None = thread not done yet
+    result: Mutex<Option<Option<UnsignedEvent>>>,
+    waker: Mutex<Option<Waker>>,
+}
+
+pub(super) struct BlockingPowFuture {
+    #[allow(clippy::type_complexity)]
+    work: Option<Box<Work>>,
+    state: Arc<PowState>,
+    cancel: Arc<AtomicBool>,
+    spawned: bool,
+}
+
+impl BlockingPowFuture {
+    pub(super) fn new(work: Box<Work>) -> Self {
+        Self {
+            work: Some(work),
+            state: Arc::new(PowState::default()),
+            cancel: Arc::new(AtomicBool::new(false)),
+            spawned: false,
+        }
+    }
+}
+
+impl Drop for BlockingPowFuture {
+    #[inline]
+    fn drop(&mut self) {
+        self.cancel.store(true, Ordering::SeqCst);
+    }
+}
+
+impl Future for BlockingPowFuture {
+    type Output = Option<UnsignedEvent>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = Pin::get_mut(self);
+
+        // Always update the waker. The executor may provide a new one on each poll.
+        // Drop the guard before acquiring the result lock to avoid deadlock.
+        {
+            let mut waker = this.state.waker.lock().unwrap();
+            *waker = Some(cx.waker().clone());
+        }
+
+        if !this.spawned {
+            this.spawned = true;
+
+            let work: Box<Work> = this.work.take().unwrap();
+            let state: Arc<PowState> = this.state.clone();
+            let cancel: Arc<AtomicBool> = this.cancel.clone();
+
+            thread::spawn(move || {
+                let event: Option<UnsignedEvent> = work(cancel);
+
+                // Release result lock before acquiring waker lock.
+                {
+                    let mut result = state.result.lock().unwrap();
+                    *result = Some(event);
+                }
+
+                let mut waker = state.waker.lock().unwrap();
+                if let Some(waker) = waker.take() {
+                    waker.wake();
+                }
+            });
+        }
+
+        let mut result = this.state.result.lock().unwrap();
+
+        match result.take() {
+            Some(result) => Poll::Ready(result),
+            None => Poll::Pending,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future::Future;
+    use std::sync::mpsc;
+    use std::task::{Context, Waker};
+    use std::time::Duration;
+
+    use super::*;
+
+    #[test]
+    fn drop_cancels_pow_future() {
+        let (tx, rx) = mpsc::channel();
+
+        let mut future = Box::pin(BlockingPowFuture::new(Box::new(move |cancel| {
+            while !cancel.load(Ordering::SeqCst) {
+                thread::sleep(Duration::from_millis(1));
+            }
+
+            tx.send(()).unwrap();
+            None
+        })));
+
+        let waker: &Waker = Waker::noop();
+        let mut cx = Context::from_waker(waker);
+
+        assert!(matches!(future.as_mut().poll(&mut cx), Poll::Pending));
+
+        drop(future);
+
+        rx.recv_timeout(Duration::from_secs(1))
+            .expect("worker should observe cancellation after future drop");
+    }
+}

--- a/crates/nostr/src/nips/nip13/mod.rs
+++ b/crates/nostr/src/nips/nip13/mod.rs
@@ -9,6 +9,21 @@
 
 use alloc::string::String;
 use alloc::vec::Vec;
+use core::any::Any;
+use core::fmt::Debug;
+use core::num::NonZeroU8;
+
+#[cfg(feature = "std")]
+mod blocking_wrapper;
+#[cfg(feature = "pow-multi-thread")]
+mod multi_thread;
+mod single_thread;
+
+#[cfg(feature = "pow-multi-thread")]
+pub use self::multi_thread::*;
+pub use self::single_thread::*;
+use crate::UnsignedEvent;
+use crate::util::BoxedFuture;
 
 /// Gets the number of leading zero bits. Result is between 0 and 255.
 #[inline]
@@ -57,13 +72,47 @@ pub fn get_prefixes_for_difficulty(leading_zero_bits: u8) -> Vec<String> {
     r
 }
 
+/// A trait for custom Proof of Work computation.
+pub trait PowAdapter: Any + Debug {
+    /// Error
+    type Error;
+
+    /// Computes Proof of Work for an unsigned event to meet the target
+    /// difficulty.
+    fn compute(
+        &self,
+        unsigned: UnsignedEvent,
+        difficulty: NonZeroU8,
+    ) -> Result<UnsignedEvent, Self::Error>;
+}
+
+/// A trait for custom Proof of Work computation.
+pub trait AsyncPowAdapter: Any + Debug + Send + Sync {
+    /// Error
+    type Error;
+
+    /// Computes Proof of Work for an unsigned event to meet the target
+    /// difficulty.
+    fn compute(
+        &self,
+        unsigned: UnsignedEvent,
+        difficulty: NonZeroU8,
+    ) -> BoxedFuture<'_, Result<UnsignedEvent, Self::Error>>;
+}
+
 #[cfg(test)]
 pub mod tests {
+    #[cfg(feature = "std")]
+    use core::convert::Infallible;
     use core::str::FromStr;
+    #[cfg(feature = "std")]
+    use core::time::Duration;
 
     use hashes::sha256::Hash as Sha256Hash;
 
     use super::*;
+    #[cfg(feature = "std")]
+    use crate::{EventBuilder, PublicKey, Tag, TagKind};
 
     #[test]
     fn check_get_leading_zeroes() {
@@ -434,5 +483,89 @@ pub mod tests {
                 "0000000000000000000000000000000000000000000000000000000000000001"
             ]
         );
+    }
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn custom_adapter() {
+        #[derive(Debug)]
+        struct TestAdapter;
+
+        impl PowAdapter for TestAdapter {
+            type Error = Infallible;
+
+            fn compute(
+                &self,
+                mut unsigned_event: UnsignedEvent,
+                target_difficulty: NonZeroU8,
+            ) -> Result<UnsignedEvent, Self::Error> {
+                unsigned_event
+                    .tags
+                    .push(Tag::pow(3490, target_difficulty.get()));
+                unsigned_event.ensure_id();
+                Ok(unsigned_event)
+            }
+        }
+
+        let unsigned = EventBuilder::text_note(
+            "Why must I find leading zero bits? Is there no beauty in the ones?",
+        )
+        .build(PublicKey::from_slice(&[0; 32]).unwrap());
+
+        let unsigned = unsigned
+            .mine(TestAdapter, NonZeroU8::new(2).unwrap())
+            .unwrap();
+
+        let Some(nonce_tag) = unsigned.tags.find(TagKind::Nonce) else {
+            panic!("nonce tag should be exist")
+        };
+
+        assert_eq!(nonce_tag.as_slice()[1], "3490");
+        assert_eq!(nonce_tag.as_slice()[2], "2");
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "std")]
+    async fn custom_async_adapter() {
+        #[derive(Debug)]
+        struct AsyncTestAdapter;
+
+        impl AsyncPowAdapter for AsyncTestAdapter {
+            type Error = Infallible;
+
+            fn compute(
+                &self,
+                mut unsigned_event: UnsignedEvent,
+                target_difficulty: NonZeroU8,
+            ) -> BoxedFuture<'_, Result<UnsignedEvent, Self::Error>> {
+                Box::pin(async move {
+                    // Simulate an async work
+                    tokio::time::sleep(Duration::from_secs(2)).await;
+
+                    unsigned_event
+                        .tags
+                        .push(Tag::pow(3490, target_difficulty.get()));
+                    unsigned_event.ensure_id();
+                    Ok(unsigned_event)
+                })
+            }
+        }
+
+        let unsigned = EventBuilder::text_note(
+            "Why must I find leading zero bits? Is there no beauty in the ones?",
+        )
+        .build(PublicKey::from_slice(&[0; 32]).unwrap());
+
+        let unsigned = unsigned
+            .mine_async(AsyncTestAdapter, NonZeroU8::new(2).unwrap())
+            .await
+            .unwrap();
+
+        let Some(nonce_tag) = unsigned.tags.find(TagKind::Nonce) else {
+            panic!("nonce tag should be exist")
+        };
+
+        assert_eq!(nonce_tag.as_slice()[1], "3490");
+        assert_eq!(nonce_tag.as_slice()[2], "2");
     }
 }

--- a/crates/nostr/src/nips/nip13/multi_thread.rs
+++ b/crates/nostr/src/nips/nip13/multi_thread.rs
@@ -1,0 +1,172 @@
+use std::convert::Infallible;
+use std::num::NonZeroU8;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+use super::blocking_wrapper::BlockingPowFuture;
+use super::{AsyncPowAdapter, BoxedFuture, PowAdapter, single_thread};
+use crate::{Tag, UnsignedEvent};
+
+/// A multithreaded Proof-of-Work miner.
+///
+/// Fallback to [`SingleThreadPow`](super::SingleThreadPow) if:
+/// - the number of threads is `1`;
+/// - thread spawning or coordination fails;
+/// - no valid solution is found by any thread (rare edge case)
+#[derive(Debug)]
+pub struct MultiThreadPow;
+
+impl PowAdapter for MultiThreadPow {
+    type Error = Infallible;
+
+    fn compute(
+        &self,
+        unsigned: UnsignedEvent,
+        difficulty: NonZeroU8,
+    ) -> Result<UnsignedEvent, Self::Error> {
+        let cancel: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
+        Ok(mine(unsigned, difficulty.get(), cancel).unwrap())
+    }
+}
+
+impl AsyncPowAdapter for MultiThreadPow {
+    type Error = Infallible;
+
+    fn compute(
+        &self,
+        unsigned: UnsignedEvent,
+        difficulty: NonZeroU8,
+    ) -> BoxedFuture<'_, Result<UnsignedEvent, Self::Error>> {
+        let diff: u8 = difficulty.get();
+
+        Box::pin(async move {
+            Ok(
+                BlockingPowFuture::new(Box::new(move |cancel| mine(unsigned, diff, cancel)))
+                    .await
+                    .unwrap(),
+            )
+        })
+    }
+}
+
+fn mine(unsigned: UnsignedEvent, difficulty: u8, cancel: Arc<AtomicBool>) -> Option<UnsignedEvent> {
+    let num_threads = thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1);
+
+    if num_threads == 1 {
+        return single_thread::mine(unsigned, difficulty, Some(cancel.as_ref()));
+    }
+
+    let found: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
+    let mut handles: Vec<JoinHandle<Option<UnsignedEvent>>> = Vec::with_capacity(num_threads);
+
+    for thread_id in 0..num_threads {
+        let found: Arc<AtomicBool> = found.clone();
+        let cancel: Arc<AtomicBool> = cancel.clone();
+
+        let mut event: UnsignedEvent = unsigned.clone();
+
+        let handle: JoinHandle<Option<UnsignedEvent>> = thread::spawn(move || {
+            let mut nonce: u128 = thread_id as u128;
+            event.tags.push(Tag::pow(0, difficulty));
+            let pow_tag_index = event.tags.len() - 1;
+
+            loop {
+                nonce += num_threads as u128;
+
+                // FIXME: "Division is the most expensive integer
+                // operation you can ask of your CPU"
+                // https://research.swtch.com/divmult
+                #[allow(clippy::collapsible_if)]
+                if (nonce / num_threads as u128) % 1024 == 0 {
+                    if found.load(Ordering::SeqCst) || cancel.load(Ordering::SeqCst) {
+                        return None;
+                    }
+                }
+
+                event.tags[pow_tag_index] = Tag::pow(nonce, difficulty);
+                let id = event.compute_id();
+
+                if id.check_pow(difficulty) {
+                    found.store(true, Ordering::SeqCst);
+                    event.id = Some(id);
+                    return Some(event);
+                }
+            }
+        });
+
+        handles.push(handle);
+    }
+
+    // Wait for found or cancel
+    loop {
+        if found.load(Ordering::SeqCst) || cancel.load(Ordering::SeqCst) {
+            break;
+        }
+
+        thread::sleep(Duration::from_millis(100));
+    }
+
+    if !found.load(Ordering::SeqCst) {
+        return None;
+    }
+
+    for handle in handles {
+        if let Ok(Some(event)) = handle.join() {
+            return Some(event);
+        }
+    }
+
+    // Fallback: shouldn't be reached since found=true guarantees one thread returned Some
+    single_thread::mine(unsigned, difficulty, Some(cancel.as_ref()))
+}
+
+#[cfg(test)]
+pub mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicBool;
+    use std::thread;
+    use std::time::Duration;
+
+    use super::*;
+    use crate::event::{EventBuilder, TagKind};
+    use crate::key::PublicKey;
+    use crate::nips::nip13::get_leading_zero_bits;
+
+    #[test]
+    fn threaded_adapter() {
+        let unsigned = EventBuilder::text_note("Wait, you guys are getting paid to find nonces? I'm just doing it for the leading zeros")
+            .build(PublicKey::from_slice(&[0; 32]).unwrap());
+
+        let unsigned = unsigned
+            .mine(MultiThreadPow, NonZeroU8::new(2).unwrap())
+            .unwrap();
+
+        let Some(nonce_tag) = unsigned.tags.find(TagKind::Nonce) else {
+            panic!("nonce tag should be exist")
+        };
+
+        assert!(unsigned.id.is_some());
+        assert_eq!(nonce_tag.as_slice()[2], "2");
+        assert!(get_leading_zero_bits(unsigned.id.unwrap()) >= 2)
+    }
+
+    #[test]
+    fn multi_thread_mining_can_be_cancelled() {
+        let cancel: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
+        let unsigned = EventBuilder::text_note("multi thread cancellation test")
+            .build(PublicKey::from_slice(&[0; 32]).unwrap());
+
+        let worker_cancel: Arc<AtomicBool> = cancel.clone();
+        let handle = thread::spawn(move || mine(unsigned, u8::MAX, worker_cancel));
+
+        thread::sleep(Duration::from_millis(10));
+        cancel.store(true, Ordering::SeqCst);
+
+        let result = handle.join().expect("multi thread miner should not panic");
+        assert!(result.is_none(), "multi thread miner should stop on cancel");
+    }
+}

--- a/crates/nostr/src/nips/nip13/single_thread.rs
+++ b/crates/nostr/src/nips/nip13/single_thread.rs
@@ -1,0 +1,131 @@
+use core::convert::Infallible;
+use core::num::NonZeroU8;
+use core::sync::atomic::{AtomicBool, Ordering};
+
+#[cfg(feature = "std")]
+use super::AsyncPowAdapter;
+use super::PowAdapter;
+#[cfg(feature = "std")]
+use super::blocking_wrapper::BlockingPowFuture;
+#[cfg(feature = "std")]
+use crate::util::BoxedFuture;
+use crate::{Tag, UnsignedEvent};
+
+/// A single-threaded PoW miner implementation
+#[derive(Debug)]
+pub struct SingleThreadPow;
+
+impl PowAdapter for SingleThreadPow {
+    type Error = Infallible;
+
+    #[inline]
+    fn compute(
+        &self,
+        unsigned: UnsignedEvent,
+        target_difficulty: NonZeroU8,
+    ) -> Result<UnsignedEvent, Self::Error> {
+        Ok(mine(unsigned, target_difficulty.get(), None).unwrap())
+    }
+}
+
+#[cfg(feature = "std")]
+impl AsyncPowAdapter for SingleThreadPow {
+    type Error = Infallible;
+
+    fn compute(
+        &self,
+        unsigned: UnsignedEvent,
+        target_difficulty: NonZeroU8,
+    ) -> BoxedFuture<'_, Result<UnsignedEvent, Self::Error>> {
+        let diff: u8 = target_difficulty.get();
+
+        Box::pin(async move {
+            // If the future is dropped (cancelled), BlockingPowFuture's Drop sets the cancel
+            // flag, mine() returns None, and we never reach this line.
+            Ok(
+                BlockingPowFuture::new(Box::new(move |cancel| mine(unsigned, diff, Some(&cancel))))
+                    .await
+                    .unwrap(),
+            )
+        })
+    }
+}
+
+pub(super) fn mine(
+    mut unsigned: UnsignedEvent,
+    difficulty: u8,
+    cancel: Option<&AtomicBool>,
+) -> Option<UnsignedEvent> {
+    let mut nonce: u128 = 0;
+    unsigned.tags.push(Tag::pow(0, difficulty));
+    let pow_tag_index = unsigned.tags.len() - 1;
+
+    loop {
+        if let Some(cancel) = cancel {
+            if nonce % 1024 == 0 && cancel.load(Ordering::SeqCst) {
+                return None;
+            }
+        }
+
+        nonce += 1;
+        unsigned.tags[pow_tag_index] = Tag::pow(nonce, difficulty);
+        let event_id = unsigned.compute_id();
+
+        if event_id.check_pow(difficulty) {
+            unsigned.id = Some(event_id);
+            return Some(unsigned);
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "std")]
+pub mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicBool;
+    use std::thread;
+    use std::time::Duration;
+
+    use super::*;
+    use crate::prelude::*;
+
+    #[test]
+    fn single_adapter() {
+        let unsigned = EventBuilder::text_note(
+            "Proof of Work: The only workout my CPU gets since I stopped gaming",
+        )
+        .build(PublicKey::from_slice(&[0; 32]).unwrap());
+
+        // Mine the event
+        let unsigned = unsigned
+            .mine(SingleThreadPow, NonZeroU8::new(2).unwrap())
+            .unwrap();
+
+        let Some(nonce_tag) = unsigned.tags.find(TagKind::Nonce) else {
+            panic!("nonce tag should be exist")
+        };
+
+        assert!(unsigned.id.is_some());
+        assert_eq!(nonce_tag.as_slice()[2], "2");
+        assert!(get_leading_zero_bits(unsigned.id.unwrap()) >= 2)
+    }
+
+    #[test]
+    fn single_thread_mining_can_be_cancelled() {
+        let cancel: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
+        let unsigned = EventBuilder::text_note("single thread cancellation test")
+            .build(PublicKey::from_slice(&[0; 32]).unwrap());
+
+        let worker_cancel: Arc<AtomicBool> = cancel.clone();
+        let handle = thread::spawn(move || mine(unsigned, u8::MAX, Some(worker_cancel.as_ref())));
+
+        thread::sleep(Duration::from_millis(10));
+        cancel.store(true, Ordering::SeqCst);
+
+        let result = handle.join().expect("single thread miner should not panic");
+        assert!(
+            result.is_none(),
+            "single thread miner should stop on cancel"
+        );
+    }
+}

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -50,11 +50,6 @@ async fn main() -> Result<()> {
     let builder = EventBuilder::text_note("My first text note from rust-nostr!");
     client.send_event_builder(builder).await?;
 
-    // Create a POW text note
-    let builder = EventBuilder::text_note("POW text note from nostr-sdk").pow(20);
-    client.send_event_builder(builder).await?; // Send to all relays
-    // client.send_event_builder_to(["wss://relay.damus.io"], builder).await?; // Send to specific relay
-
     Ok(())
 }
 ```

--- a/sdk/examples/client.rs
+++ b/sdk/examples/client.rs
@@ -2,14 +2,15 @@
 // Copyright (c) 2023-2025 Rust Nostr Developers
 // Distributed under the MIT software license
 
+use std::num::NonZeroU8;
+
 use nostr_sdk::prelude::*;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
 
-    let keys = Keys::parse("nsec1ufnus6pju578ste3v90xd5m2decpuzpql2295m3sknqcjzyys9ls0qlc85")?;
-    let client = Client::builder().signer(keys).build();
+    let client = Client::new();
 
     client.add_relay("wss://relay.damus.io").await?;
     client.add_relay("wss://nostr.wine").await?;
@@ -17,22 +18,22 @@ async fn main() -> Result<()> {
 
     client.connect().await;
 
+    let keys = Keys::parse("nsec1ufnus6pju578ste3v90xd5m2decpuzpql2295m3sknqcjzyys9ls0qlc85")?;
+
     // Publish a text note
-    let builder = EventBuilder::text_note("Hello world");
-    let output = client.send_event_builder(builder).await?;
+    let event = EventBuilder::text_note("Hello world").sign_with_keys(&keys)?;
+    let output = client.send_event(&event).await?;
     println!("Event ID: {}", output.id().to_bech32()?);
     println!("Sent to: {:?}", output.success);
     println!("Not sent to: {:?}", output.failed);
 
     // Create a text note POW event to relays
-    let builder = EventBuilder::text_note("POW text note from rust-nostr").pow(20);
-    client.send_event_builder(builder).await?;
-
-    // Send a text note POW event to specific relays
-    let builder = EventBuilder::text_note("POW text note from rust-nostr 16").pow(16);
-    client
-        .send_event_builder_to(["wss://relay.damus.io", "wss://relay.rip"], builder)
+    let unsigned = EventBuilder::text_note("POW text note from rust-nostr").build(keys.public_key);
+    let unsigned = unsigned
+        .mine_async(SingleThreadPow, NonZeroU8::new(20).unwrap())
         .await?;
+    let event = unsigned.sign_with_keys(&keys)?;
+    client.send_event(&event).await?;
 
     Ok(())
 }


### PR DESCRIPTION
### Description

- Introduced `PowAdapter` and `AsyncPowAdapter` traits for flexible PoW implementations.
- Added default single-thread and multi-thread PoW adapters, with support for future cancellation.
- Removed `EventBuilder::pow` in favor of `UnsignedEvent::mine` and `UnsignedEvent::mine_async`

Replaces https://github.com/rust-nostr/nostr/pull/1330 
Replaces https://github.com/rust-nostr/nostr/pull/1314 
Closes https://github.com/rust-nostr/nostr/issues/1309

### Notes to reviewers

After the (bad and too complicated) attempt with PR https://github.com/rust-nostr/nostr/pull/1330, I've opted for a cleaner approach, even if a bit verbose (see example below), for supporting both synchronous and asynchronous PoW adapters. 

```rust
use std::num::NonZeroU8;

use nostr::prelude::*;

fn main() -> Result<()> {
    let keys = Keys::parse("6b911fd37cdf5c81d4c0adb1ab7fa822ed253ab0ad9aa18d77257c88b29b718e")?;

    let difficulty = NonZeroU8::new(20).unwrap(); // leading zero bits
    let msg_content = "This is a Nostr message with embedded proof-of-work";

    // Build unsigned event
    let unsigned: UnsignedEvent = EventBuilder::text_note(msg_content).build(keys.public_key);

    // Compute POW
    #[cfg(not(feature = "pow-multi-thread"))]
    let unsigned = unsigned.mine(SingleThreadPow, difficulty)?; // Or mine_async
    #[cfg(feature = "pow-multi-thread")]
    let unsigned = unsigned.mine(MultiThreadPow, difficulty)?;

    // Sign event
    let event: Event = unsigned.sign_with_keys(&keys)?;

    println!("{}", event.as_json());

    Ok(())
}
```

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR