### PR TITLE
connect(fix): send connect response instead of request when client initiates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1788,6 +1788,7 @@ dependencies = [
  "dialoguer",
  "futures-core",
  "nostr",
+ "nostr-relay-builder",
  "nostr-sdk",
  "tokio",
  "tracing",

--- a/signer/nostr-connect/CHANGELOG.md
+++ b/signer/nostr-connect/CHANGELOG.md
@@ -42,6 +42,7 @@
 
 - Fix rejections of bunker signers that reply with secret in the connect response (https://github.com/rust-nostr/nostr/pull/1354)
 - Send connect response instead of a request when the connection initiated by the client (https://github.com/rust-nostr/nostr/pull/1353)
+- Fixed race condition in `NostrConnectRemoteSigner::serve()` where notifications subscription happened after sending connect response, potentially causing missed client messages (https://github.com/rust-nostr/nostr/pull/1353)
 
 ## v0.44.0 - 2025/11/06
 

--- a/signer/nostr-connect/CHANGELOG.md
+++ b/signer/nostr-connect/CHANGELOG.md
@@ -41,6 +41,7 @@
 ### Fixed
 
 - Fix rejections of bunker signers that reply with secret in the connect response (https://github.com/rust-nostr/nostr/pull/1354)
+- Send connect response instead of a request when the connection initiated by the client (https://github.com/rust-nostr/nostr/pull/1353)
 
 ## v0.44.0 - 2025/11/06
 

--- a/signer/nostr-connect/Cargo.toml
+++ b/signer/nostr-connect/Cargo.toml
@@ -27,6 +27,7 @@ tracing.workspace = true
 dialoguer = "0.12"
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 webbrowser = "1.1"
+nostr-relay-builder = { workspace = true }
 
 [[example]]
 name = "handle-auth-url"

--- a/signer/nostr-connect/src/error.rs
+++ b/signer/nostr-connect/src/error.rs
@@ -42,6 +42,8 @@ pub enum Error {
     UnexpectedUri,
     /// Public key not match
     PublicKeyNotMatchAppKeys,
+    /// Nostr connect client without a secret
+    NoClientSecret,
 }
 
 impl std::error::Error for Error {}
@@ -62,6 +64,7 @@ impl fmt::Display for Error {
             Self::Timeout => f.write_str("timeout"),
             Self::UnexpectedUri => f.write_str("unexpected URI"),
             Self::PublicKeyNotMatchAppKeys => f.write_str("public key not match app keys"),
+            Self::NoClientSecret => f.write_str("missing client secret"),
         }
     }
 }

--- a/signer/nostr-connect/src/signer.rs
+++ b/signer/nostr-connect/src/signer.rs
@@ -105,13 +105,14 @@ impl NostrConnectRemoteSigner {
         }
     }
 
-    async fn send_connect_ack(&self, public_key: PublicKey) -> Result<(), Error> {
-        let req: NostrConnectRequest = NostrConnectRequest::Connect {
-            remote_signer_public_key: self.keys.signer.public_key(),
-            secret: self.secret.clone(),
+    async fn send_connect_response(&self, public_key: PublicKey) -> Result<(), Error> {
+        let Some(secret) = self.secret.clone() else {
+            return Err(Error::NoClientSecret);
         };
 
-        let msg: NostrConnectMessage = NostrConnectMessage::request(&req);
+        // TODO: Fix the request id, should we?
+        let res = NostrConnectResponse::with_result(ResponseResult::ConnectSecret(secret));
+        let msg: NostrConnectMessage = NostrConnectMessage::response("urmom", res);
         let event: Event = EventBuilder::nostr_connect(&self.keys.signer, public_key, msg)?
             .sign_with_keys(&self.keys.signer)?;
         self.client.send_event(&event).await?;
@@ -168,7 +169,7 @@ impl NostrConnectRemoteSigner {
 
         // TODO: move into bootstrap method?
         if let Some(public_key) = self.nostr_connect_client_public_key {
-            self.send_connect_ack(public_key).await?;
+            self.send_connect_response(public_key).await?;
         }
 
         let mut notifications = self.client.notifications();

--- a/signer/nostr-connect/src/signer.rs
+++ b/signer/nostr-connect/src/signer.rs
@@ -167,12 +167,13 @@ impl NostrConnectRemoteSigner {
     {
         self.bootstrap().await?;
 
-        // TODO: move into bootstrap method?
+        // Subscribe to notifications before sending the connect response
+        // to avoid missing any client messages that arrive immediately after.
+        let mut notifications = self.client.notifications();
+
         if let Some(public_key) = self.nostr_connect_client_public_key {
             self.send_connect_response(public_key).await?;
         }
-
-        let mut notifications = self.client.notifications();
 
         while let Some(notification) = notifications.next().await {
             if let ClientNotification::Event { event, .. } = notification {

--- a/signer/nostr-connect/tests/nostr-connect.rs
+++ b/signer/nostr-connect/tests/nostr-connect.rs
@@ -1,0 +1,166 @@
+// Copyright (c) 2022-2023 Yuki Kishimoto
+// Copyright (c) 2023-2025 Rust Nostr Developers
+// Distributed under the MIT software license
+
+use std::time::Duration;
+
+use nostr::event::EventBuilder;
+use nostr::key::{Keys, PublicKey};
+use nostr::nips::nip46::{NostrConnectRequest, NostrConnectUri};
+use nostr::types::RelayUrl;
+use nostr_connect::client::NostrConnect;
+use nostr_connect::signer::{
+    NostrConnectKeys, NostrConnectRemoteSigner, NostrConnectSignerActions,
+};
+use nostr_relay_builder::LocalRelayBuilder;
+
+struct MySignerActions;
+
+impl NostrConnectSignerActions for MySignerActions {
+    fn approve(&self, _public_key: &PublicKey, _req: &NostrConnectRequest) -> bool {
+        true
+    }
+}
+
+async fn test_bunker_uri(user_keys: Keys, relay_url: RelayUrl) {
+    let bunker_keys = Keys::generate();
+    let secret = Some("urmom".to_owned());
+    let bunker = NostrConnectRemoteSigner::new(
+        NostrConnectKeys {
+            signer: bunker_keys,
+            user: user_keys.clone(),
+        },
+        [relay_url.clone()],
+        secret,
+        None,
+    )
+    .unwrap();
+
+    let bunker_uri = bunker.bunker_uri();
+    tokio::spawn(async move {
+        bunker.serve(MySignerActions).await.unwrap();
+    });
+
+    // Make sure the bunker started
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let nostr_connect_signer = NostrConnect::new(
+        NostrConnectUri::parse(bunker_uri.to_string()).unwrap(),
+        Keys::generate(),
+        Duration::from_secs(5),
+        None,
+    )
+    .unwrap();
+
+    let event = EventBuilder::text_note("GM")
+        .sign_async(&nostr_connect_signer)
+        .await
+        .unwrap();
+
+    assert_eq!(event.pubkey, user_keys.public_key);
+    assert!(event.verify().is_ok());
+}
+
+async fn test_bunker_uri_no_secret(user_keys: Keys, relay_url: RelayUrl) {
+    let bunker_keys = Keys::generate();
+    let bunker = NostrConnectRemoteSigner::new(
+        NostrConnectKeys {
+            signer: bunker_keys,
+            user: user_keys.clone(),
+        },
+        [relay_url.clone()],
+        None,
+        None,
+    )
+    .unwrap();
+
+    let bunker_uri = bunker.bunker_uri();
+    tokio::spawn(async move {
+        bunker.serve(MySignerActions).await.unwrap();
+    });
+
+    // Make sure the bunker started
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let nostr_connect_signer = NostrConnect::new(
+        NostrConnectUri::parse(bunker_uri.to_string()).unwrap(),
+        Keys::generate(),
+        Duration::from_secs(5),
+        None,
+    )
+    .unwrap();
+
+    let event = EventBuilder::text_note("GM")
+        .sign_async(&nostr_connect_signer)
+        .await
+        .unwrap();
+
+    assert_eq!(event.pubkey, user_keys.public_key);
+    assert!(event.verify().is_ok());
+}
+
+async fn test_nostrconnect_uri(relay_url: RelayUrl, user_keys: Keys) {
+    let app_keys = Keys::generate();
+    let connect_uri = NostrConnectUri::client(app_keys.public_key, [relay_url], "Test App");
+
+    let bunker = NostrConnectRemoteSigner::from_uri(
+        connect_uri.clone(),
+        NostrConnectKeys {
+            signer: Keys::generate(),
+            user: user_keys.clone(),
+        },
+        None,
+    )
+    .unwrap();
+
+    tokio::spawn(async move {
+        // Wait for the client to start listening. In the `nostrconnect` flow,
+        // the client begins listening before the bunker is ready.
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        bunker.serve(MySignerActions).await.unwrap();
+    });
+
+    let nostr_connect_signer =
+        NostrConnect::new(connect_uri, app_keys, Duration::from_secs(5), None).unwrap();
+
+    let event = EventBuilder::text_note("GM")
+        .sign_async(&nostr_connect_signer)
+        .await
+        .unwrap();
+
+    assert_eq!(event.pubkey, user_keys.public_key);
+    assert!(event.verify().is_ok());
+}
+
+#[tokio::test]
+async fn nostr_connect_bunker_uri() {
+    let relay = LocalRelayBuilder::default().build();
+    let relay_url = relay.url().await;
+    relay.run().await.unwrap();
+
+    let user_keys = Keys::generate();
+
+    test_bunker_uri(user_keys.clone(), relay_url.clone()).await;
+}
+
+#[tokio::test]
+async fn nostr_connect_bunker_uri_no_secret() {
+    let relay = LocalRelayBuilder::default().build();
+    let relay_url = relay.url().await;
+    relay.run().await.unwrap();
+
+    let user_keys = Keys::generate();
+
+    test_bunker_uri_no_secret(user_keys.clone(), relay_url.clone()).await;
+}
+
+#[tokio::test]
+async fn nostr_connect_nostrconnect_uri() {
+    let relay = LocalRelayBuilder::default().build();
+    let relay_url = relay.url().await;
+    relay.run().await.unwrap();
+
+    let user_keys = Keys::generate();
+
+    test_nostrconnect_uri(relay_url, user_keys).await;
+}


### PR DESCRIPTION
Per the NIP-46:
> _user_ passes this token to _remote-signer_, which then sends
> `connect` *response* event to the `client-pubkey` via the specified
> relays. Client discovers `remote-signer-pubkey` from connect response
> author. `secret` value MUST be provided to avoid connection spoofing,
> _client_ MUST validate the `secret` returned by `connect` response.

So it should be a response and not a request. Also the connect client expecting a response, not a request:

```rust
// signer/nostr-connect/src/client.rs:401

// Check if it's a `connect` response.
//
// Per NIP-46, for nostrconnect:// (client-initiated) connections the signer
// sends a `connect` response whose `result` is the secret value from the URI
// (not "ack"). The client MUST validate the returned secret to prevent
// connection spoofing.
if let Ok(NostrConnectResponse {
    result: Some(result),
    error: None,
}) = msg.to_response(NostrConnectMethod::Connect)
{
    let is_valid = match &result {
        // Some signers (e.g. those following older interpretations) return "ack"
        ResponseResult::Ack => true,
        // Per current NIP-46 spec the signer returns the secret value
        ResponseResult::ConnectSecret(s) => s == expected_secret,
        _ => false,
    };

    if is_valid {
        return Ok(event.pubkey);
    } else {
        tracing::warn!(
            "Received connect response with unexpected result; ignoring"
        );
    }
}
```

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
