### PR TITLE
connect: `NostrConnectKeys::new` function

### DIFF
--- a/signer/nostr-connect/CHANGELOG.md
+++ b/signer/nostr-connect/CHANGELOG.md
@@ -38,6 +38,10 @@
 
 - Bump MSRV to 1.85.0 (https://github.com/rust-nostr/nostr/pull/1267)
 
+### Added
+
+- `NostrConnectKeys::new` function (https://github.com/rust-nostr/nostr/pull/1356)
+
 ### Fixed
 
 - Fix rejections of bunker signers that reply with secret in the connect response (https://github.com/rust-nostr/nostr/pull/1354)

--- a/signer/nostr-connect/examples/nostr-connect-signer.rs
+++ b/signer/nostr-connect/examples/nostr-connect-signer.rs
@@ -12,10 +12,10 @@ const USER_SECRET_KEY: &str = "nsec1ufnus6pju578ste3v90xd5m2decpuzpql2295m3sknqc
 async fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
 
-    let keys = NostrConnectKeys {
-        signer: Keys::parse(SIGNER_SECRET_KEY)?,
-        user: Keys::parse(USER_SECRET_KEY)?,
-    };
+    let keys = NostrConnectKeys::new(
+        Keys::parse(SIGNER_SECRET_KEY)?,
+        Keys::parse(USER_SECRET_KEY)?,
+    );
 
     // Compose signer
     let signer = NostrConnectRemoteSigner::new(keys, ["wss://relay.nsec.app"], None, None)?;

--- a/signer/nostr-connect/src/signer.rs
+++ b/signer/nostr-connect/src/signer.rs
@@ -17,10 +17,17 @@ use crate::error::Error;
 pub struct NostrConnectKeys {
     /// The keys used for communication with the client.
     ///
-    /// This may be the same as the `user` one.
+    /// This may be the same as the `user` one, but not necessarily.
     pub signer: Keys,
     /// The keys used to sign events and so on.
     pub user: Keys,
+}
+
+impl NostrConnectKeys {
+    /// Construct a new [`NostrConnectKeys`]
+    pub fn new(signer: Keys, user: Keys) -> Self {
+        Self { signer, user }
+    }
 }
 
 /// Nostr Connect Signer


### PR DESCRIPTION
### Description

Just `NostrConnectKeys::new` function. I also update the signer keys docs

> remote-signer-keypair/pubkey: The keys used by remote-signer to encrypt content and communicate with client. This keypair MAY be same as user-keypair, **but not necessarily.**

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
