### PR TITLE
nostr: drop support for private and anon zaps & cleanup sign methods 

### DIFF
--- a/crates/nostr-relay-builder/src/local/inner.rs
+++ b/crates/nostr-relay-builder/src/local/inner.rs
@@ -941,7 +941,7 @@ impl InnerLocalRelay {
             let keys = Keys::generate();
 
             for _ in 0..500 {
-                events.insert(EventBuilder::text_note("Test").sign_with_keys(&keys)?);
+                events.insert(EventBuilder::text_note("Test").sign(&keys)?);
             }
 
             events

--- a/crates/nostr/CHANGELOG.md
+++ b/crates/nostr/CHANGELOG.md
@@ -43,6 +43,8 @@
 - Drop support for NIP-96
 - Remove TagStandard enum in favor of per-NIP tag enums (https://github.com/rust-nostr/nostr/pull/1347)
 - Remove TagKind (https://github.com/rust-nostr/nostr/pull/1347)
+- Drop support for private and anon zaps (https://github.com/rust-nostr/nostr/pull/1355)
+- Remove `EventBuilder::sign_with_keys` and `EventBuilder::sign_with_ctx` (https://github.com/rust-nostr/nostr/pull/1355)
 
 ### Changed
 

--- a/crates/nostr/CHANGELOG.md
+++ b/crates/nostr/CHANGELOG.md
@@ -45,6 +45,7 @@
 - Remove TagKind (https://github.com/rust-nostr/nostr/pull/1347)
 - Drop support for private and anon zaps (https://github.com/rust-nostr/nostr/pull/1355)
 - Remove `EventBuilder::sign_with_keys` and `EventBuilder::sign_with_ctx` (https://github.com/rust-nostr/nostr/pull/1355)
+- Remove `UnsignedEvent::sign_with_keys`, `UnsignedEvent::sign_with_ctx` and `UnsignedEvent::sign_with_aux_rand` (https://github.com/rust-nostr/nostr/pull/1355)
 
 ### Changed
 

--- a/crates/nostr/Cargo.toml
+++ b/crates/nostr/Cargo.toml
@@ -52,7 +52,7 @@ rand = ["dep:rand"]
 os-rng = ["rand", "rand/os_rng"]
 # Enable event POW mining using multi-threads
 pow-multi-thread = ["std"]
-all-nips = ["nip04", "nip06", "nip44", "nip46", "nip47", "nip49", "nip57", "nip59", "nip60", "nip98"]
+all-nips = ["nip04", "nip06", "nip44", "nip46", "nip47", "nip49", "nip59", "nip60", "nip98"]
 nip03 = ["dep:nostr-ots"]
 nip04 = ["dep:aes", "dep:base64", "dep:cbc"]
 nip06 = ["dep:bip39"]
@@ -60,7 +60,6 @@ nip44 = ["dep:base64", "dep:chacha20"]
 nip46 = ["nip04", "nip44"]
 nip47 = ["nip04"]
 nip49 = ["dep:chacha20poly1305", "dep:scrypt", "dep:unicode-normalization"]
-nip57 = ["dep:aes", "dep:cbc"]
 nip59 = ["nip44"]
 nip60 = ["nip44"]
 nip98 = ["dep:base64"]
@@ -119,7 +118,7 @@ required-features = ["std"]
 
 [[example]]
 name = "nip57"
-required-features = ["std", "rand", "os-rng", "nip57"]
+required-features = ["std", "rand", "os-rng"]
 
 [[example]]
 name = "nip15"

--- a/crates/nostr/README.md
+++ b/crates/nostr/README.md
@@ -82,7 +82,6 @@ The following crate feature flags are available:
 | `nip46`            |   No    | Enable NIP-46: Nostr Connect                                  |
 | `nip47`            |   No    | Enable NIP-47: Nostr Wallet Connect                           |
 | `nip49`            |   No    | Enable NIP-49: Private Key Encryption                         |
-| `nip57`            |   No    | Enable NIP-57: Zaps                                           |
 | `nip59`            |   No    | Enable NIP-59: Gift Wrap                                      |
 | `nip60`            |   No    | Enable NIP-60: Cashu Wallets                                  |
 

--- a/crates/nostr/README.md
+++ b/crates/nostr/README.md
@@ -42,16 +42,16 @@ fn main() -> Result<()> {
         .lud16("pay@yukikishimoto.com")
         .custom_field("custom_field", "my value");
 
-    let event: Event = EventBuilder::metadata(&metadata).sign_with_keys(&keys)?;
+    let event: Event = EventBuilder::metadata(&metadata).sign(&keys)?;
 
     // New text note
-    let event: Event = EventBuilder::text_note("Hello from rust-nostr").sign_with_keys(&keys)?;
+    let event: Event = EventBuilder::text_note("Hello from rust-nostr").sign(&keys)?;
 
     // New POW text note
     let difficulty: NonZeroU8 = NonZeroU8::new(16).unwrap();
     let unsigned: UnsignedEvent = EventBuilder::text_note("POW text note from rust-nostr").build(keys.public_key);
     let unsigned: UnsignedEvent = unsigned.mine(&SingleThreadPow, difficulty)?;
-    let event: Event = unsigned.sign_with_keys(&keys)?;
+    let event: Event = unsigned.sign(&keys)?;
 
     // Convert client message to JSON
     let json = ClientMessage::event(event).as_json();

--- a/crates/nostr/examples/nip09.rs
+++ b/crates/nostr/examples/nip09.rs
@@ -14,7 +14,7 @@ fn main() -> Result<()> {
         .id(event_id)
         .reason("these posts were published by accident");
 
-    let event: Event = EventBuilder::delete(request).sign_with_keys(&keys)?;
+    let event: Event = EventBuilder::delete(request).sign(&keys)?;
     println!("{}", event.as_json());
 
     Ok(())

--- a/crates/nostr/examples/nip13.rs
+++ b/crates/nostr/examples/nip13.rs
@@ -24,7 +24,7 @@ fn main() -> Result<()> {
     let unsigned: UnsignedEvent = unsigned.mine(&adapter, difficulty)?;
 
     // Sign event
-    let event: Event = unsigned.sign_with_keys(&keys)?;
+    let event: Event = unsigned.sign(&keys)?;
 
     println!("{}", event.as_json());
 

--- a/crates/nostr/examples/nip15.rs
+++ b/crates/nostr/examples/nip15.rs
@@ -13,7 +13,7 @@ fn main() -> Result<()> {
         .description("this is a test stall")
         .shipping(vec![shipping.clone()]);
 
-    let stall_event = EventBuilder::stall_data(stall).sign_with_keys(&keys)?;
+    let stall_event = EventBuilder::stall_data(stall).sign(&keys)?;
     println!("{}", stall_event.as_json());
 
     let product = ProductData::new("1", "123", "my test product", "USD")
@@ -23,7 +23,7 @@ fn main() -> Result<()> {
         .images(vec!["https://example.com/image.png".into()])
         .categories(vec!["test".into()]);
 
-    let product_event = EventBuilder::product_data(product).sign_with_keys(&keys)?;
+    let product_event = EventBuilder::product_data(product).sign(&keys)?;
     println!("{}", product_event.as_json());
 
     Ok(())

--- a/crates/nostr/examples/nip57.rs
+++ b/crates/nostr/examples/nip57.rs
@@ -9,17 +9,11 @@ fn main() -> Result<()> {
 
     let public_key =
         PublicKey::from_bech32("npub14f8usejl26twx0dhuxjh9cas7keav9vr0v8nvtwtrjqx3vycc76qqh9nsy")?;
-    let relays = [RelayUrl::parse("wss://relay.damus.io").unwrap()];
+    let relays = [RelayUrl::parse("wss://relay.damus.io")?];
     let data = ZapRequestData::new(public_key, relays).message("Zap!");
 
     let public_zap: Event = EventBuilder::public_zap_request(data.clone()).sign_with_keys(&keys)?;
     println!("Public zap request: {}", public_zap.as_json());
-
-    let anon_zap: Event = nip57::anonymous_zap_request(data.clone())?;
-    println!("Anonymous zap request: {}", anon_zap.as_json());
-
-    let private_zap: Event = nip57::private_zap_request(data, &keys)?;
-    println!("Private zap request: {}", private_zap.as_json());
 
     Ok(())
 }

--- a/crates/nostr/examples/nip57.rs
+++ b/crates/nostr/examples/nip57.rs
@@ -12,7 +12,7 @@ fn main() -> Result<()> {
     let relays = [RelayUrl::parse("wss://relay.damus.io")?];
     let data = ZapRequestData::new(public_key, relays).message("Zap!");
 
-    let public_zap: Event = EventBuilder::public_zap_request(data.clone()).sign_with_keys(&keys)?;
+    let public_zap: Event = EventBuilder::public_zap_request(data.clone()).sign(&keys)?;
     println!("Public zap request: {}", public_zap.as_json());
 
     Ok(())

--- a/crates/nostr/src/event/builder.rs
+++ b/crates/nostr/src/event/builder.rs
@@ -840,33 +840,7 @@ impl EventBuilder {
     ///
     /// **This event MUST NOT be broadcasted to relays**, instead must be sent to a recipient's LNURL pay callback url.
     ///
-    /// To build a **private** or **anonymous** zap request, use:
-    ///
-    /// ```rust,no_run
-    /// use nostr::prelude::*;
-    ///
-    /// # #[cfg(all(feature = "std", feature = "os-rng", feature = "nip57"))]
-    /// # fn main() {
-    /// # let keys = Keys::generate();
-    /// # let public_key = PublicKey::from_bech32(
-    /// # "npub14f8usejl26twx0dhuxjh9cas7keav9vr0v8nvtwtrjqx3vycc76qqh9nsy",
-    /// # ).unwrap();
-    /// # let relays = [RelayUrl::parse("wss://relay.damus.io").unwrap()];
-    /// let data = ZapRequestData::new(public_key, relays).message("Zap!");
-    ///
-    /// let anon_zap: Event = nip57::anonymous_zap_request(data.clone()).unwrap();
-    /// println!("Anonymous zap request: {anon_zap:#?}");
-    ///
-    /// let private_zap: Event = nip57::private_zap_request(data, &keys).unwrap();
-    /// println!("Private zap request: {private_zap:#?}");
-    /// # }
-    ///
-    /// # #[cfg(not(all(feature = "std", feature = "os-rng", feature = "nip57")))]
-    /// # fn main() {}
-    /// ```
-    ///
     /// <https://github.com/nostr-protocol/nips/blob/master/57.md>
-    #[cfg(feature = "nip57")]
     pub fn public_zap_request(data: ZapRequestData) -> Self {
         let message: String = data.message.clone();
         let tags: Vec<Tag> = data.into();
@@ -876,7 +850,6 @@ impl EventBuilder {
     /// Zap Receipt
     ///
     /// <https://github.com/nostr-protocol/nips/blob/master/57.md>
-    #[cfg(feature = "nip57")]
     pub fn zap_receipt<S1, S2>(bolt11: S1, preimage: Option<S2>, zap_request: &Event) -> Self
     where
         S1: Into<String>,
@@ -1900,7 +1873,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "nip57")]
     fn test_zap_event_builder() {
         let bolt11 = "lnbc10u1p3unwfusp5t9r3yymhpfqculx78u027lxspgxcr2n2987mx2j55nnfs95nxnzqpp5jmrh92pfld78spqs78v9euf2385t83uvpwk9ldrlvf6ch7tpascqhp5zvkrmemgth3tufcvflmzjzfvjt023nazlhljz2n9hattj4f8jq8qxqyjw5qcqpjrzjqtc4fc44feggv7065fqe5m4ytjarg3repr5j9el35xhmtfexc42yczarjuqqfzqqqqqqqqlgqqqqqqgq9q9qxpqysgq079nkq507a5tw7xgttmj4u990j7wfggtrasah5gd4ywfr2pjcn29383tphp4t48gquelz9z78p4cq7ml3nrrphw5w6eckhjwmhezhnqpy6gyf0";
         let preimage = Some("5d006d2cf1e73c7148e7519a4c68adc81642ce0e25a432b2434c99f97344c15f");
@@ -1922,7 +1894,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "nip57")]
     fn test_zap_event_builder_without_preimage() {
         let bolt11 = "lnbc10u1p3unwfusp5t9r3yymhpfqculx78u027lxspgxcr2n2987mx2j55nnfs95nxnzqpp5jmrh92pfld78spqs78v9euf2385t83uvpwk9ldrlvf6ch7tpascqhp5zvkrmemgth3tufcvflmzjzfvjt023nazlhljz2n9hattj4f8jq8qxqyjw5qcqpjrzjqtc4fc44feggv7065fqe5m4ytjarg3repr5j9el35xhmtfexc42yczarjuqqfzqqqqqqqqlgqqqqqqgq9q9qxpqysgq079nkq507a5tw7xgttmj4u990j7wfggtrasah5gd4ywfr2pjcn29383tphp4t48gquelz9z78p4cq7ml3nrrphw5w6eckhjwmhezhnqpy6gyf0";
         let preimage: Option<&str> = None;

--- a/crates/nostr/src/event/builder.rs
+++ b/crates/nostr/src/event/builder.rs
@@ -9,14 +9,6 @@ use alloc::vec::Vec;
 use core::fmt;
 use core::ops::Range;
 
-#[cfg(all(feature = "std", feature = "os-rng"))]
-use rand::TryRngCore;
-#[cfg(all(feature = "std", feature = "os-rng"))]
-use rand::rngs::OsRng;
-#[cfg(feature = "rand")]
-use rand::{CryptoRng, RngCore};
-#[cfg(feature = "rand")]
-use secp256k1::{Secp256k1, Signing, Verification};
 use serde_json::{Value, json};
 
 use crate::nips::nip58::Nip58Tag;
@@ -310,33 +302,6 @@ impl EventBuilder {
     {
         let public_key: PublicKey = signer.get_public_key().await?;
         Ok(self.build(public_key).sign_async(signer).await?)
-    }
-
-    /// Build, sign and return [`Event`] using [`Keys`] signer
-    ///
-    /// Check [`EventBuilder::sign_with_ctx`] to learn more.
-    #[inline]
-    #[cfg(all(feature = "std", feature = "os-rng"))]
-    pub fn sign_with_keys(self, keys: &Keys) -> Result<Event, Error> {
-        self.sign_with_ctx(&SECP256K1, &mut OsRng.unwrap_err(), keys)
-    }
-
-    /// Build, sign and return [`Event`] using [`Keys`] signer
-    ///
-    /// Check [`EventBuilder::build`] to learn more.
-    #[cfg(feature = "rand")]
-    pub fn sign_with_ctx<C, R>(
-        self,
-        secp: &Secp256k1<C>,
-        rng: &mut R,
-        keys: &Keys,
-    ) -> Result<Event, Error>
-    where
-        C: Signing + Verification,
-        R: RngCore + CryptoRng,
-    {
-        let pubkey: PublicKey = keys.public_key();
-        Ok(self.build(pubkey).sign_with_ctx(secp, rng, keys)?)
     }
 
     /// Profile metadata
@@ -1267,7 +1232,7 @@ impl EventBuilder {
         Self::new(Kind::GiftWrap, content)
             .tags(tags)
             .custom_created_at(Timestamp::tweaked(nip59::RANGE_RANDOM_TIMESTAMP_TWEAK))
-            .sign_with_keys(&keys)
+            .sign(&keys)
     }
 
     /// Gift Wrap
@@ -1840,9 +1805,7 @@ mod tests {
                 .unwrap(),
         );
 
-        let event = EventBuilder::text_note("hello")
-            .sign_with_keys(&keys)
-            .unwrap();
+        let event = EventBuilder::text_note("hello").sign(&keys).unwrap();
 
         let serialized = event.as_json();
         let deserialized = Event::from_json(serialized).unwrap();
@@ -1859,7 +1822,7 @@ mod tests {
         // Self-tagging
         let event = EventBuilder::text_note("hello")
             .tag(Tag::public_key(keys.public_key()))
-            .sign_with_keys(&keys)
+            .sign(&keys)
             .unwrap();
         assert!(event.tags.is_empty());
 
@@ -1867,7 +1830,7 @@ mod tests {
         let other = Keys::generate();
         let event = EventBuilder::text_note("hello 2")
             .tag(Tag::public_key(other.public_key()))
-            .sign_with_keys(&keys)
+            .sign(&keys)
             .unwrap();
         assert_eq!(event.tags.len(), 1);
     }
@@ -2001,7 +1964,7 @@ mod tests {
         let event_builder: Event =
             EventBuilder::award_badge(&badge_definition_event, awarded_pubkeys)
                 .unwrap()
-                .sign_with_keys(&keys)
+                .sign(&keys)
                 .unwrap();
 
         assert_eq!(event_builder.kind, Kind::BadgeAward);
@@ -2027,12 +1990,12 @@ mod tests {
         ];
         let bravery_badge_event =
             EventBuilder::define_badge("bravery", None, None, None, None, Vec::new())
-                .sign_with_keys(&badge_one_keys)
+                .sign(&badge_one_keys)
                 .unwrap();
         let bravery_badge_award =
             EventBuilder::award_badge(&bravery_badge_event, awarded_pubkeys.clone())
                 .unwrap()
-                .sign_with_keys(&badge_one_keys)
+                .sign(&badge_one_keys)
                 .unwrap();
 
         // Badge 2
@@ -2041,12 +2004,12 @@ mod tests {
 
         let honor_badge_event =
             EventBuilder::define_badge("honor", None, None, None, None, Vec::new())
-                .sign_with_keys(&badge_two_keys)
+                .sign(&badge_two_keys)
                 .unwrap();
         let honor_badge_award =
             EventBuilder::award_badge(&honor_badge_event, awarded_pubkeys.clone())
                 .unwrap()
-                .sign_with_keys(&badge_two_keys)
+                .sign(&badge_two_keys)
                 .unwrap();
 
         let example_event_json = format!(
@@ -2073,7 +2036,7 @@ mod tests {
         let profile_badges =
             EventBuilder::profile_badges(badge_definitions, badge_awards, &pub_key)
                 .unwrap()
-                .sign_with_keys(&keys)
+                .sign(&keys)
                 .unwrap();
 
         assert_eq!(profile_badges.kind, Kind::ProfileBadges);
@@ -2091,7 +2054,7 @@ mod tests {
         // Build reply
         let reply_keys = Keys::generate();
         let reply = EventBuilder::text_note_reply("Test reply", &root_event, None, None)
-            .sign_with_keys(&reply_keys)
+            .sign(&reply_keys)
             .unwrap();
         assert_eq!(reply.tags.public_keys().count(), 1); // Root author
         assert_eq!(reply.tags.public_keys().next().unwrap(), root_event.pubkey);
@@ -2102,7 +2065,7 @@ mod tests {
         let other_keys = Keys::generate();
         let reply_of_reply =
             EventBuilder::text_note_reply("Test reply of reply", &reply, Some(&root_event), None)
-                .sign_with_keys(&other_keys)
+                .sign(&other_keys)
                 .unwrap();
         assert_eq!(reply_of_reply.tags.public_keys().count(), 2); // Reply + root author
 
@@ -2122,10 +2085,10 @@ mod tests {
     fn replaceable_repost() {
         let keys = Keys::generate();
         let replaceable = EventBuilder::mute_list(MuteList::default())
-            .sign_with_keys(&keys)
+            .sign(&keys)
             .unwrap();
         let repost = EventBuilder::repost(&replaceable, None)
-            .sign_with_keys(&keys)
+            .sign(&keys)
             .unwrap();
 
         assert_eq!(repost.kind, Kind::GenericRepost);
@@ -2147,11 +2110,9 @@ mod tests {
     #[cfg(all(feature = "std", feature = "os-rng"))]
     fn addressable_repost() {
         let keys = Keys::generate();
-        let addressable = EventBuilder::follow_set("lorem", [])
-            .sign_with_keys(&keys)
-            .unwrap();
+        let addressable = EventBuilder::follow_set("lorem", []).sign(&keys).unwrap();
         let repost = EventBuilder::repost(&addressable, None)
-            .sign_with_keys(&keys)
+            .sign(&keys)
             .unwrap();
 
         assert_eq!(repost.kind, Kind::GenericRepost);
@@ -2176,11 +2137,9 @@ mod tests {
         let note_keys = Keys::generate();
         let repost_keys = Keys::generate();
         let relay_url = RelayUrl::parse("wss://relay.example.com").unwrap();
-        let note = EventBuilder::text_note("hello")
-            .sign_with_keys(&note_keys)
-            .unwrap();
+        let note = EventBuilder::text_note("hello").sign(&note_keys).unwrap();
         let repost = EventBuilder::repost(&note, Some(relay_url.clone()))
-            .sign_with_keys(&repost_keys)
+            .sign(&repost_keys)
             .unwrap();
 
         assert_eq!(repost.kind, Kind::Repost);
@@ -2207,11 +2166,9 @@ mod tests {
         let keys = Keys::generate();
         let protected = EventBuilder::text_note("secret")
             .tag(Tag::protected())
-            .sign_with_keys(&keys)
+            .sign(&keys)
             .unwrap();
-        let repost = EventBuilder::repost(&protected, None)
-            .sign_with_keys(&keys)
-            .unwrap();
+        let repost = EventBuilder::repost(&protected, None).sign(&keys).unwrap();
 
         assert!(repost.content.is_empty());
     }
@@ -2228,7 +2185,7 @@ mod benches {
     pub fn builder_to_event(bh: &mut Bencher) {
         let keys = Keys::generate();
         bh.iter(|| {
-            black_box(EventBuilder::text_note("hello").sign_with_keys(&keys)).unwrap();
+            black_box(EventBuilder::text_note("hello").sign(&keys)).unwrap();
         });
     }
 }

--- a/crates/nostr/src/event/mod.rs
+++ b/crates/nostr/src/event/mod.rs
@@ -383,7 +383,7 @@ mod tests {
     fn test_custom_kind() {
         let keys = Keys::generate();
         let e: Event = EventBuilder::new(Kind::Custom(123), "my content")
-            .sign_with_keys(&keys)
+            .sign(&keys)
             .unwrap();
 
         let serialized = e.as_json();
@@ -400,7 +400,7 @@ mod tests {
         let my_keys = Keys::generate();
         let event = EventBuilder::text_note("my content")
             .tags([Tag::expiration(Timestamp::from(1600000000))])
-            .sign_with_keys(&my_keys)
+            .sign(&my_keys)
             .unwrap();
 
         assert!(&event.is_expired());
@@ -415,7 +415,7 @@ mod tests {
         let my_keys = Keys::generate();
         let event = EventBuilder::text_note("my content")
             .tags([Tag::expiration(Timestamp::from(expiry_date))])
-            .sign_with_keys(&my_keys)
+            .sign(&my_keys)
             .unwrap();
 
         assert!(!&event.is_expired());
@@ -426,7 +426,7 @@ mod tests {
     fn test_event_without_expiration_tag() {
         let my_keys = Keys::generate();
         let event = EventBuilder::text_note("my content")
-            .sign_with_keys(&my_keys)
+            .sign(&my_keys)
             .unwrap();
         assert!(!&event.is_expired());
     }

--- a/crates/nostr/src/event/unsigned.rs
+++ b/crates/nostr/src/event/unsigned.rs
@@ -7,23 +7,15 @@
 use alloc::string::String;
 use core::num::NonZeroU8;
 
-#[cfg(all(feature = "std", feature = "os-rng"))]
-use rand::TryRngCore;
-#[cfg(all(feature = "std", feature = "os-rng"))]
-use rand::rngs::OsRng;
-#[cfg(feature = "rand")]
-use rand::{CryptoRng, RngCore};
 use secp256k1::schnorr::Signature;
-use secp256k1::{Message, Secp256k1, Signing, Verification};
+use secp256k1::{Secp256k1, Verification};
 
 use super::error::Error;
 #[cfg(feature = "std")]
 use crate::SECP256K1;
 use crate::nips::nip13::{AsyncPowAdapter, PowAdapter};
 use crate::signer::{AsyncSignEvent, SignEvent};
-#[cfg(feature = "rand")]
-use crate::util;
-use crate::{Event, EventId, JsonUtil, Keys, Kind, PublicKey, Tag, Tags, Timestamp};
+use crate::{Event, EventId, JsonUtil, Kind, PublicKey, Tag, Tags, Timestamp};
 
 /// Unsigned event
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -147,62 +139,18 @@ impl UnsignedEvent {
         Ok(signer.sign_event(self).await?)
     }
 
-    /// Sign an unsigned event with [`Keys`] signer
-    #[inline]
-    #[cfg(all(feature = "std", feature = "os-rng"))]
-    pub fn sign_with_keys(self, keys: &Keys) -> Result<Event, Error> {
-        self.sign_with_ctx(&SECP256K1, &mut OsRng.unwrap_err(), keys)
-    }
-
-    /// Sign an unsigned event with [`Keys`] signer
-    #[inline]
-    #[cfg(feature = "rand")]
-    pub fn sign_with_ctx<C, R>(
-        self,
-        secp: &Secp256k1<C>,
-        rng: &mut R,
-        keys: &Keys,
-    ) -> Result<Event, Error>
-    where
-        C: Signing + Verification,
-        R: RngCore + CryptoRng,
-    {
-        let aux: [u8; 32] = util::random_32_bytes(rng);
-        self.sign_with_aux_rand(secp, keys, &aux)
-    }
-
-    /// Sign an unsigned event using the given auxiliary random data.
+    /// Add a signature to an unsigned event
     ///
-    /// Internally: calculate [EventId] (if not set), sign it, compose and verify [Event].
-    pub fn sign_with_aux_rand<C>(
-        self,
-        secp: &Secp256k1<C>,
-        keys: &Keys,
-        aux: &[u8; 32],
-    ) -> Result<Event, Error>
-    where
-        C: Signing + Verification,
-    {
-        let verify_id: bool = self.id.is_some();
-        let id: EventId = self.id.unwrap_or_else(|| self.compute_id());
-        let message: Message = Message::from_digest(id.to_bytes());
-        let sig: Signature = keys.sign_schnorr_with_aux_rand(secp, &message, aux);
-        self.internal_add_signature(secp, id, sig, verify_id, false)
-    }
-
-    /// Add signature to unsigned event
-    ///
-    /// Internally verify the [Event].
+    /// This method internally verifies the event ID and signature.
     #[inline]
     #[cfg(feature = "std")]
     pub fn add_signature(self, sig: Signature) -> Result<Event, Error> {
         self.add_signature_with_ctx(&SECP256K1, sig)
     }
 
-    /// Add signature to unsigned event
+    /// Add a signature to an unsigned event
     ///
-    /// Internally verify the [Event].
-    #[inline]
+    /// Internally verifies the event ID and signature.
     pub fn add_signature_with_ctx<C>(
         self,
         secp: &Secp256k1<C>,
@@ -211,22 +159,13 @@ impl UnsignedEvent {
     where
         C: Verification,
     {
-        let verify_id: bool = self.id.is_some();
-        let id: EventId = self.id.unwrap_or_else(|| self.compute_id());
-        self.internal_add_signature(secp, id, sig, verify_id, true)
-    }
+        let (id, verify_id): (EventId, bool) = match self.id {
+            // Mark the ID as verified if it's already set, as may be wrong.
+            Some(id) => (id, true),
+            // No event ID, we are computing it so we don't need to verify it.
+            None => (self.compute_id(), false),
+        };
 
-    fn internal_add_signature<C>(
-        self,
-        secp: &Secp256k1<C>,
-        id: EventId,
-        sig: Signature,
-        verify_id: bool,
-        verify_sig: bool,
-    ) -> Result<Event, Error>
-    where
-        C: Verification,
-    {
         let event: Event = Event::new(
             id,
             self.pubkey,
@@ -237,13 +176,13 @@ impl UnsignedEvent {
             sig,
         );
 
-        // Verify event ID
+        // Verify the event ID
         if verify_id && !event.verify_id() {
             return Err(Error::InvalidId);
         }
 
         // Verify event signature
-        if verify_sig && !event.verify_signature_with_ctx(secp) {
+        if !event.verify_signature_with_ctx(secp) {
             return Err(Error::InvalidSignature);
         }
 

--- a/crates/nostr/src/key/mod.rs
+++ b/crates/nostr/src/key/mod.rs
@@ -27,6 +27,8 @@ pub mod secret_key;
 pub use self::public_key::PublicKey;
 pub use self::secret_key::SecretKey;
 #[cfg(all(feature = "std", feature = "os-rng"))]
+use crate::event::{Event, EventId, UnsignedEvent};
+#[cfg(all(feature = "std", feature = "os-rng"))]
 use crate::nips::nip04::{AsyncNip04, Nip04};
 #[cfg(all(feature = "std", feature = "os-rng"))]
 use crate::nips::nip44::{AsyncNip44, Nip44};
@@ -38,8 +40,6 @@ use crate::util;
 use crate::util::BoxedFuture;
 #[cfg(feature = "std")]
 use crate::util::SECP256K1;
-#[cfg(all(feature = "std", feature = "os-rng"))]
-use crate::{Event, UnsignedEvent};
 
 /// [`Keys`] error
 #[derive(Debug, PartialEq)]
@@ -277,7 +277,10 @@ impl GetPublicKey for Keys {
 #[cfg(all(feature = "std", feature = "os-rng"))]
 impl SignEvent for Keys {
     fn sign_event(&self, unsigned: UnsignedEvent) -> Result<Event, SignerError> {
-        unsigned.sign_with_keys(self).map_err(SignerError::backend)
+        let id: EventId = unsigned.id.unwrap_or_else(|| unsigned.compute_id());
+        let message: Message = Message::from_digest(id.to_bytes());
+        let sig: Signature = self.sign_schnorr(&message);
+        unsigned.add_signature(sig).map_err(SignerError::backend)
     }
 }
 

--- a/crates/nostr/src/nips/mod.rs
+++ b/crates/nostr/src/nips/mod.rs
@@ -44,7 +44,6 @@ pub mod nip49;
 pub mod nip51;
 pub mod nip53;
 pub mod nip56;
-#[cfg(feature = "nip57")]
 pub mod nip57;
 pub mod nip58;
 #[cfg(feature = "nip59")]

--- a/crates/nostr/src/nips/nip09.rs
+++ b/crates/nostr/src/nips/nip09.rs
@@ -116,7 +116,7 @@ mod tests {
             .coordinate(coordinate)
             .reason("these posts were published by accident");
 
-        let event: Event = request.to_event_builder().sign_with_keys(&keys).unwrap();
+        let event: Event = request.to_event_builder().sign(&keys).unwrap();
 
         assert_eq!(event.kind, Kind::EventDeletion);
         assert_eq!(event.content, "these posts were published by accident");
@@ -137,7 +137,7 @@ mod tests {
         // Event ID without reason
         let request = EventDeletionRequest::new().id(event_id);
 
-        let event: Event = request.to_event_builder().sign_with_keys(&keys).unwrap();
+        let event: Event = request.to_event_builder().sign(&keys).unwrap();
 
         assert_eq!(event.kind, Kind::EventDeletion);
         assert!(event.content.is_empty());

--- a/crates/nostr/src/nips/nip34.rs
+++ b/crates/nostr/src/nips/nip34.rs
@@ -949,11 +949,7 @@ mod tests {
         };
 
         let keys = Keys::generate();
-        let event: Event = repo
-            .to_event_builder()
-            .unwrap()
-            .sign_with_keys(&keys)
-            .unwrap();
+        let event: Event = repo.to_event_builder().unwrap().sign(&keys).unwrap();
 
         assert_eq!(event.kind, Kind::GitRepoAnnouncement);
         assert!(event.content.is_empty());
@@ -1013,11 +1009,7 @@ mod tests {
         };
 
         let keys = Keys::generate();
-        let event: Event = repo
-            .to_event_builder()
-            .unwrap()
-            .sign_with_keys(&keys)
-            .unwrap();
+        let event: Event = repo.to_event_builder().unwrap().sign(&keys).unwrap();
 
         assert_eq!(event.kind, Kind::GitIssue);
         assert_eq!(event.content, "My issue content");
@@ -1065,11 +1057,7 @@ mod tests {
         };
 
         let keys = Keys::generate();
-        let event: Event = repo
-            .to_event_builder()
-            .unwrap()
-            .sign_with_keys(&keys)
-            .unwrap();
+        let event: Event = repo.to_event_builder().unwrap().sign(&keys).unwrap();
 
         assert_eq!(event.kind, Kind::GitPatch);
         assert_eq!(event.content, "<patch>");
@@ -1126,11 +1114,7 @@ mod tests {
         };
 
         let keys = Keys::generate();
-        let event: Event = update
-            .to_event_builder()
-            .unwrap()
-            .sign_with_keys(&keys)
-            .unwrap();
+        let event: Event = update.to_event_builder().unwrap().sign(&keys).unwrap();
 
         assert_eq!(event.kind, Kind::GitPullRequestUpdate);
         assert!(event.content.is_empty());

--- a/crates/nostr/src/nips/nip42.rs
+++ b/crates/nostr/src/nips/nip42.rs
@@ -167,7 +167,7 @@ mod tests {
         let challenge = "1234567890";
 
         let event = EventBuilder::auth(challenge, relay_url.clone())
-            .sign_with_keys(&keys)
+            .sign(&keys)
             .unwrap();
 
         assert!(is_valid_auth_event(&event, &relay_url, challenge));
@@ -181,20 +181,18 @@ mod tests {
 
         // Wrong challenge
         let event = EventBuilder::auth("abcd", relay_url.clone())
-            .sign_with_keys(&keys)
+            .sign(&keys)
             .unwrap();
         assert!(!is_valid_auth_event(&event, &relay_url, challenge));
 
         // Wrong relay url
         let event = EventBuilder::auth(challenge, RelayUrl::parse("wss://example.com").unwrap())
-            .sign_with_keys(&keys)
+            .sign(&keys)
             .unwrap();
         assert!(!is_valid_auth_event(&event, &relay_url, challenge));
 
         // Wrong kind
-        let event = EventBuilder::text_note("abcd")
-            .sign_with_keys(&keys)
-            .unwrap();
+        let event = EventBuilder::text_note("abcd").sign(&keys).unwrap();
         assert!(!is_valid_auth_event(&event, &relay_url, challenge));
     }
 }

--- a/crates/nostr/src/nips/nip47.rs
+++ b/crates/nostr/src/nips/nip47.rs
@@ -626,7 +626,7 @@ impl Request {
         let keys: Keys = Keys::new(uri.secret.clone());
         Ok(EventBuilder::new(Kind::WalletConnectRequest, encrypted)
             .tag(Tag::public_key(uri.public_key))
-            .sign_with_keys(&keys)?)
+            .sign(&keys)?)
     }
 }
 

--- a/crates/nostr/src/nips/nip57.rs
+++ b/crates/nostr/src/nips/nip57.rs
@@ -12,50 +12,17 @@ use alloc::vec::Vec;
 use core::fmt;
 use core::num::ParseIntError;
 
-use aes::Aes256;
-#[cfg(feature = "rand")]
-use aes::cipher::BlockEncryptMut;
-use aes::cipher::block_padding::Pkcs7;
-use aes::cipher::{BlockDecryptMut, KeyIvInit};
-#[cfg(feature = "rand")]
-use bech32::Bech32;
-use bech32::Hrp;
-use cbc::Decryptor;
-#[cfg(feature = "rand")]
-use cbc::Encryptor;
-use hashes::Hash;
-use hashes::sha256::Hash as Sha256Hash;
-#[cfg(all(feature = "std", feature = "os-rng"))]
-use rand::TryRngCore;
-#[cfg(all(feature = "std", feature = "os-rng"))]
-use rand::rngs::OsRng;
-#[cfg(feature = "rand")]
-use rand::{CryptoRng, RngCore};
-#[cfg(feature = "rand")]
-use secp256k1::{Secp256k1, Signing, Verification};
-
 use super::nip01::Coordinate;
 use super::util::{
-    take_and_parse_from_str, take_and_parse_optional_from_str, take_optional_string,
-    take_public_key, take_relay_url, take_string,
+    take_and_parse_from_str, take_and_parse_optional_from_str, take_public_key, take_relay_url,
+    take_string,
 };
-#[cfg(all(feature = "std", feature = "os-rng"))]
-use crate::SECP256K1;
 use crate::event::builder::Error as BuilderError;
 use crate::event::tag::{Tag, TagCodec, TagCodecError, impl_tag_codec_conversions};
 use crate::key::Error as KeyError;
 use crate::types::url;
-use crate::{Event, EventId, JsonUtil, PublicKey, RelayUrl, SecretKey, Timestamp, event, util};
-#[cfg(feature = "rand")]
-use crate::{EventBuilder, Keys, Kind};
+use crate::{EventId, PublicKey, RelayUrl, event};
 
-#[cfg(feature = "rand")]
-type Aes256CbcEnc = Encryptor<Aes256>;
-type Aes256CbcDec = Decryptor<Aes256>;
-
-const PRIVATE_ZAP_MSG_BECH32_PREFIX: Hrp = Hrp::parse_unchecked("pzap");
-const PRIVATE_ZAP_IV_BECH32_PREFIX: Hrp = Hrp::parse_unchecked("iv");
-const ANON: &str = "anon";
 const AMOUNT: &str = "amount";
 const BOLT11: &str = "bolt11";
 const DESCRIPTION: &str = "description";
@@ -172,11 +139,6 @@ pub enum Nip57Tag {
     },
     /// `lnurl` tag
     Lnurl(String),
-    /// `anon` tag
-    Anon {
-        /// Optional private zap payload
-        msg: Option<String>,
-    },
     /// `bolt11` tag
     Bolt11(String),
     /// `description` tag
@@ -214,9 +176,6 @@ impl TagCodec for Nip57Tag {
                 Ok(Self::Amount { millisats, bolt11 })
             }
             LNURL => Ok(Self::Lnurl(take_string(&mut iter, "LNURL")?)),
-            ANON => Ok(Self::Anon {
-                msg: take_optional_string(&mut iter),
-            }),
             BOLT11 => Ok(Self::Bolt11(take_string(&mut iter, "BOLT11")?)),
             DESCRIPTION => Ok(Self::Description(take_string(&mut iter, "description")?)),
             PREIMAGE => Ok(Self::Preimage(take_string(&mut iter, "preimage")?)),
@@ -252,13 +211,6 @@ impl TagCodec for Nip57Tag {
                 Tag::new(tag)
             }
             Self::Lnurl(lnurl) => Tag::new(vec![String::from(LNURL), lnurl.clone()]),
-            Self::Anon { msg } => {
-                let mut tag: Vec<String> = vec![String::from(ANON)];
-                if let Some(msg) = msg {
-                    tag.push(msg.clone());
-                }
-                Tag::new(tag)
-            }
             Self::Bolt11(bolt11) => Tag::new(vec![String::from(BOLT11), bolt11.clone()]),
             Self::Description(description) => {
                 Tag::new(vec![String::from(DESCRIPTION), description.clone()])
@@ -330,10 +282,6 @@ where
 pub enum ZapType {
     /// Public
     Public,
-    /// Private
-    Private,
-    /// Anonymous
-    Anonymous,
 }
 
 /// Zap Request Data
@@ -463,171 +411,7 @@ impl From<ZapRequestData> for Vec<Tag> {
     }
 }
 
-/// Create **anonymous** zap request
-#[cfg(all(feature = "std", feature = "os-rng"))]
-pub fn anonymous_zap_request(data: ZapRequestData) -> Result<Event, Error> {
-    let keys = Keys::generate();
-    let message: String = data.message.clone();
-    let mut tags: Vec<Tag> = data.into();
-    tags.push(Nip57Tag::Anon { msg: None }.into());
-    Ok(EventBuilder::new(Kind::ZapRequest, message)
-        .tags(tags)
-        .sign_with_keys(&keys)?)
-}
-
-/// Create **private** zap request
-#[inline]
-#[cfg(all(feature = "std", feature = "os-rng"))]
-pub fn private_zap_request(data: ZapRequestData, keys: &Keys) -> Result<Event, Error> {
-    private_zap_request_with_ctx(&SECP256K1, &mut OsRng.unwrap_err(), data, keys)
-}
-
-/// Create **private** zap request
-#[cfg(feature = "rand")]
-pub fn private_zap_request_with_ctx<C, R>(
-    secp: &Secp256k1<C>,
-    rng: &mut R,
-    data: ZapRequestData,
-    keys: &Keys,
-) -> Result<Event, Error>
-where
-    C: Signing + Verification,
-    R: RngCore + CryptoRng,
-{
-    let created_at: Timestamp = Timestamp::now();
-
-    // Create encryption key
-    let secret_key: SecretKey =
-        create_encryption_key(keys.secret_key(), &data.public_key, created_at)?;
-
-    // Compose encrypted message
-    let mut tags: Vec<Tag> = vec![Tag::public_key(data.public_key)];
-    if let Some(event_id) = data.event_id {
-        tags.push(Tag::event(event_id));
-    }
-    let msg: String = EventBuilder::new(Kind::ZapPrivateMessage, &data.message)
-        .tags(tags)
-        .sign_with_ctx(secp, rng, keys)?
-        .as_json();
-    let msg: String = encrypt_private_zap_message(rng, &secret_key, &data.public_key, msg)?;
-
-    // Compose event
-    let mut tags: Vec<Tag> = data.into();
-    tags.push(Nip57Tag::Anon { msg: Some(msg) }.into());
-    let private_zap_keys: Keys = Keys::new_with_ctx(secp, secret_key);
-    Ok(EventBuilder::new(Kind::ZapRequest, "")
-        .tags(tags)
-        .custom_created_at(created_at)
-        .sign_with_ctx(secp, rng, &private_zap_keys)?)
-}
-
-/// Create NIP57 encryption key for **private** zap
-pub fn create_encryption_key(
-    secret_key: &SecretKey,
-    public_key: &PublicKey,
-    created_at: Timestamp,
-) -> Result<SecretKey, Error> {
-    let mut unhashed: String = secret_key.to_secret_hex();
-    unhashed.push_str(&public_key.to_string());
-    unhashed.push_str(&created_at.to_string());
-    let hash = Sha256Hash::hash(unhashed.as_bytes());
-    Ok(SecretKey::from_slice(hash.as_byte_array())?)
-}
-
-/// Encrypt a private zap message using the given keys
-#[cfg(feature = "rand")]
-pub fn encrypt_private_zap_message<R, T>(
-    rng: &mut R,
-    secret_key: &SecretKey,
-    public_key: &PublicKey,
-    msg: T,
-) -> Result<String, Error>
-where
-    R: RngCore,
-    T: AsRef<[u8]>,
-{
-    let key: [u8; 32] = util::generate_shared_key(secret_key, public_key)?;
-    let mut iv: [u8; 16] = [0u8; 16];
-    rng.fill_bytes(&mut iv);
-
-    let cipher = Aes256CbcEnc::new(&key.into(), &iv.into());
-    let msg: Vec<u8> = cipher.encrypt_padded_vec_mut::<Pkcs7>(msg.as_ref());
-
-    // Bech32 msg
-    let encrypted_bech32_msg: String =
-        bech32::encode::<Bech32>(PRIVATE_ZAP_MSG_BECH32_PREFIX, &msg)?;
-
-    // Bech32 IV
-    let iv_bech32: String = bech32::encode::<Bech32>(PRIVATE_ZAP_IV_BECH32_PREFIX, &iv)?;
-
-    Ok(format!("{encrypted_bech32_msg}_{iv_bech32}"))
-}
-
-fn extract_anon_tag_message(event: &Event) -> Result<String, Error> {
-    for tag in event.tags.iter() {
-        if let Ok(Nip57Tag::Anon { msg }) = Nip57Tag::try_from(tag) {
-            return msg.ok_or(Error::InvalidPrivateZapMessage);
-        }
-    }
-    Err(Error::PrivateZapMessageNotFound)
-}
-
-/// Decrypt **private** zap message that was sent by the owner of the secret key
-pub fn decrypt_sent_private_zap_message(
-    secret_key: &SecretKey,
-    public_key: &PublicKey,
-    private_zap_event: &Event,
-) -> Result<Event, Error> {
-    // Re-create our ephemeral encryption key
-    let secret_key: SecretKey =
-        create_encryption_key(secret_key, public_key, private_zap_event.created_at)?;
-    let key: [u8; 32] = util::generate_shared_key(&secret_key, public_key)?;
-
-    // decrypt like normal
-    decrypt_private_zap_message(key, private_zap_event)
-}
-
-/// Decrypt **private** zap message that was received by the owner of the secret key
-#[inline]
-pub fn decrypt_received_private_zap_message(
-    secret_key: &SecretKey,
-    private_zap_event: &Event,
-) -> Result<Event, Error> {
-    let key: [u8; 32] = util::generate_shared_key(secret_key, &private_zap_event.pubkey)?;
-    decrypt_private_zap_message(key, private_zap_event)
-}
-
-fn decrypt_private_zap_message(key: [u8; 32], private_zap_event: &Event) -> Result<Event, Error> {
-    let msg: String = extract_anon_tag_message(private_zap_event)?;
-    let mut splitted = msg.split('_');
-
-    let msg: &str = splitted.next().ok_or(Error::InvalidPrivateZapMessage)?;
-    let iv: &str = splitted.next().ok_or(Error::InvalidPrivateZapMessage)?;
-
-    // IV
-    let (hrp, iv) = bech32::decode(iv)?;
-    if hrp != PRIVATE_ZAP_IV_BECH32_PREFIX {
-        return Err(Error::WrongBech32Prefix);
-    }
-
-    // Msg
-    let (hrp, msg) = bech32::decode(msg)?;
-    if hrp != PRIVATE_ZAP_MSG_BECH32_PREFIX {
-        return Err(Error::WrongBech32Prefix);
-    }
-
-    // Decrypt
-    let cipher = Aes256CbcDec::new(&key.into(), iv.as_slice().into());
-    let result: Vec<u8> = cipher
-        .decrypt_padded_vec_mut::<Pkcs7>(&msg)
-        .map_err(|_| Error::WrongBlockMode)?;
-
-    // TODO: check if event kind is equal to 9733
-    Ok(Event::from_json(result)?)
-}
-
 #[cfg(test)]
-#[cfg(all(feature = "std", feature = "os-rng"))]
 mod tests {
     use super::*;
 
@@ -664,23 +448,6 @@ mod tests {
         assert_eq!(
             parsed.to_tag(),
             Tag::parse(["amount", "21000", "lnbc21u1p0test"]).unwrap()
-        );
-    }
-
-    #[test]
-    fn test_anon_tag() {
-        let tag = vec!["anon", "encrypted-message"];
-        let parsed = Nip57Tag::parse(tag).unwrap();
-
-        assert_eq!(
-            parsed,
-            Nip57Tag::Anon {
-                msg: Some(String::from("encrypted-message")),
-            }
-        );
-        assert_eq!(
-            parsed.to_tag(),
-            Tag::parse(["anon", "encrypted-message"]).unwrap()
         );
     }
 
@@ -738,30 +505,5 @@ mod tests {
             ])
             .unwrap()
         );
-    }
-
-    #[test]
-    fn test_encrypt_decrypt_private_zap_message() {
-        let alice_keys = Keys::generate();
-        let bob_keys = Keys::generate();
-
-        let relays = [RelayUrl::parse("wss://relay.damus.io").unwrap()];
-        let msg = "Private Zap message!";
-        let data = ZapRequestData::new(bob_keys.public_key(), relays).message(msg);
-        let private_zap = private_zap_request(data, &alice_keys).unwrap();
-
-        let private_zap_msg = decrypt_sent_private_zap_message(
-            alice_keys.secret_key(),
-            &bob_keys.public_key(),
-            &private_zap,
-        )
-        .unwrap();
-
-        assert_eq!(msg, &private_zap_msg.content);
-
-        let private_zap_msg =
-            decrypt_received_private_zap_message(bob_keys.secret_key(), &private_zap).unwrap();
-
-        assert_eq!(msg, &private_zap_msg.content)
     }
 }

--- a/crates/nostr/src/prelude.rs
+++ b/crates/nostr/src/prelude.rs
@@ -68,7 +68,6 @@ pub use crate::nips::nip49::{self, *};
 pub use crate::nips::nip51::{self, *};
 pub use crate::nips::nip53::{self, *};
 pub use crate::nips::nip56::{self, *};
-#[cfg(feature = "nip57")]
 pub use crate::nips::nip57::{self, *};
 pub use crate::nips::nip58;
 #[cfg(feature = "nip59")]

--- a/database/nostr-database-test-suite/src/lib.rs
+++ b/database/nostr-database-test-suite/src/lib.rs
@@ -40,7 +40,7 @@ macro_rules! database_unit_tests {
         }
 
         fn build_event(keys: &Keys, builder: EventBuilder) -> Event {
-            builder.sign_with_keys(keys).expect("Failed to build and sign event")
+            builder.sign(keys).expect("Failed to build and sign event")
         }
 
         // Return the number of added events
@@ -82,7 +82,7 @@ macro_rules! database_unit_tests {
             builder: EventBuilder,
             keys: &Keys,
         ) -> (Event, SaveEventStatus) {
-            let event = builder.sign_with_keys(keys).expect("Failed to sign event");
+            let event = builder.sign(keys).expect("Failed to sign event");
             let status = store.save_event(&event).await.expect("Failed to save event");
             (event, status)
         }
@@ -104,24 +104,24 @@ macro_rules! database_unit_tests {
             let helper = Keys::generate();
 
             let event1 = EventBuilder::text_note("Hi 1")
-                .sign_with_keys(&to_vanish)
+                .sign(&to_vanish)
                 .unwrap();
             let event2 = EventBuilder::text_note("Hi 2")
-                .sign_with_keys(&to_vanish)
+                .sign(&to_vanish)
                 .unwrap();
             let replaceable = EventBuilder::contact_list([
                 Contact::new(Keys::generate().public_key),
                 Contact::new(Keys::generate().public_key),
             ])
-            .sign_with_keys(&to_vanish)
+            .sign(&to_vanish)
             .unwrap();
             let addresable = EventBuilder::long_form_text_note("LONG")
                 .tag(Tag::identifier("lorem-ipsum".to_string()))
-                .sign_with_keys(&to_vanish)
+                .sign(&to_vanish)
                 .unwrap();
             let dummy_gift_wrap = EventBuilder::new(Kind::GiftWrap, ":)")
                 .tag(Tag::public_key(to_vanish.public_key))
-                .sign_with_keys(&helper)
+                .sign(&helper)
                 .unwrap();
 
             store.save_event(&event1).await.unwrap();
@@ -279,7 +279,7 @@ macro_rules! database_unit_tests {
             let metadata1 = Metadata::new().name("First");
             let event1 = EventBuilder::metadata(&metadata1)
                 .custom_created_at(Timestamp::from_secs(1000))
-                .sign_with_keys(&keys)
+                .sign(&keys)
                 .expect("Failed to sign");
 
             store.save_event(&event1).await.expect("Failed to save event");
@@ -288,7 +288,7 @@ macro_rules! database_unit_tests {
             let metadata2 = Metadata::new().name("Second");
             let event2 = EventBuilder::metadata(&metadata2)
                 .custom_created_at(Timestamp::from_secs(2000))
-                .sign_with_keys(&keys)
+                .sign(&keys)
                 .expect("Failed to sign");
 
             store.save_event(&event2).await.expect("Failed to save event");
@@ -313,7 +313,7 @@ macro_rules! database_unit_tests {
             let event1 = EventBuilder::new(Kind::from(32121), "Content 1")
                 .tag(Tag::identifier("test-id"))
                 .custom_created_at(Timestamp::from_secs(1000))
-                .sign_with_keys(&keys)
+                .sign(&keys)
                 .expect("Failed to sign");
 
             store.save_event(&event1).await.expect("Failed to save event");
@@ -322,7 +322,7 @@ macro_rules! database_unit_tests {
             let event2 = EventBuilder::new(Kind::from(32121), "Content 2")
                 .tag(Tag::identifier("test-id"))
                 .custom_created_at(Timestamp::from_secs(2000))
-                .sign_with_keys(&keys)
+                .sign(&keys)
                 .expect("Failed to sign");
 
             store.save_event(&event2).await.expect("Failed to save event");
@@ -347,10 +347,10 @@ macro_rules! database_unit_tests {
 
             // Create events to delete
             let event1 = EventBuilder::text_note("To be deleted 1")
-                .sign_with_keys(&keys)
+                .sign(&keys)
                 .expect("Failed to sign");
             let event2 = EventBuilder::text_note("To be deleted 2")
-                .sign_with_keys(&keys)
+                .sign(&keys)
                 .expect("Failed to sign");
 
             store.save_event(&event1).await.expect("Failed to save event");
@@ -359,7 +359,7 @@ macro_rules! database_unit_tests {
             // Create deletion event
             let deletion =
                 EventBuilder::delete(EventDeletionRequest::new().id(event1.id).id(event2.id))
-                    .sign_with_keys(&keys)
+                    .sign(&keys)
                     .expect("Failed to sign");
 
             store.save_event(&deletion)
@@ -392,7 +392,7 @@ macro_rules! database_unit_tests {
 
             // Create events to delete
             let event = EventBuilder::new(Kind::Custom(11_111), "To be deleted 1")
-                .sign_with_keys(&keys)
+                .sign(&keys)
                 .expect("Failed to sign");
 
             let status = store.save_event(&event).await.expect("Failed to save event");
@@ -404,7 +404,7 @@ macro_rules! database_unit_tests {
                 .coordinate(event.coordinate().unwrap());
             let deletion =
                 EventBuilder::delete(req)
-                    .sign_with_keys(&keys)
+                    .sign(&keys)
                     .expect("Failed to sign");
 
             store.save_event(&deletion)
@@ -945,7 +945,7 @@ macro_rules! database_unit_tests {
             // Request to vanish
             let request_to_vanish = EventBuilder::request_vanish(VanishTarget::AllRelays)
                 .unwrap()
-                .sign_with_keys(&to_vanish)
+                .sign(&to_vanish)
                 .unwrap();
             store.save_event(&request_to_vanish).await.unwrap();
 
@@ -970,7 +970,7 @@ macro_rules! database_unit_tests {
             );
 
             let new_event = EventBuilder::text_note("It was a mistake, please accept my event")
-                .sign_with_keys(&to_vanish)
+                .sign(&to_vanish)
                 .unwrap();
 
             // Try adding new event, should get rejected
@@ -996,7 +996,7 @@ macro_rules! database_unit_tests {
             // Request to vanish
             let request_to_vanish = EventBuilder::request_vanish(VanishTarget::relay(url))
                 .unwrap()
-                .sign_with_keys(&to_vanish)
+                .sign(&to_vanish)
                 .unwrap();
             store.save_event(&request_to_vanish).await.unwrap();
 
@@ -1021,7 +1021,7 @@ macro_rules! database_unit_tests {
             );
 
             let new_event = EventBuilder::text_note("It was a mistake, please accept my event")
-                .sign_with_keys(&to_vanish)
+                .sign(&to_vanish)
                 .unwrap();
 
             // Try adding new event, should get rejected

--- a/database/nostr-lmdb/src/store/filter.rs
+++ b/database/nostr-lmdb/src/store/filter.rs
@@ -176,9 +176,7 @@ mod tests {
 
     fn create_test_event(content: &str) -> Event {
         let keys = Keys::generate();
-        EventBuilder::text_note(content)
-            .sign_with_keys(&keys)
-            .unwrap()
+        EventBuilder::text_note(content).sign(&keys).unwrap()
     }
 
     #[test]
@@ -205,7 +203,7 @@ mod tests {
         let keys = Keys::generate();
         let event = EventBuilder::text_note("content")
             .tag(Tag::parse(["title", "Search userfacing tags"]).unwrap())
-            .sign_with_keys(&keys)
+            .sign(&keys)
             .unwrap();
         let event: EventBorrow = (&event).into();
 

--- a/database/nostr-lmdb/src/store/ingester.rs
+++ b/database/nostr-lmdb/src/store/ingester.rs
@@ -397,7 +397,7 @@ mod tests {
 
         // Create a mix of valid and duplicate events
         let event1 = EventBuilder::text_note("Event 1")
-            .sign_with_keys(&keys)
+            .sign(&keys)
             .expect("Failed to sign event");
 
         // Save event1 first
@@ -408,11 +408,11 @@ mod tests {
 
         // Now try to save a batch with duplicate and new events
         let event2 = EventBuilder::text_note("Event 2")
-            .sign_with_keys(&keys)
+            .sign(&keys)
             .expect("Failed to sign event");
 
         let event3 = EventBuilder::text_note("Event 3")
-            .sign_with_keys(&keys)
+            .sign(&keys)
             .expect("Failed to sign event");
 
         let futures = vec![
@@ -453,7 +453,7 @@ mod tests {
         let mut events = Vec::new();
         for i in 0..10 {
             let event = EventBuilder::text_note(format!("Event to delete {}", i))
-                .sign_with_keys(&keys)
+                .sign(&keys)
                 .expect("Failed to sign event");
             store
                 .save_event(&event)
@@ -464,11 +464,11 @@ mod tests {
 
         // Now create a mixed batch of saves and deletes
         let new_event1 = EventBuilder::text_note("New event 1")
-            .sign_with_keys(&keys)
+            .sign(&keys)
             .expect("Failed to sign event");
 
         let new_event2 = EventBuilder::text_note("New event 2")
-            .sign_with_keys(&keys)
+            .sign(&keys)
             .expect("Failed to sign event");
 
         // Execute mixed operations concurrently

--- a/database/nostr-lmdb/src/store/lmdb/mod.rs
+++ b/database/nostr-lmdb/src/store/lmdb/mod.rs
@@ -1419,7 +1419,7 @@ mod tests {
         let keys = Keys::generate();
         EventBuilder::new(Kind::from(kind), "test content")
             .custom_created_at(Timestamp::from_secs(created_at))
-            .sign_with_keys(&keys)
+            .sign(&keys)
             .unwrap()
     }
 

--- a/database/nostr-sqlite/src/store.rs
+++ b/database/nostr-sqlite/src/store.rs
@@ -898,7 +898,7 @@ mod tests {
             .tag(Tag::parse(["subject", "gamma-token"]).unwrap())
             .tag(Tag::parse(["name", "delta-token"]).unwrap())
             .tag(Tag::identifier("epsilon-token"))
-            .sign_with_keys(&keys)
+            .sign(&keys)
             .unwrap();
 
         assert!(db.save_event(&event).await.unwrap().is_success());

--- a/gossip/nostr-gossip-test-suite/src/lib.rs
+++ b/gossip/nostr-gossip-test-suite/src/lib.rs
@@ -101,7 +101,7 @@ macro_rules! gossip_unit_tests {
                         relay_hint: Some(relay_url.clone()),
                     },
                 ))
-                .sign_with_keys(&keys)
+                .sign(&keys)
                 .unwrap();
 
             store.process(&event, None).await.unwrap();
@@ -128,7 +128,7 @@ macro_rules! gossip_unit_tests {
             // Process multiple events from the same relay
             for i in 0..5 {
                 let event = EventBuilder::text_note(format!("Test {i}"))
-                    .sign_with_keys(&keys)
+                    .sign(&keys)
                     .unwrap();
 
                 store.process(&event, Some(&relay_url)).await.unwrap();

--- a/sdk/examples/client.rs
+++ b/sdk/examples/client.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<()> {
     let keys = Keys::parse("nsec1ufnus6pju578ste3v90xd5m2decpuzpql2295m3sknqcjzyys9ls0qlc85")?;
 
     // Publish a text note
-    let event = EventBuilder::text_note("Hello world").sign_with_keys(&keys)?;
+    let event = EventBuilder::text_note("Hello world").sign(&keys)?;
     let output = client.send_event(&event).await?;
     println!("Event ID: {}", output.id().to_bech32()?);
     println!("Sent to: {:?}", output.success);
@@ -32,7 +32,7 @@ async fn main() -> Result<()> {
     let unsigned = unsigned
         .mine_async(&SingleThreadPow, NonZeroU8::new(20).unwrap())
         .await?;
-    let event = unsigned.sign_with_keys(&keys)?;
+    let event = unsigned.sign(&keys)?;
     client.send_event(&event).await?;
 
     Ok(())

--- a/sdk/src/client/api/send_event.rs
+++ b/sdk/src/client/api/send_event.rs
@@ -470,7 +470,7 @@ mod tests {
 
         let keys = Keys::generate();
         let event = EventBuilder::text_note("Broadcast test")
-            .sign_with_keys(&keys)
+            .sign(&keys)
             .unwrap();
 
         // Send event (broadcast to all WRITE relays by default)
@@ -498,7 +498,7 @@ mod tests {
 
         let keys = Keys::generate();
         let event = EventBuilder::text_note("Targeted test")
-            .sign_with_keys(&keys)
+            .sign(&keys)
             .unwrap();
 
         // Send only to relay 1
@@ -539,7 +539,7 @@ mod tests {
 
         let keys = Keys::generate();
         let event = EventBuilder::text_note("Force to all test")
-            .sign_with_keys(&keys)
+            .sign(&keys)
             .unwrap();
 
         // Force send to all WRITE instead of using gossip
@@ -570,7 +570,7 @@ mod tests {
         // Setup User A keys and their Relay List (NIP-65) pointing to the Outbox Relay
         let keys_a = Keys::generate();
         let relay_list = EventBuilder::relay_list([(outbox_url.clone(), None)])
-            .sign_with_keys(&keys_a)
+            .sign(&keys_a)
             .unwrap();
         let res = discovery_mock.add_event(relay_list).await.unwrap();
         assert!(res.is_success());
@@ -619,7 +619,7 @@ mod tests {
         // - Automatically connect to 'outbox_url'
         // - Send the event to the outbox and public relay
         let event = EventBuilder::text_note("Gossip test")
-            .sign_with_keys(&keys_a)
+            .sign(&keys_a)
             .unwrap();
 
         // Send event using default config (must be sent to gossip)
@@ -652,7 +652,7 @@ mod tests {
 
         let keys = Keys::generate();
         let event = EventBuilder::text_note("Broadcast test")
-            .sign_with_keys(&keys)
+            .sign(&keys)
             .unwrap();
 
         // Send event
@@ -676,7 +676,7 @@ mod tests {
         // Setup Bob keys and NIP-17 list pointing to the Inbox Relay
         let bob_keys = Keys::generate();
         let relay_list = EventBuilder::nip17_relay_list([inbox_url.clone()])
-            .sign_with_keys(&bob_keys)
+            .sign(&bob_keys)
             .unwrap();
         let res = discovery_mock.add_event(relay_list).await.unwrap();
         assert!(res.is_success());
@@ -709,7 +709,7 @@ mod tests {
         // NOTE: this is not a NIP-17 event, as the nip59 feature is required, so we are sending a fake gift wrap tagging the recipient
         let event = EventBuilder::new(Kind::GiftWrap, "payload")
             .tag(Tag::public_key(bob_keys.public_key))
-            .sign_with_keys(&Keys::generate())
+            .sign(&Keys::generate())
             .unwrap();
         let output = client.send_event(&event).to_nip17().await.unwrap();
 
@@ -739,7 +739,7 @@ mod tests {
         let bob_keys = Keys::generate();
         let event = EventBuilder::new(Kind::GiftWrap, "payload")
             .tag(Tag::public_key(bob_keys.public_key))
-            .sign_with_keys(&Keys::generate())
+            .sign(&Keys::generate())
             .unwrap();
 
         // Send event

--- a/sdk/src/client/gossip/resolver.rs
+++ b/sdk/src/client/gossip/resolver.rs
@@ -337,9 +337,7 @@ mod tests {
         let list = relays
             .into_iter()
             .filter_map(|(url, m)| Some((RelayUrl::parse(url).ok()?, m)));
-        EventBuilder::relay_list(list)
-            .sign_with_keys(&keys)
-            .unwrap()
+        EventBuilder::relay_list(list).sign(&keys).unwrap()
     }
 
     async fn setup() -> GossipRelayResolver {

--- a/sdk/src/relay/api/fetch_events.rs
+++ b/sdk/src/relay/api/fetch_events.rs
@@ -117,9 +117,7 @@ mod tests {
 
         // Send some events
         for i in 0..num_events {
-            let event = EventBuilder::text_note(i.to_string())
-                .sign_with_keys(&keys)
-                .unwrap();
+            let event = EventBuilder::text_note(i.to_string()).sign(&keys).unwrap();
             relay.send_event(&event).await.unwrap();
         }
 
@@ -184,9 +182,7 @@ mod tests {
         let keys = Keys::generate();
 
         // Send an event
-        let event = EventBuilder::text_note("Test")
-            .sign_with_keys(&keys)
-            .unwrap();
+        let event = EventBuilder::text_note("Test").sign(&keys).unwrap();
         relay.send_event(&event).await.unwrap();
 
         let filter = Filter::new().kind(Kind::TextNote).limit(3);
@@ -227,9 +223,7 @@ mod tests {
         relay.connect();
 
         // Send an event
-        let event = EventBuilder::text_note("Test")
-            .sign_with_keys(&keys)
-            .unwrap();
+        let event = EventBuilder::text_note("Test").sign(&keys).unwrap();
         relay.send_event(&event).await.unwrap();
 
         let filter = Filter::new().kind(Kind::TextNote).limit(3);
@@ -286,7 +280,7 @@ mod tests {
 
             // Build and send event
             let event = EventBuilder::metadata(&Metadata::new().name("Test"))
-                .sign_with_keys(&keys)
+                .sign(&keys)
                 .unwrap();
             r.send_event(&event).await.unwrap();
         });
@@ -316,9 +310,7 @@ mod tests {
                 tokio::time::sleep(Duration::from_secs(2)).await;
 
                 // Build and send event
-                let event = EventBuilder::text_note("Additional")
-                    .sign_with_keys(&keys)
-                    .unwrap();
+                let event = EventBuilder::text_note("Additional").sign(&keys).unwrap();
                 r.send_event(&event).await.unwrap();
             }
         });
@@ -347,9 +339,7 @@ mod tests {
             // Send more events
             for _ in 0..2 {
                 // Build and send event
-                let event = EventBuilder::text_note("Additional")
-                    .sign_with_keys(&keys)
-                    .unwrap();
+                let event = EventBuilder::text_note("Additional").sign(&keys).unwrap();
                 r.send_event(&event).await.unwrap();
 
                 tokio::time::sleep(Duration::from_secs(2)).await;

--- a/sdk/src/relay/api/send_event.rs
+++ b/sdk/src/relay/api/send_event.rs
@@ -178,9 +178,7 @@ mod tests {
             .unwrap();
 
         let keys = Keys::generate();
-        let event = EventBuilder::text_note("Test")
-            .sign_with_keys(&keys)
-            .unwrap();
+        let event = EventBuilder::text_note("Test").sign(&keys).unwrap();
         relay.send_event(&event).await.unwrap();
     }
 
@@ -200,9 +198,7 @@ mod tests {
 
         // Signer and event
         let keys = Keys::generate();
-        let event = EventBuilder::text_note("Test")
-            .sign_with_keys(&keys)
-            .unwrap();
+        let event = EventBuilder::text_note("Test").sign(&keys).unwrap();
 
         // Auth disabled, so must fails as is unauthenticated
         match relay.send_event(&event).await.unwrap_err() {
@@ -234,9 +230,7 @@ mod tests {
 
         relay.connect();
 
-        let event = EventBuilder::text_note("Test")
-            .sign_with_keys(&keys)
-            .unwrap();
+        let event = EventBuilder::text_note("Test").sign(&keys).unwrap();
 
         // Send as authenticated
         assert!(relay.send_event(&event).await.is_ok());

--- a/sdk/src/relay/api/stream_events.rs
+++ b/sdk/src/relay/api/stream_events.rs
@@ -212,9 +212,7 @@ mod tests {
     #[tokio::test]
     async fn test_stream_with_subscription_verification_single_filter() {
         let keys = Keys::generate();
-        let event = EventBuilder::text_note("test")
-            .sign_with_keys(&keys)
-            .unwrap();
+        let event = EventBuilder::text_note("test").sign(&keys).unwrap();
 
         let mock = MockRelay::run().await.unwrap();
         let url = mock.url().await;
@@ -247,9 +245,7 @@ mod tests {
     #[tokio::test]
     async fn test_stream_with_subscription_verification_multiple_filters() {
         let keys = Keys::generate();
-        let event = EventBuilder::text_note("test")
-            .sign_with_keys(&keys)
-            .unwrap();
+        let event = EventBuilder::text_note("test").sign(&keys).unwrap();
 
         let mock = MockRelay::run().await.unwrap();
         let url = mock.url().await;

--- a/sdk/src/relay/api/subscribe.rs
+++ b/sdk/src/relay/api/subscribe.rs
@@ -218,7 +218,7 @@ mod tests {
 
         // Event
         let kind = Kind::Custom(22_222); // Ephemeral kind
-        let event: Event = EventBuilder::new(kind, "").sign_with_keys(&keys).unwrap();
+        let event: Event = EventBuilder::new(kind, "").sign(&keys).unwrap();
 
         let event_id: EventId = event.id;
 

--- a/sdk/src/relay/api/sync.rs
+++ b/sdk/src/relay/api/sync.rs
@@ -647,13 +647,13 @@ mod tests {
         // Build events to store in the local database
         let local_events = [
             EventBuilder::text_note("Local 1")
-                .sign_with_keys(&Keys::generate())
+                .sign(&Keys::generate())
                 .unwrap(),
             EventBuilder::text_note("Local 2")
-                .sign_with_keys(&Keys::generate())
+                .sign(&Keys::generate())
                 .unwrap(),
             EventBuilder::new(Kind::Custom(123), "Local 123")
-                .sign_with_keys(&Keys::generate())
+                .sign(&Keys::generate())
                 .unwrap(),
         ];
 
@@ -678,13 +678,13 @@ mod tests {
             // Event in common with the local database
             local_events[0].clone(),
             EventBuilder::text_note("Test 2")
-                .sign_with_keys(&Keys::generate())
+                .sign(&Keys::generate())
                 .unwrap(),
             EventBuilder::text_note("Test 3")
-                .sign_with_keys(&Keys::generate())
+                .sign(&Keys::generate())
                 .unwrap(),
             EventBuilder::new(Kind::Custom(123), "Test 4")
-                .sign_with_keys(&Keys::generate())
+                .sign(&Keys::generate())
                 .unwrap(),
         ];
 

--- a/sdk/src/relay/inner.rs
+++ b/sdk/src/relay/inner.rs
@@ -1796,9 +1796,7 @@ mod tests {
     #[tokio::test]
     async fn test_subscription_verification_accepts_event_matching_any_filter() {
         let keys = Keys::generate();
-        let event = EventBuilder::text_note("test")
-            .sign_with_keys(&keys)
-            .unwrap();
+        let event = EventBuilder::text_note("test").sign(&keys).unwrap();
 
         let filter = Filter::new().kind(Kind::TextNote).since(event.created_at);
         let matching_filter = filter.clone().author(event.pubkey);

--- a/sdk/src/relay/mod.rs
+++ b/sdk/src/relay/mod.rs
@@ -967,7 +967,7 @@ mod tests {
 
         // Test wake up when sending an event
         let event = EventBuilder::text_note("text wake-up")
-            .sign_with_keys(&Keys::generate())
+            .sign(&Keys::generate())
             .unwrap();
         relay.send_event(&event).await.unwrap();
         assert_eq!(relay.status(), RelayStatus::Connected);

--- a/signer/nostr-connect/src/client.rs
+++ b/signer/nostr-connect/src/client.rs
@@ -226,7 +226,7 @@ impl NostrConnect {
         let req_id = msg.id().to_string();
         let event: Event =
             EventBuilder::nostr_connect(&self.client_keys, remote_signer_public_key, msg)?
-                .sign_with_keys(&self.client_keys)?;
+                .sign(&self.client_keys)?;
 
         let mut notifications = self.client.notifications();
 

--- a/signer/nostr-connect/src/signer.rs
+++ b/signer/nostr-connect/src/signer.rs
@@ -114,7 +114,7 @@ impl NostrConnectRemoteSigner {
         let res = NostrConnectResponse::with_result(ResponseResult::ConnectSecret(secret));
         let msg: NostrConnectMessage = NostrConnectMessage::response("urmom", res);
         let event: Event = EventBuilder::nostr_connect(&self.keys.signer, public_key, msg)?
-            .sign_with_keys(&self.keys.signer)?;
+            .sign(&self.keys.signer)?;
         self.client.send_event(&event).await?;
         Ok(())
     }
@@ -292,7 +292,7 @@ impl NostrConnectRemoteSigner {
                                             }
                                         }
                                         NostrConnectRequest::SignEvent(unsigned) => {
-                                            match unsigned.sign_with_keys(&self.keys.user) {
+                                            match unsigned.sign(&self.keys.user) {
                                                 Ok(event) => NostrConnectResponse::with_result(
                                                     ResponseResult::SignEvent(Box::new(event)),
                                                 ),
@@ -319,7 +319,7 @@ impl NostrConnectRemoteSigner {
                                     event.pubkey,
                                     msg,
                                 )?
-                                .sign_with_keys(&self.keys.signer)?;
+                                .sign(&self.keys.signer)?;
                                 self.client.send_event(&event).await?;
                             }
                         }


### PR DESCRIPTION
### Description

First round of cleanups for the `nostr` library:

- Dropped support for private and anon zaps (NIP-57) as there isn't a defined spec for them; [current revision](https://github.com/nostr-protocol/nips/blob/abe6fb959c4517c30ac1476e113d8f64eab0a8ff/57.md) defines only public zaps.
- Cleanup sign methods for `EventBuilder` and `UnsignedEvent`.

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
