### PR TITLE
sdk: fix subscription verification for multi-filter REQs

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -93,6 +93,10 @@
 - Add gossip background refresher (https://github.com/rust-nostr/nostr/pull/1260)
 - Add `AdmitPolicy::admit_relay` (https://github.com/rust-nostr/nostr/pull/1339)
 
+### Fixed
+
+- Fix subscription verification for multi-filter REQs (https://github.com/rust-nostr/nostr/pull/1349)
+
 ## v0.44.1 - 2025/11/09
 
 ### Fixed

--- a/sdk/src/relay/api/stream_events.rs
+++ b/sdk/src/relay/api/stream_events.rs
@@ -161,10 +161,14 @@ impl Stream for SubscriptionActivityEventStream {
 mod tests {
     use std::time::Duration;
 
+    use futures::StreamExt;
+    use nostr::event::EventBuilder;
+    use nostr::key::Keys;
     use nostr::{Filter, Kind, SubscriptionId};
     use nostr_relay_builder::MockRelay;
 
     use super::*;
+    use crate::relay::{Relay, RelayOptions};
 
     #[tokio::test]
     async fn test_stream_terminates_on_drop() {
@@ -203,5 +207,76 @@ mod tests {
         // Now the subscription must not exist anymore
         let exists: bool = relay.subscription(&id).await.is_some();
         assert!(!exists);
+    }
+
+    #[tokio::test]
+    async fn test_stream_with_subscription_verification_single_filter() {
+        let keys = Keys::generate();
+        let event = EventBuilder::text_note("test")
+            .sign_with_keys(&keys)
+            .unwrap();
+
+        let mock = MockRelay::run().await.unwrap();
+        let url = mock.url().await;
+
+        mock.add_event(event.clone()).await.unwrap();
+
+        let opts = RelayOptions::default()
+            .verify_subscriptions(true)
+            .ban_relay_on_mismatch(true);
+        let relay = Relay::builder(url).opts(opts).build();
+
+        relay.connect();
+
+        let filter = Filter::new().author(event.pubkey).kind(Kind::TextNote);
+
+        let mut stream = relay
+            .stream_events(filter)
+            .timeout(Duration::from_secs(3))
+            .await
+            .unwrap();
+
+        let streamed_event = stream
+            .next()
+            .await
+            .expect("Received None instead of the event")
+            .unwrap();
+        assert_eq!(streamed_event.id, event.id);
+    }
+
+    #[tokio::test]
+    async fn test_stream_with_subscription_verification_multiple_filters() {
+        let keys = Keys::generate();
+        let event = EventBuilder::text_note("test")
+            .sign_with_keys(&keys)
+            .unwrap();
+
+        let mock = MockRelay::run().await.unwrap();
+        let url = mock.url().await;
+
+        mock.add_event(event.clone()).await.unwrap();
+
+        let opts = RelayOptions::default()
+            .verify_subscriptions(true)
+            .ban_relay_on_mismatch(true);
+        let relay = Relay::builder(url).opts(opts).build();
+
+        relay.connect();
+
+        let matching_filter = Filter::new().author(event.pubkey).kind(Kind::TextNote);
+        let non_matching_filter = Filter::new().author(event.pubkey).kind(Kind::Repost);
+
+        let mut stream = relay
+            .stream_events([matching_filter, non_matching_filter])
+            .timeout(Duration::from_secs(3))
+            .await
+            .unwrap();
+
+        let streamed_event = stream
+            .next()
+            .await
+            .expect("Received None instead of the event")
+            .unwrap();
+        assert_eq!(streamed_event.id, event.id);
     }
 }

--- a/sdk/src/relay/inner.rs
+++ b/sdk/src/relay/inner.rs
@@ -1182,16 +1182,19 @@ impl InnerRelay {
                 }
             }
 
-            // Check if the filter matches the event
-            for filter in filters.iter() {
-                if !filter.match_event(&event, MATCH_EVENT_OPTS) {
-                    // Ban the relay
-                    if self.opts.ban_relay_on_mismatch {
-                        self.ban();
-                    }
-
-                    return Err(Error::EventNotMatchFilter);
+            // NIP-01 treats multiple filters in the same REQ as OR: an event is
+            // valid for the subscription if it matches at least one filter. Requiring every
+            // filter to match would reject valid events and may incorrectly ban the relay.
+            if !filters
+                .iter()
+                .any(|f| f.match_event(&event, MATCH_EVENT_OPTS))
+            {
+                // Ban the relay
+                if self.opts.ban_relay_on_mismatch {
+                    self.ban();
                 }
+
+                return Err(Error::EventNotMatchFilter);
             }
         }
 
@@ -1770,6 +1773,64 @@ async fn close_ws(tx: &mut WebSocketSink) -> Result<(), Error> {
     match time::timeout(Some(WEBSOCKET_TX_TIMEOUT), tx.close()).await {
         Some(res) => Ok(res?),
         None => Err(Error::Timeout),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nostr::{EventBuilder, Filter, Keys, Kind, RelayUrl, SubscriptionId};
+
+    use super::*;
+    use crate::relay::{Relay, RelayOptions};
+
+    #[tokio::test]
+    async fn test_subscription_verification_accepts_event_matching_any_filter() {
+        let keys = Keys::generate();
+        let event = EventBuilder::text_note("test")
+            .sign_with_keys(&keys)
+            .unwrap();
+
+        let filter = Filter::new().kind(Kind::TextNote).since(event.created_at);
+        let matching_filter = filter.clone().author(event.pubkey);
+        let non_matching_filter = filter.pubkey(event.pubkey);
+
+        assert!(matching_filter.match_event(&event, MATCH_EVENT_OPTS));
+        assert!(!non_matching_filter.match_event(&event, MATCH_EVENT_OPTS));
+
+        let url = RelayUrl::parse("wss://relay.example.com").unwrap();
+        let opts = RelayOptions::default()
+            .verify_subscriptions(true)
+            .ban_relay_on_mismatch(true);
+        let relay = Relay::builder(url).opts(opts).build();
+
+        // Manually add the subscription
+        let subscription_id = SubscriptionId::new("test");
+        relay
+            .inner
+            .update_subscription(
+                subscription_id.clone(),
+                vec![matching_filter, non_matching_filter],
+                true,
+            )
+            .await;
+
+        // Handle manually the event message
+        let message = relay
+            .inner
+            .handle_event_msg(subscription_id.clone(), event.clone())
+            .await
+            .unwrap();
+
+        match message {
+            Some(RelayMessage::Event {
+                subscription_id: received_subscription_id,
+                event: received_event,
+            }) => {
+                assert_eq!(received_subscription_id.as_ref(), &subscription_id);
+                assert_eq!(received_event.id, event.id);
+            }
+            other => panic!("unexpected message: {other:?}"),
+        }
     }
 }
 


### PR DESCRIPTION
### Description

Ensure multiple filters in the same REQ are treated as OR, rejecting events only when none match.

Fixes https://github.com/rust-nostr/nostr/issues/1348

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
