### PR TITLE
connect: rename `urls` parameter to `relays` in `NostrConnectRemoteSigner::new`

### DIFF
--- a/signer/nostr-connect/src/signer.rs
+++ b/signer/nostr-connect/src/signer.rs
@@ -43,7 +43,7 @@ impl NostrConnectRemoteSigner {
     /// Construct new remote signer
     pub fn new<'a, I, U>(
         keys: NostrConnectKeys,
-        urls: I,
+        relays: I,
         secret: Option<String>,
         opts: Option<RelayOptions>,
     ) -> Result<Self, Error>
@@ -51,14 +51,14 @@ impl NostrConnectRemoteSigner {
         I: IntoIterator<Item = U>,
         U: Into<RelayUrlArg<'a>>,
     {
-        let mut relays = Vec::new();
-        for relay in urls.into_iter() {
-            relays.push(relay.into().try_into_relay_url()?.into_owned());
+        let mut _relays = Vec::new();
+        for relay in relays.into_iter() {
+            _relays.push(relay.into().try_into_relay_url()?.into_owned());
         }
 
         Ok(Self {
             keys,
-            relays,
+            relays: _relays,
             client: Client::default(),
             opts: opts.unwrap_or_default(),
             secret,


### PR DESCRIPTION
### Description

urls is not clear

### Notes to the reviewers

I don't think it needs a changelog

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [ ] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
