### PR TITLE
sdk: add `AdmitPolicy::admit_relay`

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -91,6 +91,7 @@
 - Add `GossipAllowedRelays` to `GossipOptions` to filter relays during selection (https://github.com/rust-nostr/nostr/pull/1128)
 - Add `AdmitPolicy::admit_auth` to control relay authentication (https://github.com/rust-nostr/nostr/pull/1218)
 - Add gossip background refresher (https://github.com/rust-nostr/nostr/pull/1260)
+- Add `AdmitPolicy::admit_relay` (https://github.com/rust-nostr/nostr/pull/1339)
 
 ## v0.44.1 - 2025/11/09
 

--- a/sdk/src/client/api/add.rs
+++ b/sdk/src/client/api/add.rs
@@ -168,7 +168,30 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use super::*;
+    use crate::policy::{AdmitPolicy, AdmitStatus, PolicyError};
+
+    #[derive(Debug)]
+    struct RejectRelayPolicy {
+        rejected_relays: HashSet<RelayUrl>,
+    }
+
+    impl AdmitPolicy for RejectRelayPolicy {
+        fn admit_relay<'a>(
+            &'a self,
+            relay_url: &'a RelayUrl,
+        ) -> BoxedFuture<'a, Result<AdmitStatus, PolicyError>> {
+            Box::pin(async move {
+                if self.rejected_relays.contains(relay_url) {
+                    Ok(AdmitStatus::rejected("relay rejected"))
+                } else {
+                    Ok(AdmitStatus::Success)
+                }
+            })
+        }
+    }
 
     #[tokio::test]
     async fn test_add_relay() {
@@ -228,5 +251,21 @@ mod tests {
             relay.capabilities().load(),
             RelayCapabilities::READ | RelayCapabilities::GOSSIP
         );
+    }
+
+    #[tokio::test]
+    async fn test_add_relay_rejected_by_policy() {
+        let rejected = RelayUrl::parse("wss://relay.damus.io").unwrap();
+        let client = Client::builder()
+            .admit_policy(RejectRelayPolicy {
+                rejected_relays: HashSet::from([rejected.clone()]),
+            })
+            .build();
+
+        let res = client.add_relay(&rejected).await.unwrap();
+        assert!(!res);
+
+        let relay = client.relay(&rejected).await.unwrap();
+        assert!(relay.is_none());
     }
 }

--- a/sdk/src/client/middleware.rs
+++ b/sdk/src/client/middleware.rs
@@ -13,6 +13,18 @@ pub(crate) struct AdmissionPolicyMiddleware {
 }
 
 impl AdmitPolicy for AdmissionPolicyMiddleware {
+    fn admit_relay<'a>(
+        &'a self,
+        relay_url: &'a RelayUrl,
+    ) -> BoxedFuture<'a, Result<AdmitStatus, PolicyError>> {
+        Box::pin(async move {
+            match &self.external_policy {
+                Some(policy) => policy.admit_relay(relay_url).await,
+                None => Ok(AdmitStatus::Success),
+            }
+        })
+    }
+
     fn admit_connection<'a>(
         &'a self,
         relay_url: &'a RelayUrl,

--- a/sdk/src/client/mod.rs
+++ b/sdk/src/client/mod.rs
@@ -342,7 +342,10 @@ impl Client {
     /// Add relay
     ///
     /// By default, relays added with this method will have both [`RelayCapabilities::READ`] and [`RelayCapabilities::WRITE`] capabilities enabled.
-    /// If the relay already exists, the capabilities will be updated and `false` returned.
+    ///
+    /// Returns `true` only when a new relay is actually inserted into the pool.
+    /// If the relay already exists, its capabilities are updated and `false` is returned.
+    /// If the relay is rejected by the admission policy, this method also returns `false`.
     ///
     /// To add a relay with specific capabilities, use [`AddRelay::capabilities`].
     ///

--- a/sdk/src/policy.rs
+++ b/sdk/src/policy.rs
@@ -71,6 +71,17 @@ impl AdmitStatus {
 
 /// Admission policy
 pub trait AdmitPolicy: fmt::Debug + Send + Sync {
+    /// Admit a relay in the pool
+    ///
+    /// Returns [`AdmitStatus::Success`] if the relay can be added to the pool, otherwise [`AdmitStatus::Rejected`].
+    fn admit_relay<'a>(
+        &'a self,
+        relay_url: &'a RelayUrl,
+    ) -> BoxedFuture<'a, Result<AdmitStatus, PolicyError>> {
+        let _ = relay_url;
+        Box::pin(async move { Ok(AdmitStatus::Success) })
+    }
+
     /// Admit connecting to a relay
     ///
     /// Returns [`AdmitStatus::Success`] if the connection is allowed, otherwise [`AdmitStatus::Rejected`].

--- a/sdk/src/pool/error.rs
+++ b/sdk/src/pool/error.rs
@@ -2,11 +2,14 @@ use std::fmt;
 
 use nostr::RelayUrl;
 
+use crate::policy::PolicyError;
 use crate::relay;
 
 /// Relay Pool error
 #[derive(Debug)]
 pub enum Error {
+    /// Policy error
+    Policy(PolicyError),
     /// Relay error
     Relay(relay::Error),
     /// Too many relays
@@ -27,12 +30,19 @@ impl std::error::Error for Error {}
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::Policy(e) => e.fmt(f),
             Self::Relay(e) => e.fmt(f),
             Self::TooManyRelays { .. } => f.write_str("too many relays"),
             Self::NoRelaysSpecified => f.write_str("no relays specified"),
             Self::RelayNotFound(url) => write!(f, "relay '{}' not found", url),
             Self::Shutdown => f.write_str("relay pool is shutdown"),
         }
+    }
+}
+
+impl From<PolicyError> for Error {
+    fn from(e: PolicyError) -> Self {
+        Self::Policy(e)
     }
 }
 

--- a/sdk/src/pool/mod.rs
+++ b/sdk/src/pool/mod.rs
@@ -23,6 +23,7 @@ pub(crate) use self::builder::RelayPoolBuilder;
 pub(crate) use self::error::Error;
 use crate::client::{ClientNotification, InnerAckPolicy, Output, SyncSummary};
 use crate::monitor::Monitor;
+use crate::policy::AdmitStatus;
 use crate::relay::{
     self, AtomicRelayCapabilities, Relay, RelayCapabilities, RelayOptions, ReqExitPolicy,
     SubscribeAutoCloseOptions, SyncOptions,
@@ -170,6 +171,19 @@ impl RelayPool {
         // Check if the pool has been shutdown
         if self.is_shutdown() {
             return Err(Error::Shutdown);
+        }
+
+        // Check if the relay can be added to the pool, per-policy.
+        if let Some(policy) = &self.state.admit_policy {
+            if let AdmitStatus::Rejected { .. } = policy.admit_relay(&url).await? {
+                // Do not return an error here.
+                //
+                // A relay rejected by the admission policy is a valid outcome for this
+                // operation, not a pool failure. Returning an error would make callers
+                // such as `Client::gossip_break_down_filter` fail the whole workflow,
+                // while they only may need to know that this relay was not added.
+                return Ok(false);
+            }
         }
 
         // Get relays


### PR DESCRIPTION
### Description

New policy to prevent relays from being added to the pool. This may be useful when using gossip, where relays are automatically added to the pool.

Ref https://github.com/rust-nostr/nostr/discussions/1337

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
