### PR TITLE
nostr: update `nip11`

### DIFF
--- a/crates/nostr/CHANGELOG.md
+++ b/crates/nostr/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Replace `TryIntoUrl` trait with `RelayUrlArg` enum (https://github.com/rust-nostr/nostr/pull/1217)
 - Remove `Copy` trait from `MachineReadablePrefix` enum (https://github.com/rust-nostr/nostr/pull/1258)
 - Remove `EventBuilder::pow` in favor of `UnsignedEvent::mine` and `UnsignedEvent::mine_async` (https://github.com/rust-nostr/nostr/pull/1334)
+- Replace `kinds: Option<Vec<String>>` in `FeeSchedule` with `kinds: Option<Vec<u16>>` in `RelayInformationDocument` (https://github.com/rust-nostr/nostr/pull/1336)
 
 ### Changed
 
@@ -74,6 +75,8 @@
 - Add the kind number in the kind doc (https://github.com/rust-nostr/nostr/pull/1293)
 - Add `PowAdapter` and `AsyncPowAdapter` traits (https://github.com/rust-nostr/nostr/pull/1334)
 - Add `UnsignedEvent::mine` and `UnsignedEvent::mine_async` (https://github.com/rust-nostr/nostr/pull/1334)
+- Add `banner`, `self`, `terms_of_service` to `RelayInformationDocument` (https://github.com/rust-nostr/nostr/pull/1336)
+- Add `restricted_writes`, `default_limit` to `Limitation` (https://github.com/rust-nostr/nostr/pull/1336)
 
 ### Removed
 
@@ -84,6 +87,9 @@
 - Remove `kind` field in `CommentTarget::Coordinate` variant (https://github.com/rust-nostr/nostr/pull/1294)
 - Remove `Timestamp::as_u64` (https://github.com/rust-nostr/nostr/pull/1295)
 - Remove `Nip19Event::from_event` (https://github.com/rust-nostr/nostr/pull/1296)
+- Remove `relay_countries`, `retention`, `language_tags`, `tags`, `posting_policy` from `RelayInformationDocument` (https://github.com/rust-nostr/nostr/pull/1336)
+- Remove `Retention`, `RetentionKind` from `nip11` (https://github.com/rust-nostr/nostr/pull/1336)
+- Remove `max_filters` from `Limitation` (https://github.com/rust-nostr/nostr/pull/1336)
 
 ### Fixed
 

--- a/crates/nostr/src/nips/nip11.rs
+++ b/crates/nostr/src/nips/nip11.rs
@@ -31,30 +31,19 @@ pub struct RelayInformationDocument {
     pub version: Option<String>,
     /// Limitations imposed by the relay on clients
     pub limitation: Option<Limitation>,
-    /// The relay's retention policies
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    #[serde(default)]
-    pub retention: Vec<Retention>,
-    /// Country codes whose laws and policies may affect this relay
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    #[serde(default)]
-    pub relay_countries: Vec<String>,
-    /// Ordered list of IETF language tags indicating the major languages spoken on the relay
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    #[serde(default)]
-    pub language_tags: Vec<String>,
-    /// List of limitations on the topics to be discussed
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    #[serde(default)]
-    pub tags: Vec<String>,
-    /// Link to a human-readable page which specifies the community policies
-    pub posting_policy: Option<String>,
     /// Link to relay's fee schedules
     pub payments_url: Option<String>,
     /// Relay fee schedules
     pub fees: Option<FeeSchedules>,
     /// URL pointing to an image to be used as an icon for the relay
     pub icon: Option<String>,
+    /// Banner
+    pub banner: Option<String>,
+    /// Relay's own pubkey
+    #[serde(rename = "self")]
+    pub self_pubkey: Option<String>,
+    /// Term of service
+    pub terms_of_service: Option<String>,
 }
 
 impl RelayInformationDocument {
@@ -77,8 +66,6 @@ pub struct Limitation {
     pub max_message_length: Option<i32>,
     /// Total number of subscriptions that may be active on a single websocket connection
     pub max_subscriptions: Option<i32>,
-    /// Maximum number of filter values in each subscription
-    pub max_filters: Option<i32>,
     /// Relay will clamp each filter's limit value to this number
     pub max_limit: Option<i32>,
     /// Maximum length of subscription id as a string
@@ -87,37 +74,20 @@ pub struct Limitation {
     pub max_event_tags: Option<i32>,
     /// Maximum number of characters in the content field of any event
     pub max_content_length: Option<i32>,
-    /// New events will require at least this difficulty of PoW,
+    /// New events will require at least this difficulty of PoW
     pub min_pow_difficulty: Option<i32>,
     /// Relay requires NIP42 authentication to happen before a new connection may perform any other action
     pub auth_required: Option<bool>,
     /// Relay requires payment before a new connection may perform any action
     pub payment_required: Option<bool>,
+    /// Relay requires some kind of condition to be fulfilled to accept events
+    pub restricted_writes: Option<bool>,
     /// 'created_at' lower limit
     pub created_at_lower_limit: Option<Timestamp>,
     /// 'created_at' upper limit
     pub created_at_upper_limit: Option<Timestamp>,
-}
-
-/// A retention schedule for the relay
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-pub struct Retention {
-    /// The event kinds this retention pertains to
-    pub kinds: Option<Vec<RetentionKind>>,
-    /// The amount of time these events are kept
-    pub time: Option<u64>,
-    /// The max number of events kept before removing older events
-    pub count: Option<u64>,
-}
-
-/// A single kind or range of kinds the retention pertains to
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum RetentionKind {
-    /// A single kind
-    Single(u64),
-    /// A kind range
-    Range(u64, u64),
+    /// Maximum returned events if you send a filter without a `limit`
+    pub default_limit: Option<i32>,
 }
 
 /// Available fee schedules
@@ -147,7 +117,7 @@ pub struct FeeSchedule {
     /// The duration for which the fee is valid
     pub period: Option<i32>,
     /// The event kinds the fee allows the client to publish to the relay
-    pub kinds: Option<Vec<String>>,
+    pub kinds: Option<Vec<u16>>,
 }
 
 #[cfg(test)]
@@ -155,54 +125,66 @@ mod tests {
     use super::*;
 
     #[test]
-    fn correctly_serializes_retention_kind() {
-        let kinds = vec![
-            RetentionKind::Single(0),
-            RetentionKind::Single(1),
-            RetentionKind::Range(5, 7),
-            RetentionKind::Range(40, 49),
-        ];
-        let got = serde_json::to_string(&kinds).unwrap();
-        let expected = "[0,1,[5,7],[40,49]]";
-
-        assert_eq!(got, expected, "got: {}, expected: {}", got, expected);
-    }
-
-    #[test]
-    fn correctly_deserializes_retention_kind() {
-        let kinds = "[0, 1, [5, 7], [40, 49]]";
-        let got = serde_json::from_str::<Vec<RetentionKind>>(kinds).unwrap();
-        let expected = vec![
-            RetentionKind::Single(0),
-            RetentionKind::Single(1),
-            RetentionKind::Range(5, 7),
-            RetentionKind::Range(40, 49),
-        ];
-
-        assert_eq!(got, expected, "got: {:?}, expected: {:?}", got, expected);
-    }
-
-    #[test]
     fn correctly_parses_relay_information_document() {
         let json = r#"{
             "name": "Test Relay",
             "description": "A test relay for unit testing",
+            "banner": "https://example.com/banner.webp",
+            "icon": "https://example.com/icon.webp",
             "pubkey": "bf2bee5281149c7c350f5d12ae32f514c7864ff10805182f4178538c2c421007",
+            "self": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
             "contact": "test@example.com",
             "supported_nips": [1, 9, 11],
             "software": "https://github.com/example/relay",
             "version": "1.0.0",
+            "terms_of_service": "https://example.com/tos",
             "limitation": {
-                "max_message_length": 16384,
-                "max_subscriptions": 300,
                 "auth_required": false,
-                "payment_required": true
+                "created_at_lower_limit": 94608000,
+                "created_at_upper_limit": 300,
+                "max_event_tags": 4000,
+                "max_limit": 1000,
+                "max_message_length": 16384,
+                "max_subid_length": 71,
+                "max_subscriptions": 300,
+                "min_pow_difficulty": 0,
+                "payment_required": true,
+                "restricted_writes": true
+            },
+            "payments_url": "https://example.com",
+            "fees": {
+                "admission": [
+                    {
+                        "amount": 1000000,
+                        "unit": "msats"
+                    }
+                ],
+                "subscription": [
+                    {
+                        "amount": 5000000,
+                        "unit": "msats",
+                        "period": 2592000
+                    }
+                ],
+                "publication": [
+                    {
+                        "kinds": [4],
+                        "amount": 100,
+                        "unit": "msats"
+                    }
+                ]
             }
         }"#;
 
         let doc = RelayInformationDocument::from_json(json).unwrap();
 
         assert_eq!(doc.name, Some(String::from("Test Relay")));
+        assert_eq!(
+            doc.self_pubkey,
+            Some(String::from(
+                "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+            ))
+        );
         assert_eq!(
             doc.description,
             Some(String::from("A test relay for unit testing"))


### PR DESCRIPTION
### Description

- Replace `kinds: Option<Vec<String>>` in `FeeSchedule` with `kinds: Option<Vec<u16>>` in `RelayInformationDocument`
- Add `banner`, `self`, `terms_of_service` to `RelayInformationDocument`
- Add `restricted_writes`, `default_limit` to `Limitation`
- Remove `relay_countries`, `retention`, `language_tags`, `tags`, `posting_policy` from `RelayInformationDocument`
- Remove `Retention`, `RetentionKind` from `nip11`
- Remove `max_filters` from `Limitation`

### Checklist

- [x] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [x] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [x] I personally wrote and understood all code in this PR
