### PR TITLE
sdk: replace `Connection` with `Proxy`

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -59,6 +59,7 @@
 - Remove `Event::is_expired_with_supplier` (https://github.com/rust-nostr/nostr/pull/1266)
 - Remove `Timestamp::now_with_supplier` and `Timestamp::tweaked_with_supplier_and_rng` (https://github.com/rust-nostr/nostr/pull/1266)
 - Box `RelayMessage` in `RelayNotification` and `ClientNotification` (https://github.com/rust-nostr/nostr/pull/1299)
+- Replace `Connection` and `ConnectionTarget` with `Proxy` (https://github.com/rust-nostr/nostr/pull/1351)
 
 ### Changed
 
@@ -92,6 +93,7 @@
 - Add `AdmitPolicy::admit_auth` to control relay authentication (https://github.com/rust-nostr/nostr/pull/1218)
 - Add gossip background refresher (https://github.com/rust-nostr/nostr/pull/1260)
 - Add `AdmitPolicy::admit_relay` (https://github.com/rust-nostr/nostr/pull/1339)
+- Add `Proxy` with global, onion-only and custom relay proxy policies (https://github.com/rust-nostr/nostr/pull/1351)
 
 ### Fixed
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -31,10 +31,8 @@ async fn main() -> Result<()> {
 
     // Configure client to use proxy for `.onion` relays
     let addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 9050));
-    let connection: Connection = Connection::new()
-        .proxy(addr) // Use `.embedded_tor()` instead to enable the embedded tor client (require `tor` feature)
-        .target(ConnectionTarget::Onion);
-    let client = Client::builder().signer(keys).connection(connection).build();
+    let proxy: Proxy = Proxy::onion(addr);
+    let client = Client::builder().signer(keys).proxy(proxy).build();
 
     // Add relays
     client.add_relay("wss://relay.damus.io").await?;

--- a/sdk/examples/tor.rs
+++ b/sdk/examples/tor.rs
@@ -13,22 +13,14 @@ async fn main() -> Result<()> {
     // Parse keys
     let keys = Keys::parse("nsec1ufnus6pju578ste3v90xd5m2decpuzpql2295m3sknqcjzyys9ls0qlc85")?;
 
-    // Configure client to use embedded tor for `.onion` relays
-    let connection: Connection = Connection::new()
-        .proxy(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 9050)))
-        .target(ConnectionTarget::Onion);
-    let client = Client::builder()
-        .signer(keys.clone())
-        .connection(connection)
-        .build();
+    // Configure client to use a proxy for the onion relays
+    let proxy: Proxy = Proxy::onion(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 9050)));
+    let client = Client::builder().signer(keys.clone()).proxy(proxy).build();
 
     // Add relays
     client.add_relay("wss://relay.damus.io").await?;
     client
         .add_relay("ws://oxtrdevav64z64yb7x6rjg4ntzqjhedm5b5zjqulugknhzr46ny2qbad.onion")
-        .await?;
-    client
-        .add_relay("ws://2jsnlhfnelig5acq6iacydmzdbdmg7xwunm4xl6qwbvzacw4lwrjmlyd.onion")
         .await?;
 
     client.connect().await;

--- a/sdk/src/client/api/add.rs
+++ b/sdk/src/client/api/add.rs
@@ -2,11 +2,12 @@ use std::borrow::Cow;
 use std::future::IntoFuture;
 use std::time::Duration;
 
-use async_wsocket::ConnectionMode;
 use nostr::types::url::{RelayUrl, RelayUrlArg};
 
 use crate::client::{Client, Error};
 use crate::future::BoxedFuture;
+#[cfg(not(target_arch = "wasm32"))]
+use crate::proxy::Proxy;
 use crate::relay::{RelayCapabilities, RelayLimits, RelayOptions};
 
 /// Add new relay to the pool
@@ -47,10 +48,11 @@ impl<'client, 'url> AddRelay<'client, 'url> {
         self
     }
 
-    /// Set connection mode
+    /// Set proxy
     #[inline]
-    pub fn connection_mode(mut self, mode: ConnectionMode) -> Self {
-        self.opts.connection_mode = mode;
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn proxy(mut self, proxy: Proxy) -> Self {
+        self.opts.proxy = Some(proxy);
         self
     }
 
@@ -169,6 +171,7 @@ where
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;
+    use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 
     use super::*;
     use crate::policy::{AdmitPolicy, AdmitStatus, PolicyError};
@@ -267,5 +270,51 @@ mod tests {
 
         let relay = client.relay(&rejected).await.unwrap();
         assert!(relay.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_add_relay_with_proxy_all() {
+        let addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 9050));
+        let proxy: Proxy = Proxy::all(addr);
+        let client = Client::builder().proxy(proxy).build();
+
+        client.add_relay("wss://relay.damus.io").await.unwrap();
+        client
+            .add_relay("ws://oxtrdevav64z64yb7x6rjg4ntzqjhedm5b5zjqulugknhzr46ny2qbad.onion")
+            .await
+            .unwrap();
+
+        let relay = client.relay("wss://relay.damus.io").await.unwrap().unwrap();
+        assert_eq!(relay.proxy(), Some(addr));
+
+        let relay = client
+            .relay("ws://oxtrdevav64z64yb7x6rjg4ntzqjhedm5b5zjqulugknhzr46ny2qbad.onion")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(relay.proxy(), Some(addr));
+    }
+
+    #[tokio::test]
+    async fn test_add_relay_with_proxy_onion() {
+        let addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 9050));
+        let proxy: Proxy = Proxy::onion(addr);
+        let client = Client::builder().proxy(proxy).build();
+
+        client.add_relay("wss://relay.damus.io").await.unwrap();
+        client
+            .add_relay("ws://oxtrdevav64z64yb7x6rjg4ntzqjhedm5b5zjqulugknhzr46ny2qbad.onion")
+            .await
+            .unwrap();
+
+        let relay = client.relay("wss://relay.damus.io").await.unwrap().unwrap();
+        assert!(relay.proxy().is_none());
+
+        let relay = client
+            .relay("ws://oxtrdevav64z64yb7x6rjg4ntzqjhedm5b5zjqulugknhzr46ny2qbad.onion")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(relay.proxy(), Some(addr));
     }
 }

--- a/sdk/src/client/builder.rs
+++ b/sdk/src/client/builder.rs
@@ -4,14 +4,10 @@
 
 //! Client builder
 
-#[cfg(not(target_arch = "wasm32"))]
-use std::net::SocketAddr;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Duration;
 
-#[cfg(not(target_arch = "wasm32"))]
-use async_wsocket::ConnectionMode;
 use nostr::signer::AsyncNostrSigner;
 use nostr_database::{IntoNostrDatabase, NostrDatabase};
 use nostr_gossip::{GossipAllowedRelays, IntoNostrGossip, NostrGossip};
@@ -21,6 +17,8 @@ use crate::events_tracker::MemoryEventsTracker;
 use crate::monitor::Monitor;
 use crate::policy::AdmitPolicy;
 use crate::prelude::RelayLimits;
+#[cfg(not(target_arch = "wasm32"))]
+use crate::proxy::Proxy;
 use crate::transport::websocket::{
     DefaultWebsocketTransport, IntoWebSocketTransport, WebSocketTransport,
 };
@@ -193,9 +191,9 @@ pub struct ClientBuilder {
     pub gossip_config: GossipConfig,
     /// Relay monitor
     pub monitor: Option<Monitor>,
-    /// Connection
+    /// Proxy
     #[cfg(not(target_arch = "wasm32"))]
-    pub connection: Connection,
+    pub proxy: Option<Proxy>,
     /// Max relays allowed in the pool
     pub max_relays: Option<NonZeroUsize>,
     /// Automatic authentication to relays (NIP-42)
@@ -229,7 +227,7 @@ impl Default for ClientBuilder {
             gossip_config: GossipConfig::default(),
             monitor: None,
             #[cfg(not(target_arch = "wasm32"))]
-            connection: Connection::default(),
+            proxy: None,
             max_relays: None,
             automatic_authentication: true,
             connect_timeout: Duration::from_secs(15),
@@ -325,11 +323,11 @@ impl ClientBuilder {
         self
     }
 
-    /// Connection mode and target
+    /// Proxy
     #[inline]
     #[cfg(not(target_arch = "wasm32"))]
-    pub fn connection(mut self, connection: Connection) -> Self {
-        self.connection = connection;
+    pub fn proxy(mut self, proxy: Proxy) -> Self {
+        self.proxy = Some(proxy);
         self
     }
 
@@ -422,76 +420,4 @@ pub enum SleepWhenIdle {
         /// After how much time of inactivity put the relay to sleep.
         timeout: Duration,
     },
-}
-
-/// Connection target
-#[cfg(not(target_arch = "wasm32"))]
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
-pub enum ConnectionTarget {
-    /// All relays
-    #[default]
-    All,
-    /// Only `.onion` relays
-    Onion,
-}
-
-/// Connection
-#[cfg(not(target_arch = "wasm32"))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct Connection {
-    /// Mode
-    pub mode: ConnectionMode,
-    /// Target
-    pub target: ConnectionTarget,
-}
-
-#[allow(clippy::derivable_impls)]
-#[cfg(not(target_arch = "wasm32"))]
-impl Default for Connection {
-    fn default() -> Self {
-        Self {
-            mode: ConnectionMode::default(),
-            target: ConnectionTarget::default(),
-        }
-    }
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-impl Connection {
-    /// New default connection config
-    #[inline]
-    pub fn new() -> Self {
-        Self {
-            mode: ConnectionMode::default(),
-            target: ConnectionTarget::default(),
-        }
-    }
-
-    /// Set connection mode (default: direct)
-    #[inline]
-    pub fn mode(mut self, mode: ConnectionMode) -> Self {
-        self.mode = mode;
-        self
-    }
-
-    /// Set connection target (default: all)
-    #[inline]
-    pub fn target(mut self, target: ConnectionTarget) -> Self {
-        self.target = target;
-        self
-    }
-
-    /// Set direct connection
-    #[inline]
-    pub fn direct(mut self) -> Self {
-        self.mode = ConnectionMode::direct();
-        self
-    }
-
-    /// Set proxy
-    #[inline]
-    pub fn proxy(mut self, addr: SocketAddr) -> Self {
-        self.mode = ConnectionMode::proxy(addr);
-        self
-    }
 }

--- a/sdk/src/client/mod.rs
+++ b/sdk/src/client/mod.rs
@@ -10,8 +10,6 @@ use std::pin::Pin;
 use std::sync::{Arc, Weak};
 use std::time::Duration;
 
-#[cfg(not(target_arch = "wasm32"))]
-use async_wsocket::ConnectionMode;
 use futures::{Stream, StreamExt};
 use nostr::prelude::*;
 use nostr_database::prelude::*;
@@ -32,13 +30,15 @@ use self::middleware::AdmissionPolicyMiddleware;
 pub use self::notification::*;
 use crate::monitor::Monitor;
 use crate::pool::{RelayPool, RelayPoolBuilder};
+#[cfg(not(target_arch = "wasm32"))]
+use crate::proxy::Proxy;
 use crate::relay::{Relay, RelayCapabilities, RelayLimits, RelayOptions, SyncOptions};
 use crate::stream::NotificationStream;
 
 #[derive(Debug)]
 struct ClientConfig {
     #[cfg(not(target_arch = "wasm32"))]
-    connection: Connection,
+    proxy: Option<Proxy>,
     gossip_config: GossipConfig,
     connect_timeout: Duration,
     relay_limits: RelayLimits,
@@ -129,7 +129,7 @@ impl Client {
             gossip: builder.gossip.map(Gossip::new),
             config: ClientConfig {
                 #[cfg(not(target_arch = "wasm32"))]
-                connection: builder.connection,
+                proxy: builder.proxy,
                 gossip_config: builder.gossip_config,
                 connect_timeout: builder.connect_timeout,
                 relay_limits: builder.relay_limits,
@@ -303,22 +303,10 @@ impl Client {
     fn compose_relay_opts<'a>(&self, _url: &'a RelayUrlArg<'a>) -> RelayOptions {
         let mut opts: RelayOptions = RelayOptions::new();
 
-        // Set connection mode
+        // Set proxy
         #[cfg(not(target_arch = "wasm32"))]
-        if let Ok(url) = _url.try_as_relay_url() {
-            match &self.config().connection.mode {
-                ConnectionMode::Direct => {}
-                ConnectionMode::Proxy(..) => match self.config().connection.target {
-                    ConnectionTarget::All => {
-                        opts = opts.connection_mode(self.config().connection.mode.clone());
-                    }
-                    ConnectionTarget::Onion => {
-                        if url.is_onion() {
-                            opts = opts.connection_mode(self.config().connection.mode.clone())
-                        }
-                    }
-                },
-            };
+        if let Some(proxy) = &self.config().proxy {
+            opts = opts.proxy(proxy.clone());
         }
 
         // Set sleep when idle

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -13,6 +13,8 @@ pub mod monitor;
 pub mod policy;
 mod pool;
 pub mod prelude;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod proxy;
 pub mod relay;
 mod shared;
 mod stream;

--- a/sdk/src/prelude.rs
+++ b/sdk/src/prelude.rs
@@ -8,7 +8,6 @@
 #![allow(ambiguous_glob_reexports)]
 #![doc(hidden)]
 
-pub use async_wsocket::ConnectionMode;
 pub use futures::StreamExt;
 pub use nostr::prelude::*;
 pub use nostr_database::prelude::*;
@@ -17,5 +16,7 @@ pub use nostr_gossip::prelude::*;
 pub use crate::client::{self, *};
 pub use crate::monitor::{self, *};
 pub use crate::policy::*;
+#[cfg(not(target_arch = "wasm32"))]
+pub use crate::proxy::{self, *};
 pub use crate::relay::{self, *};
 pub use crate::*;

--- a/sdk/src/proxy.rs
+++ b/sdk/src/proxy.rs
@@ -1,0 +1,173 @@
+//! Relay proxy configuration.
+
+use std::fmt;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use nostr::RelayUrl;
+
+#[derive(Clone)]
+enum InnerProxy {
+    All(SocketAddr),
+    #[allow(clippy::type_complexity)]
+    Custom(Arc<dyn Fn(&RelayUrl) -> Option<SocketAddr> + Send + Sync + 'static>),
+}
+
+/// SOCKS5 proxy policy for relay connections.
+///
+/// A proxy policy decides whether a relay connection should use a SOCKS5 proxy
+/// and which proxy address should be used. The policy is evaluated separately
+/// for each relay URL when the relay connects.
+///
+/// Use [`Proxy::all`] to route every relay through the same proxy,
+/// [`Proxy::onion`] to route only `.onion` relays, or [`Proxy::custom`] for
+/// application-specific routing.
+#[derive(Clone)]
+pub struct Proxy(InnerProxy);
+
+impl fmt::Debug for Proxy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0 {
+            InnerProxy::All(addr) => f
+                .debug_tuple("Proxy")
+                .field(&format_args!("All({})", addr))
+                .finish(),
+            InnerProxy::Custom(_) => f.debug_tuple("Proxy").field(&"Custom").finish(),
+        }
+    }
+}
+
+impl Proxy {
+    /// Use a SOCKS5 proxy for all relay connections.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+    /// # use nostr_sdk::prelude::*;
+    /// let addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 9050));
+    /// let proxy = Proxy::all(addr);
+    /// let client = Client::builder().proxy(proxy).build();
+    /// ```
+    #[inline]
+    pub fn all(addr: SocketAddr) -> Self {
+        Self(InnerProxy::All(addr))
+    }
+
+    /// Use a SOCKS5 proxy only for `.onion` relay connections.
+    ///
+    /// This is a convenience
+    /// wrapper around [`Proxy::custom`] for the common Tor SOCKS5 proxy setup.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+    /// # use nostr_sdk::prelude::*;
+    /// let addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 9050));
+    /// let proxy = Proxy::onion(addr);
+    /// let client = Client::builder().proxy(proxy).build();
+    /// ```
+    #[inline]
+    pub fn onion(addr: SocketAddr) -> Self {
+        Self::custom(move |relay_url| {
+            if relay_url.is_onion() {
+                Some(addr)
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Use a custom SOCKS5 proxy policy.
+    ///
+    /// The callback receives the relay URL and returns the proxy address to use.
+    /// Returning [`None`] means that the relay should use a direct connection.
+    ///
+    /// Use this when proxy routing depends on application-specific rules, such
+    /// as selected domains, user settings, or multiple proxy endpoints.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+    /// # use nostr_sdk::prelude::*;
+    /// let addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 9050));
+    /// let client = Client::builder()
+    ///     .proxy(Proxy::custom(move |relay_url| {
+    ///         if relay_url.domain() == Some("example.com") {
+    ///             Some(addr)
+    ///         } else {
+    ///             None
+    ///         }
+    ///     }))
+    ///     .build();
+    /// ```
+    #[inline]
+    pub fn custom<F>(fun: F) -> Self
+    where
+        F: Fn(&RelayUrl) -> Option<SocketAddr> + Send + Sync + 'static,
+    {
+        Self(InnerProxy::Custom(Arc::new(fun)))
+    }
+
+    #[inline]
+    pub(crate) fn get_addr(&self, url: &RelayUrl) -> Option<SocketAddr> {
+        match &self.0 {
+            InnerProxy::All(addr) => Some(*addr),
+            InnerProxy::Custom(fun) => fun(url),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{Ipv4Addr, SocketAddrV4};
+
+    use super::*;
+
+    const ADDR: SocketAddr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 9050));
+
+    #[test]
+    fn test_proxy_all() {
+        let proxy: Proxy = Proxy::all(ADDR);
+
+        let clearnet_url = RelayUrl::parse("wss://relay.damus.io").unwrap();
+        let onion_url =
+            RelayUrl::parse("ws://2jsnlhfnelig5acq6iacydmzdbdmg7xwunm4xl6qwbvzacw4lwrjmlyd.onion")
+                .unwrap();
+
+        assert_eq!(proxy.get_addr(&clearnet_url), Some(ADDR));
+        assert_eq!(proxy.get_addr(&onion_url), Some(ADDR));
+    }
+
+    #[test]
+    fn test_proxy_onion() {
+        let proxy: Proxy = Proxy::onion(ADDR);
+
+        let clearnet_url = RelayUrl::parse("wss://relay.damus.io").unwrap();
+        let onion_url =
+            RelayUrl::parse("ws://2jsnlhfnelig5acq6iacydmzdbdmg7xwunm4xl6qwbvzacw4lwrjmlyd.onion")
+                .unwrap();
+
+        assert!(proxy.get_addr(&clearnet_url).is_none());
+        assert_eq!(proxy.get_addr(&onion_url), Some(ADDR));
+    }
+
+    #[test]
+    fn test_proxy_custom() {
+        let proxy: Proxy = Proxy::custom(move |url| {
+            if url.domain() == Some("example.com") {
+                Some(ADDR)
+            } else {
+                None
+            }
+        });
+
+        let damus_url = RelayUrl::parse("wss://relay.damus.io").unwrap();
+        let example_url = RelayUrl::parse("wss://example.com").unwrap();
+
+        assert!(proxy.get_addr(&damus_url).is_none());
+        assert_eq!(proxy.get_addr(&example_url), Some(ADDR));
+    }
+}

--- a/sdk/src/relay/inner.rs
+++ b/sdk/src/relay/inner.rs
@@ -1,12 +1,14 @@
 use std::borrow::Cow;
 use std::cmp;
 use std::collections::HashMap;
+#[cfg(not(target_arch = "wasm32"))]
+use std::net::SocketAddr;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::Duration;
 
 use async_utility::{task, time};
-use async_wsocket::{ConnectionMode, Message};
+use async_wsocket::Message;
 use futures::{self, SinkExt, StreamExt};
 #[cfg(not(target_arch = "wasm32"))]
 use nostr::rand::RngCore;
@@ -176,8 +178,9 @@ impl InnerRelay {
     }
 
     #[inline]
-    pub fn connection_mode(&self) -> &ConnectionMode {
-        &self.opts.connection_mode
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(super) fn proxy(&self) -> Option<SocketAddr> {
+        self.opts.proxy.as_ref().and_then(|p| p.get_addr(&self.url))
     }
 
     /// Check if the connection task is running
@@ -655,7 +658,7 @@ impl InnerRelay {
         let connect_fut = self
             .state
             .transport
-            .connect((&self.url).into(), &self.opts.connection_mode);
+            .connect((&self.url).into(), self.proxy());
         let fut = time::timeout(Some(timeout), connect_fut);
 
         // Try to connect

--- a/sdk/src/relay/mod.rs
+++ b/sdk/src/relay/mod.rs
@@ -3,13 +3,14 @@
 use std::borrow::Cow;
 use std::cmp;
 use std::collections::HashMap;
+#[cfg(not(target_arch = "wasm32"))]
+use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use async_utility::time;
-use async_wsocket::ConnectionMode;
 use futures::{Stream, StreamExt};
 use nostr_database::prelude::*;
 use tokio::sync::{broadcast, oneshot};
@@ -157,10 +158,11 @@ impl Relay {
         &self.inner.url
     }
 
-    /// Get connection mode
+    /// Get proxy
     #[inline]
-    pub fn connection_mode(&self) -> &ConnectionMode {
-        self.inner.connection_mode()
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn proxy(&self) -> Option<SocketAddr> {
+        self.inner.proxy()
     }
 
     /// Get status

--- a/sdk/src/relay/options.rs
+++ b/sdk/src/relay/options.rs
@@ -1,15 +1,17 @@
 use std::time::Duration;
 
-use async_wsocket::ConnectionMode;
 use tokio::sync::watch::{self, Receiver, Sender};
 
 use super::constants::{DEFAULT_NOTIFICATION_CHANNEL_SIZE, DEFAULT_RETRY_INTERVAL};
 use super::limits::RelayLimits;
+#[cfg(not(target_arch = "wasm32"))]
+use crate::proxy::Proxy;
 
 /// Relay options
 #[derive(Debug, Clone)]
 pub struct RelayOptions {
-    pub(crate) connection_mode: ConnectionMode,
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) proxy: Option<Proxy>,
     pub(crate) ping: bool,
     pub(crate) reconnect: bool,
     pub(crate) sleep_when_idle: bool,
@@ -27,7 +29,8 @@ pub struct RelayOptions {
 impl Default for RelayOptions {
     fn default() -> Self {
         Self {
-            connection_mode: ConnectionMode::default(),
+            #[cfg(not(target_arch = "wasm32"))]
+            proxy: None,
             ping: true,
             reconnect: true,
             sleep_when_idle: false,
@@ -51,10 +54,11 @@ impl RelayOptions {
         Self::default()
     }
 
-    /// Set connection mode
+    /// Set proxy
     #[inline]
-    pub fn connection_mode(mut self, mode: ConnectionMode) -> Self {
-        self.connection_mode = mode;
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn proxy(mut self, proxy: Proxy) -> Self {
+        self.proxy = Some(proxy);
         self
     }
 

--- a/sdk/src/transport/websocket.rs
+++ b/sdk/src/transport/websocket.rs
@@ -5,6 +5,7 @@
 //! WebSocket transport
 
 use std::fmt;
+use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
@@ -68,7 +69,7 @@ pub trait WebSocketTransport: fmt::Debug + Send + Sync {
     fn connect<'a>(
         &'a self,
         url: &'a Url,
-        mode: &'a ConnectionMode,
+        proxy: Option<SocketAddr>,
     ) -> BoxedFuture<'a, Result<(WebSocketSink, WebSocketStream), TransportError>>;
 }
 
@@ -84,11 +85,16 @@ impl WebSocketTransport for DefaultWebsocketTransport {
     fn connect<'a>(
         &'a self,
         url: &'a Url,
-        mode: &'a ConnectionMode,
+        proxy: Option<SocketAddr>,
     ) -> BoxedFuture<'a, Result<(WebSocketSink, WebSocketStream), TransportError>> {
         Box::pin(async move {
+            let mode: ConnectionMode = match proxy {
+                Some(proxy) => ConnectionMode::Proxy(proxy),
+                None => ConnectionMode::Direct,
+            };
+
             // Connect
-            let socket: WebSocket = WebSocket::connect(url, mode)
+            let socket: WebSocket = WebSocket::connect(url, &mode)
                 .await
                 .map_err(TransportError::backend)?;
 


### PR DESCRIPTION
### Description

Replace the `Connection` / `ConnectionTarget` API with a `Proxy` abstraction that can either apply one proxy to every relay or choose a proxy per relay URL.

Closes https://github.com/rust-nostr/nostr/issues/1350

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
