### PR TITLE
connect: fix rejections of bunker signers that reply with secret in the connect response

### DIFF
--- a/crates/nostr/src/nips/nip46.rs
+++ b/crates/nostr/src/nips/nip46.rs
@@ -546,19 +546,6 @@ impl ResponseResult {
     }
 
     #[inline]
-    pub fn to_ack(self) -> Result<(), Error> {
-        if let Self::Ack = self {
-            Ok(())
-        } else {
-            Err(Error::UnexpectedResponse {
-                method: NostrConnectMethod::Connect,
-                expected: String::from("ack"),
-                received: self.to_string(),
-            })
-        }
-    }
-
-    #[inline]
     pub fn to_get_public_key(self) -> Result<PublicKey, Error> {
         if let Self::GetPublicKey(val) = self {
             Ok(val)

--- a/signer/nostr-connect/CHANGELOG.md
+++ b/signer/nostr-connect/CHANGELOG.md
@@ -38,6 +38,10 @@
 
 - Bump MSRV to 1.85.0 (https://github.com/rust-nostr/nostr/pull/1267)
 
+### Fixed
+
+- Fix rejections of bunker signers that reply with secret in the connect response (https://github.com/rust-nostr/nostr/pull/1354)
+
 ## v0.44.0 - 2025/11/06
 
 ### Fixed

--- a/signer/nostr-connect/src/client.rs
+++ b/signer/nostr-connect/src/client.rs
@@ -137,8 +137,9 @@ impl NostrConnect {
         };
 
         // Send `connect` command if bunker URI
-        if self.uri.is_bunker() {
-            self.connect(remote_signer_public_key).await?;
+        if let NostrConnectUri::Bunker { secret, .. } = &self.uri {
+            self.connect_bunker(remote_signer_public_key, secret)
+                .await?;
         }
 
         Ok(remote_signer_public_key)
@@ -284,16 +285,25 @@ impl NostrConnect {
         .ok_or(Error::Timeout)?
     }
 
-    /// Connect msg
-    async fn connect(&self, remote_signer_public_key: PublicKey) -> Result<(), Error> {
+    /// Connect bunker
+    async fn connect_bunker(
+        &self,
+        remote_signer_public_key: PublicKey,
+        secret: &Option<String>,
+    ) -> Result<(), Error> {
         let req = NostrConnectRequest::Connect {
             remote_signer_public_key,
-            secret: self.uri.secret().map(|secret| secret.to_string()),
+            secret: secret.clone(),
         };
-        let res = self
+        let res: ResponseResult = self
             .send_request_with_pk(req, remote_signer_public_key)
             .await?;
-        Ok(res.to_ack()?)
+
+        if is_valid_connect_response(&res, secret.as_deref()) {
+            return Ok(());
+        }
+
+        Err(Error::InvalidResponse(res.to_string()))
     }
 
     async fn _get_public_key(&self) -> Result<&PublicKey, Error> {
@@ -409,15 +419,7 @@ async fn get_remote_signer_public_key(
                         error: None,
                     }) = msg.to_response(NostrConnectMethod::Connect)
                     {
-                        let is_valid = match &result {
-                            // Some signers (e.g. those following older interpretations) return "ack"
-                            ResponseResult::Ack => true,
-                            // Per current NIP-46 spec the signer returns the secret value
-                            ResponseResult::ConnectSecret(s) => s == expected_secret,
-                            _ => false,
-                        };
-
-                        if is_valid {
+                        if is_valid_connect_response(&result, Some(expected_secret)) {
                             return Ok(event.pubkey);
                         } else {
                             tracing::warn!(
@@ -433,6 +435,19 @@ async fn get_remote_signer_public_key(
     })
     .await
     .ok_or(Error::Timeout)?
+}
+
+fn is_valid_connect_response(response: &ResponseResult, expected_secret: Option<&str>) -> bool {
+    match &response {
+        // Some signers (e.g. those following older interpretations) return "ack"
+        ResponseResult::Ack => true,
+        // Per current NIP-46 spec the signer returns the secret value
+        ResponseResult::ConnectSecret(s) => match expected_secret {
+            Some(expected_secret) => s == expected_secret,
+            None => false,
+        },
+        _ => false,
+    }
 }
 
 /// Nostr Connect auth_url handler
@@ -537,5 +552,27 @@ impl AsyncNip44 for NostrConnect {
 impl AsyncNostrSigner for NostrConnect {
     fn backend(&self) -> SignerBackend<'_> {
         SignerBackend::NostrConnect
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_valid_connect_response() {
+        assert!(is_valid_connect_response(&ResponseResult::Ack, None));
+        assert!(is_valid_connect_response(
+            &ResponseResult::ConnectSecret("secret".to_string()),
+            Some("secret")
+        ));
+        assert!(!is_valid_connect_response(
+            &ResponseResult::ConnectSecret("secret".to_string()),
+            Some("other_secret")
+        ));
+        assert!(!is_valid_connect_response(
+            &ResponseResult::ConnectSecret("secret".to_string()),
+            None
+        ));
     }
 }

--- a/signer/nostr-connect/src/error.rs
+++ b/signer/nostr-connect/src/error.rs
@@ -30,6 +30,8 @@ pub enum Error {
     RelayUrl(url::Error),
     /// Set user public key error
     SetUserPublicKey(SetError<PublicKey>),
+    /// Invalid response from remote signer
+    InvalidResponse(String),
     /// NIP46 response error
     Response(String),
     /// Signer public key not found
@@ -54,6 +56,7 @@ impl fmt::Display for Error {
             Self::Client(e) => e.fmt(f),
             Self::RelayUrl(e) => e.fmt(f),
             Self::SetUserPublicKey(e) => e.fmt(f),
+            Self::InvalidResponse(e) => e.fmt(f),
             Self::Response(e) => e.fmt(f),
             Self::SignerPublicKeyNotFound => f.write_str("signer public key not found"),
             Self::Timeout => f.write_str("timeout"),


### PR DESCRIPTION
### Description

Fixes https://github.com/rust-nostr/nostr/issues/1352

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [x] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
