### PR TITLE
nostr: add event finalization traits and some NIP-specific builders

### DIFF
--- a/crates/nostr-relay-builder/src/local/inner.rs
+++ b/crates/nostr-relay-builder/src/local/inner.rs
@@ -941,7 +941,7 @@ impl InnerLocalRelay {
             let keys = Keys::generate();
 
             for _ in 0..500 {
-                events.insert(EventBuilder::text_note("Test").sign(&keys)?);
+                events.insert(EventBuilder::text_note("Test").finalize(&keys)?);
             }
 
             events

--- a/crates/nostr-relay-builder/tests/plugins.rs
+++ b/crates/nostr-relay-builder/tests/plugins.rs
@@ -2,7 +2,7 @@
 // Copyright (c) 2023-2025 Rust Nostr Developers
 // Distributed under the MIT software license
 
-use nostr::event::{EventBuilder, Tag};
+use nostr::event::{EventBuilder, FinalizeEvent, Tag};
 use nostr::filter::Filter;
 use nostr::key::Keys;
 use nostr::util::BoxedFuture;
@@ -49,7 +49,7 @@ async fn update_filter() {
     // Event with our target tag
     let event = EventBuilder::text_note(":)")
         .tag(Tag::hashtag(UPDATE_TAG))
-        .sign(&keys)
+        .finalize(&keys)
         .unwrap();
     client.send_event(&event).await.unwrap();
 
@@ -57,7 +57,7 @@ async fn update_filter() {
     // It would only appear if the filter had not been updated correctly.
     let event = EventBuilder::text_note(":)")
         .tag(Tag::hashtag("TEST"))
-        .sign(&keys)
+        .finalize(&keys)
         .unwrap();
     client.send_event(&event).await.unwrap();
 

--- a/crates/nostr/README.md
+++ b/crates/nostr/README.md
@@ -42,16 +42,16 @@ fn main() -> Result<()> {
         .lud16("pay@yukikishimoto.com")
         .custom_field("custom_field", "my value");
 
-    let event: Event = EventBuilder::metadata(&metadata).sign(&keys)?;
+    let event: Event = EventBuilder::metadata(&metadata).finalize(&keys)?;
 
     // New text note
-    let event: Event = EventBuilder::text_note("Hello from rust-nostr").sign(&keys)?;
+    let event: Event = EventBuilder::text_note("Hello from rust-nostr").finalize(&keys)?;
 
     // New POW text note
     let difficulty: NonZeroU8 = NonZeroU8::new(16).unwrap();
-    let unsigned: UnsignedEvent = EventBuilder::text_note("POW text note from rust-nostr").build(keys.public_key);
+    let unsigned: UnsignedEvent = EventBuilder::text_note("POW text note from rust-nostr").finalize_unsigned(keys.public_key);
     let unsigned: UnsignedEvent = unsigned.mine(&SingleThreadPow, difficulty)?;
-    let event: Event = unsigned.sign(&keys)?;
+    let event: Event = unsigned.finalize(&keys)?;
 
     // Convert client message to JSON
     let json = ClientMessage::event(event).as_json();

--- a/crates/nostr/examples/nip09.rs
+++ b/crates/nostr/examples/nip09.rs
@@ -14,7 +14,7 @@ fn main() -> Result<()> {
         .id(event_id)
         .reason("these posts were published by accident");
 
-    let event: Event = EventBuilder::delete(request).sign(&keys)?;
+    let event: Event = EventBuilder::delete(request).finalize(&keys)?;
     println!("{}", event.as_json());
 
     Ok(())

--- a/crates/nostr/examples/nip13.rs
+++ b/crates/nostr/examples/nip13.rs
@@ -13,7 +13,8 @@ fn main() -> Result<()> {
     let msg_content = "This is a Nostr message with embedded proof-of-work";
 
     // Build unsigned event
-    let unsigned: UnsignedEvent = EventBuilder::text_note(msg_content).build(keys.public_key);
+    let unsigned: UnsignedEvent =
+        EventBuilder::text_note(msg_content).finalize_unsigned(keys.public_key);
 
     #[cfg(not(feature = "pow-multi-thread"))]
     let adapter = SingleThreadPow;
@@ -24,7 +25,7 @@ fn main() -> Result<()> {
     let unsigned: UnsignedEvent = unsigned.mine(&adapter, difficulty)?;
 
     // Sign event
-    let event: Event = unsigned.sign(&keys)?;
+    let event: Event = unsigned.finalize(&keys)?;
 
     println!("{}", event.as_json());
 

--- a/crates/nostr/examples/nip15.rs
+++ b/crates/nostr/examples/nip15.rs
@@ -13,7 +13,7 @@ fn main() -> Result<()> {
         .description("this is a test stall")
         .shipping(vec![shipping.clone()]);
 
-    let stall_event = EventBuilder::stall_data(stall).sign(&keys)?;
+    let stall_event = EventBuilder::stall_data(stall).finalize(&keys)?;
     println!("{}", stall_event.as_json());
 
     let product = ProductData::new("1", "123", "my test product", "USD")
@@ -23,7 +23,7 @@ fn main() -> Result<()> {
         .images(vec!["https://example.com/image.png".into()])
         .categories(vec!["test".into()]);
 
-    let product_event = EventBuilder::product_data(product).sign(&keys)?;
+    let product_event = EventBuilder::product_data(product).finalize(&keys)?;
     println!("{}", product_event.as_json());
 
     Ok(())

--- a/crates/nostr/examples/nip57.rs
+++ b/crates/nostr/examples/nip57.rs
@@ -12,7 +12,7 @@ fn main() -> Result<()> {
     let relays = [RelayUrl::parse("wss://relay.damus.io")?];
     let data = ZapRequestData::new(public_key, relays).message("Zap!");
 
-    let public_zap: Event = EventBuilder::public_zap_request(data.clone()).sign(&keys)?;
+    let public_zap: Event = EventBuilder::public_zap_request(data.clone()).finalize(&keys)?;
     println!("Public zap request: {}", public_zap.as_json());
 
     Ok(())

--- a/crates/nostr/src/event/builder.rs
+++ b/crates/nostr/src/event/builder.rs
@@ -4,6 +4,7 @@
 
 //! Event builder
 
+use alloc::boxed::Box;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use core::fmt;
@@ -14,6 +15,7 @@ use serde_json::{Value, json};
 use crate::nips::nip58::Nip58Tag;
 use crate::nips::nip62::VanishTarget;
 use crate::prelude::*;
+use crate::util::BoxedFuture;
 
 /// Wrong kind error
 #[derive(Debug, PartialEq, Eq)]
@@ -53,9 +55,6 @@ pub enum Error {
     NIP44(nip44::Error),
     /// NIP58 error
     NIP58(nip58::Error),
-    /// NIP59 error
-    #[cfg(all(feature = "std", feature = "nip59"))]
-    NIP59(nip59::Error),
     /// Wrong kind
     WrongKind {
         /// The received wrong kind
@@ -82,8 +81,6 @@ impl fmt::Display for Error {
             #[cfg(all(feature = "std", feature = "nip44"))]
             Self::NIP44(e) => e.fmt(f),
             Self::NIP58(e) => e.fmt(f),
-            #[cfg(all(feature = "std", feature = "nip59"))]
-            Self::NIP59(e) => e.fmt(f),
             Self::WrongKind { received, expected } => {
                 write!(f, "Wrong kind: received={received}, expected={expected}")
             }
@@ -143,32 +140,103 @@ impl From<nip58::Error> for Error {
     }
 }
 
-#[cfg(all(feature = "std", feature = "nip59"))]
-impl From<nip59::Error> for Error {
-    fn from(e: nip59::Error) -> Self {
-        Self::NIP59(e)
+/// Template that can be converted into a generic [`EventBuilder`].
+pub trait EventBuilderTemplate: Sized {
+    /// Convert into the generic event builder.
+    fn build(self) -> EventBuilder;
+}
+
+impl<B> FinalizeUnsignedEvent for B
+where
+    B: EventBuilderTemplate,
+{
+    #[inline]
+    fn finalize_unsigned(self, public_key: PublicKey) -> UnsignedEvent {
+        let builder: EventBuilder = self.build();
+        builder.finalize_unsigned(public_key)
+    }
+}
+
+impl<B, S> FinalizeEvent<S> for B
+where
+    B: EventBuilderTemplate,
+    S: GetPublicKey + SignEvent + ?Sized,
+{
+    type Error = SignerError;
+
+    fn finalize(self, signer: &S) -> Result<Event, Self::Error> {
+        let builder: EventBuilder = self.build();
+        builder.finalize(signer)
+    }
+}
+
+/// Template that can asynchronously be converted into a generic [`EventBuilder`].
+pub trait EventBuilderTemplateAsync {
+    /// Convert this typed builder into the generic event builder.
+    fn build_async<'a>(self) -> BoxedFuture<'a, EventBuilder>
+    where
+        Self: 'a;
+}
+
+impl<B> EventBuilderTemplateAsync for B
+where
+    B: EventBuilderTemplate + Send,
+{
+    #[inline]
+    fn build_async<'a>(self) -> BoxedFuture<'a, EventBuilder>
+    where
+        Self: 'a,
+    {
+        Box::pin(async move { EventBuilderTemplate::build(self) })
+    }
+}
+
+impl<B> FinalizeUnsignedEventAsync for B
+where
+    B: EventBuilderTemplateAsync + Send,
+{
+    #[inline]
+    fn finalize_unsigned_async<'a>(self, public_key: PublicKey) -> BoxedFuture<'a, UnsignedEvent>
+    where
+        Self: 'a,
+    {
+        Box::pin(async move {
+            let builder: EventBuilder = self.build_async().await;
+            builder.finalize_unsigned_async(public_key).await
+        })
+    }
+}
+
+impl<B, S> FinalizeEventAsync<S> for B
+where
+    B: EventBuilderTemplateAsync + Send,
+    S: AsyncGetPublicKey + AsyncSignEvent + ?Sized,
+{
+    type Error = SignerError;
+
+    fn finalize_async<'a>(self, signer: &'a S) -> BoxedFuture<'a, Result<Event, Self::Error>>
+    where
+        Self: 'a,
+        S: 'a,
+    {
+        Box::pin(async move {
+            let builder: EventBuilder = self.build_async().await;
+            builder.finalize_async(signer).await
+        })
     }
 }
 
 /// Event builder
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct EventBuilder {
-    // Not expose the kind, tags and content.
-    // These if changed may break the previously constructed events
-    // (i.e., change the content of a NIP46 event or of a NIP59 seal).
-    kind: Kind,
-    tags: Tags,
-    content: String,
-    /// Custom timestamp
-    pub custom_created_at: Option<Timestamp>,
-    /// Allow self-tagging
-    ///
-    /// If enabled, the `p` tags that match the signing keypair will not be discarded.
-    pub allow_self_tagging: bool,
-    /// Deduplicate tags
-    ///
-    /// For more details check [`Tags::dedup`].
-    pub dedup_tags: bool,
+    /// Event kind.
+    pub kind: Kind,
+    /// Event tags.
+    pub tags: Tags,
+    /// Event content.
+    pub content: String,
+    /// Custom timestamp.
+    pub created_at: Option<Timestamp>,
 }
 
 impl EventBuilder {
@@ -182,9 +250,7 @@ impl EventBuilder {
             kind,
             tags: Tags::new(),
             content: content.into(),
-            custom_created_at: None,
-            allow_self_tagging: false,
-            dedup_tags: false,
+            created_at: None,
         }
     }
 
@@ -215,93 +281,11 @@ impl EventBuilder {
         self
     }
 
-    /// Set a custom `created_at` UNIX timestamp
+    /// Set a custom `created_at` UNIX timestamp.
     #[inline]
     pub fn custom_created_at(mut self, created_at: Timestamp) -> Self {
-        self.custom_created_at = Some(created_at);
+        self.created_at = Some(created_at);
         self
-    }
-
-    /// Allow self-tagging
-    ///
-    /// When this mode is enabled, any `p` tags referencing the author’s public key will not be discarded.
-    pub fn allow_self_tagging(mut self) -> Self {
-        self.allow_self_tagging = true;
-        self
-    }
-
-    /// Deduplicate tags
-    ///
-    /// For more details check [`Tags::dedup`].
-    pub fn dedup_tags(mut self) -> Self {
-        self.dedup_tags = true;
-        self
-    }
-
-    /// Build an unsigned event
-    ///
-    /// By default, this method removes any `p` tags that match the author's public key.
-    /// To allow self-tagging, call [`EventBuilder::allow_self_tagging`] first.
-    pub fn build(mut self, public_key: PublicKey) -> UnsignedEvent {
-        // If self-tagging isn't allowed, discard all `p` tags that match the event author.
-        if !self.allow_self_tagging {
-            let public_key_hex: String = public_key.to_hex();
-            self.tags.retain(|t| {
-                if t.kind() == "p" {
-                    if let Some(content) = t.content() {
-                        if content == public_key_hex {
-                            return false; // Remove `p` tag that match author
-                        }
-                    }
-                }
-
-                true // No `p` tag or author public key not match
-            });
-        }
-
-        // Deduplicate tags
-        if self.dedup_tags {
-            self.tags.dedup();
-        }
-
-        // Construct unsigned event
-        UnsignedEvent {
-            // Not compute event ID, as the user may want POW, so would be an unnecessary computation.
-            id: None,
-            pubkey: public_key,
-            created_at: self.custom_created_at.unwrap_or_else(Timestamp::now),
-            kind: self.kind,
-            tags: self.tags,
-            content: self.content,
-        }
-    }
-
-    /// Build, sign and return [`Event`]
-    ///
-    /// Shortcut for `builder.build(public_key).sign(signer)`.
-    ///
-    /// Check [`EventBuilder::build`] to learn more.
-    #[inline]
-    pub fn sign<T>(self, signer: &T) -> Result<Event, Error>
-    where
-        T: GetPublicKey + SignEvent,
-    {
-        let public_key: PublicKey = signer.get_public_key()?;
-        Ok(self.build(public_key).sign(signer)?)
-    }
-
-    /// Build, sign and return [`Event`]
-    ///
-    /// Shortcut for `builder.build(public_key).sign(signer)`.
-    ///
-    /// Check [`EventBuilder::build`] to learn more.
-    #[inline]
-    pub async fn sign_async<T>(self, signer: &T) -> Result<Event, Error>
-    where
-        T: AsyncGetPublicKey + AsyncSignEvent,
-    {
-        let public_key: PublicKey = signer.get_public_key_async().await?;
-        Ok(self.build(public_key).sign_async(signer).await?)
     }
 
     /// Profile metadata
@@ -469,24 +453,6 @@ impl EventBuilder {
         S: Into<String>,
     {
         Self::new(Kind::LongFormTextNote, content)
-    }
-
-    /// Contact/Follow list
-    ///
-    /// <https://github.com/nostr-protocol/nips/blob/master/02.md>
-    pub fn contact_list<I>(contacts: I) -> Self
-    where
-        I: IntoIterator<Item = Contact>,
-    {
-        let tags = contacts.into_iter().map(|contact| {
-            Nip02Tag::PublicKey {
-                public_key: contact.public_key,
-                relay_hint: contact.relay_url,
-                alias: contact.alias,
-            }
-            .to_tag()
-        });
-        Self::new(Kind::ContactList, "").tags(tags)
     }
 
     /// OpenTimestamps Attestations for Events
@@ -729,33 +695,6 @@ impl EventBuilder {
             Nip42Tag::Challenge(challenge.into()).into(),
             Nip42Tag::Relay(relay).into(),
         ])
-    }
-
-    /// Nostr Connect / Nostr Remote Signing
-    ///
-    /// <https://github.com/nostr-protocol/nips/blob/master/46.md>
-    #[inline]
-    #[cfg(all(
-        feature = "std",
-        feature = "os-rng",
-        feature = "nip44",
-        feature = "nip46"
-    ))]
-    pub fn nostr_connect(
-        sender_keys: &Keys,
-        receiver_pubkey: PublicKey,
-        msg: NostrConnectMessage,
-    ) -> Result<Self, Error> {
-        Ok(Self::new(
-            Kind::NostrConnect,
-            nip44::encrypt(
-                sender_keys.secret_key(),
-                &receiver_pubkey,
-                msg.as_json(),
-                nip44::Version::default(),
-            )?,
-        )
-        .tag(Tag::public_key(receiver_pubkey)))
     }
 
     /// Live Event
@@ -1164,118 +1103,6 @@ impl EventBuilder {
         Self::new(Kind::SetProduct, content).tags(tags)
     }
 
-    /// Seal
-    ///
-    /// <https://github.com/nostr-protocol/nips/blob/master/59.md>
-    #[inline]
-    #[cfg(all(feature = "std", feature = "os-rng", feature = "nip59"))]
-    pub fn seal<T>(
-        signer: &T,
-        receiver_pubkey: &PublicKey,
-        rumor: UnsignedEvent,
-    ) -> Result<Self, Error>
-    where
-        T: Nip44,
-    {
-        Ok(nip59::make_seal(signer, receiver_pubkey, rumor)?)
-    }
-
-    /// Seal
-    ///
-    /// <https://github.com/nostr-protocol/nips/blob/master/59.md>
-    #[inline]
-    #[cfg(all(feature = "std", feature = "os-rng", feature = "nip59"))]
-    pub async fn seal_async<T>(
-        signer: &T,
-        receiver_pubkey: &PublicKey,
-        rumor: UnsignedEvent,
-    ) -> Result<Self, Error>
-    where
-        T: AsyncNip44,
-    {
-        Ok(nip59::make_seal_async(signer, receiver_pubkey, rumor).await?)
-    }
-
-    /// Gift Wrap from seal
-    ///
-    /// <https://github.com/nostr-protocol/nips/blob/master/59.md>
-    #[cfg(all(feature = "std", feature = "os-rng", feature = "nip59"))]
-    pub fn gift_wrap_from_seal<I>(
-        receiver: &PublicKey,
-        seal: &Event,
-        extra_tags: I,
-    ) -> Result<Event, Error>
-    where
-        I: IntoIterator<Item = Tag>,
-    {
-        if seal.kind != Kind::Seal {
-            return Err(Error::WrongKind {
-                received: seal.kind,
-                expected: WrongKindError::Single(Kind::Seal),
-            });
-        }
-
-        let keys: Keys = Keys::generate();
-        let content: String = nip44::encrypt(
-            keys.secret_key(),
-            receiver,
-            seal.as_json(),
-            nip44::Version::default(),
-        )?;
-
-        // Collect extra tags
-        let mut tags: Vec<Tag> = extra_tags.into_iter().collect();
-
-        // Push received public key
-        tags.push(Tag::public_key(*receiver));
-
-        Self::new(Kind::GiftWrap, content)
-            .tags(tags)
-            .custom_created_at(Timestamp::tweaked(nip59::RANGE_RANDOM_TIMESTAMP_TWEAK))
-            .sign(&keys)
-    }
-
-    /// Gift Wrap
-    ///
-    /// <https://github.com/nostr-protocol/nips/blob/master/59.md>
-    #[inline]
-    #[cfg(all(feature = "std", feature = "os-rng", feature = "nip59"))]
-    pub fn gift_wrap<T, I>(
-        signer: &T,
-        receiver: &PublicKey,
-        rumor: UnsignedEvent,
-        extra_tags: I,
-    ) -> Result<Event, Error>
-    where
-        T: GetPublicKey + SignEvent + Nip44,
-        I: IntoIterator<Item = Tag>,
-    {
-        let seal: Event = Self::seal(signer, receiver, rumor)?.sign(signer)?;
-        Self::gift_wrap_from_seal(receiver, &seal, extra_tags)
-    }
-
-    /// Gift Wrap
-    ///
-    /// <https://github.com/nostr-protocol/nips/blob/master/59.md>
-    #[inline]
-    #[cfg(all(feature = "std", feature = "os-rng", feature = "nip59"))]
-    pub async fn gift_wrap_async<T, I>(
-        signer: &T,
-        receiver: &PublicKey,
-        rumor: UnsignedEvent,
-        extra_tags: I,
-    ) -> Result<Event, Error>
-    where
-        T: AsyncGetPublicKey + AsyncSignEvent + AsyncNip44,
-        I: IntoIterator<Item = Tag>,
-    {
-        let seal: Event = Self::seal_async(signer, receiver, rumor)
-            .await?
-            .sign_async(signer)
-            .await?;
-        Self::gift_wrap_from_seal(receiver, &seal, extra_tags)
-    }
-
     /// Private direct message relay list
     ///
     /// <https://github.com/nostr-protocol/nips/blob/master/17.md>
@@ -1284,71 +1111,6 @@ impl EventBuilder {
         I: IntoIterator<Item = RelayUrl>,
     {
         Self::new(Kind::InboxRelays, "").tags(urls.into_iter().map(Nip17Tag::Relay).map(Into::into))
-    }
-
-    /// Private Direct message rumor
-    ///
-    /// You probably are looking for [`EventBuilder::private_msg`] method.
-    ///
-    /// <div class="warning">
-    /// This constructor compose ONLY the rumor for the private direct message!
-    /// NOT USE THIS IF YOU DON'T KNOW WHAT YOU ARE DOING!
-    /// </div>
-    ///
-    /// <https://github.com/nostr-protocol/nips/blob/master/17.md>
-    #[inline]
-    #[cfg(feature = "nip59")]
-    pub fn private_msg_rumor<S>(receiver: PublicKey, message: S) -> Self
-    where
-        S: Into<String>,
-    {
-        Self::new(Kind::PrivateDirectMessage, message).tags([Tag::public_key(receiver)])
-    }
-
-    /// Private Direct message
-    ///
-    /// <https://github.com/nostr-protocol/nips/blob/master/17.md>
-    #[inline]
-    #[cfg(all(feature = "std", feature = "os-rng", feature = "nip59"))]
-    pub fn private_msg<T, S, I>(
-        signer: &T,
-        receiver: PublicKey,
-        message: S,
-        rumor_extra_tags: I,
-    ) -> Result<Event, Error>
-    where
-        T: GetPublicKey + SignEvent + Nip44,
-        S: Into<String>,
-        I: IntoIterator<Item = Tag>,
-    {
-        let public_key: PublicKey = signer.get_public_key()?;
-        let rumor: UnsignedEvent = Self::private_msg_rumor(receiver, message)
-            .tags(rumor_extra_tags)
-            .build(public_key);
-        Self::gift_wrap(signer, &receiver, rumor, [])
-    }
-
-    /// Private Direct message
-    ///
-    /// <https://github.com/nostr-protocol/nips/blob/master/17.md>
-    #[inline]
-    #[cfg(all(feature = "std", feature = "os-rng", feature = "nip59"))]
-    pub async fn private_msg_async<T, S, I>(
-        signer: &T,
-        receiver: PublicKey,
-        message: S,
-        rumor_extra_tags: I,
-    ) -> Result<Event, Error>
-    where
-        T: AsyncGetPublicKey + AsyncSignEvent + AsyncNip44,
-        S: Into<String>,
-        I: IntoIterator<Item = Tag>,
-    {
-        let public_key: PublicKey = signer.get_public_key_async().await?;
-        let rumor: UnsignedEvent = Self::private_msg_rumor(receiver, message)
-            .tags(rumor_extra_tags)
-            .build(public_key);
-        Self::gift_wrap_async(signer, &receiver, rumor, []).await
     }
 
     /// Mute list
@@ -1788,6 +1550,63 @@ fn has_nostr_event_uri(content: &str, event_id: &EventId) -> bool {
     false
 }
 
+impl FinalizeUnsignedEvent for EventBuilder {
+    #[inline]
+    fn finalize_unsigned(self, public_key: PublicKey) -> UnsignedEvent {
+        UnsignedEvent {
+            // Not compute event ID, as the user may want POW, so would be an unnecessary computation.
+            id: None,
+            pubkey: public_key,
+            created_at: self.created_at.unwrap_or_else(Timestamp::now),
+            kind: self.kind,
+            tags: self.tags,
+            content: self.content,
+        }
+    }
+}
+
+impl FinalizeUnsignedEventAsync for EventBuilder {
+    #[inline]
+    fn finalize_unsigned_async<'a>(self, public_key: PublicKey) -> BoxedFuture<'a, UnsignedEvent>
+    where
+        Self: 'a,
+    {
+        Box::pin(async move { self.finalize_unsigned(public_key) })
+    }
+}
+
+impl<S> FinalizeEvent<S> for EventBuilder
+where
+    S: GetPublicKey + SignEvent + ?Sized,
+{
+    type Error = SignerError;
+
+    fn finalize(self, signer: &S) -> Result<Event, Self::Error> {
+        let public_key: PublicKey = signer.get_public_key()?;
+        let unsigned: UnsignedEvent = self.finalize_unsigned(public_key);
+        signer.sign_event(unsigned)
+    }
+}
+
+impl<S> FinalizeEventAsync<S> for EventBuilder
+where
+    S: AsyncGetPublicKey + AsyncSignEvent + ?Sized,
+{
+    type Error = SignerError;
+
+    fn finalize_async<'a>(self, signer: &'a S) -> BoxedFuture<'a, Result<Event, Self::Error>>
+    where
+        Self: 'a,
+        S: 'a,
+    {
+        Box::pin(async move {
+            let public_key: PublicKey = signer.get_public_key_async().await?;
+            let unsigned: UnsignedEvent = self.finalize_unsigned(public_key);
+            signer.sign_event_async(unsigned).await
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #[cfg(all(feature = "std", feature = "os-rng"))]
@@ -1805,34 +1624,12 @@ mod tests {
                 .unwrap(),
         );
 
-        let event = EventBuilder::text_note("hello").sign(&keys).unwrap();
+        let event = EventBuilder::text_note("hello").finalize(&keys).unwrap();
 
         let serialized = event.as_json();
         let deserialized = Event::from_json(serialized).unwrap();
 
         assert_eq!(event, deserialized);
-    }
-
-    #[test]
-    #[cfg(all(feature = "std", feature = "os-rng"))]
-    fn test_self_tagging() {
-        let keys = Keys::parse("6b911fd37cdf5c81d4c0adb1ab7fa822ed253ab0ad9aa18d77257c88b29b718e")
-            .unwrap();
-
-        // Self-tagging
-        let event = EventBuilder::text_note("hello")
-            .tag(Tag::public_key(keys.public_key()))
-            .sign(&keys)
-            .unwrap();
-        assert!(event.tags.is_empty());
-
-        // Tag someone else
-        let other = Keys::generate();
-        let event = EventBuilder::text_note("hello 2")
-            .tag(Tag::public_key(other.public_key()))
-            .sign(&keys)
-            .unwrap();
-        assert_eq!(event.tags.len(), 1);
     }
 
     #[test]
@@ -1964,7 +1761,7 @@ mod tests {
         let event_builder: Event =
             EventBuilder::award_badge(&badge_definition_event, awarded_pubkeys)
                 .unwrap()
-                .sign(&keys)
+                .finalize(&keys)
                 .unwrap();
 
         assert_eq!(event_builder.kind, Kind::BadgeAward);
@@ -1990,12 +1787,12 @@ mod tests {
         ];
         let bravery_badge_event =
             EventBuilder::define_badge("bravery", None, None, None, None, Vec::new())
-                .sign(&badge_one_keys)
+                .finalize(&badge_one_keys)
                 .unwrap();
         let bravery_badge_award =
             EventBuilder::award_badge(&bravery_badge_event, awarded_pubkeys.clone())
                 .unwrap()
-                .sign(&badge_one_keys)
+                .finalize(&badge_one_keys)
                 .unwrap();
 
         // Badge 2
@@ -2004,12 +1801,12 @@ mod tests {
 
         let honor_badge_event =
             EventBuilder::define_badge("honor", None, None, None, None, Vec::new())
-                .sign(&badge_two_keys)
+                .finalize(&badge_two_keys)
                 .unwrap();
         let honor_badge_award =
             EventBuilder::award_badge(&honor_badge_event, awarded_pubkeys.clone())
                 .unwrap()
-                .sign(&badge_two_keys)
+                .finalize(&badge_two_keys)
                 .unwrap();
 
         let example_event_json = format!(
@@ -2036,7 +1833,7 @@ mod tests {
         let profile_badges =
             EventBuilder::profile_badges(badge_definitions, badge_awards, &pub_key)
                 .unwrap()
-                .sign(&keys)
+                .finalize(&keys)
                 .unwrap();
 
         assert_eq!(profile_badges.kind, Kind::ProfileBadges);
@@ -2054,7 +1851,7 @@ mod tests {
         // Build reply
         let reply_keys = Keys::generate();
         let reply = EventBuilder::text_note_reply("Test reply", &root_event, None, None)
-            .sign(&reply_keys)
+            .finalize(&reply_keys)
             .unwrap();
         assert_eq!(reply.tags.public_keys().count(), 1); // Root author
         assert_eq!(reply.tags.public_keys().next().unwrap(), root_event.pubkey);
@@ -2065,7 +1862,7 @@ mod tests {
         let other_keys = Keys::generate();
         let reply_of_reply =
             EventBuilder::text_note_reply("Test reply of reply", &reply, Some(&root_event), None)
-                .sign(&other_keys)
+                .finalize(&other_keys)
                 .unwrap();
         assert_eq!(reply_of_reply.tags.public_keys().count(), 2); // Reply + root author
 
@@ -2085,10 +1882,10 @@ mod tests {
     fn replaceable_repost() {
         let keys = Keys::generate();
         let replaceable = EventBuilder::mute_list(MuteList::default())
-            .sign(&keys)
+            .finalize(&keys)
             .unwrap();
         let repost = EventBuilder::repost(&replaceable, None)
-            .sign(&keys)
+            .finalize(&keys)
             .unwrap();
 
         assert_eq!(repost.kind, Kind::GenericRepost);
@@ -2110,9 +1907,11 @@ mod tests {
     #[cfg(all(feature = "std", feature = "os-rng"))]
     fn addressable_repost() {
         let keys = Keys::generate();
-        let addressable = EventBuilder::follow_set("lorem", []).sign(&keys).unwrap();
+        let addressable = EventBuilder::follow_set("lorem", [])
+            .finalize(&keys)
+            .unwrap();
         let repost = EventBuilder::repost(&addressable, None)
-            .sign(&keys)
+            .finalize(&keys)
             .unwrap();
 
         assert_eq!(repost.kind, Kind::GenericRepost);
@@ -2137,9 +1936,11 @@ mod tests {
         let note_keys = Keys::generate();
         let repost_keys = Keys::generate();
         let relay_url = RelayUrl::parse("wss://relay.example.com").unwrap();
-        let note = EventBuilder::text_note("hello").sign(&note_keys).unwrap();
+        let note = EventBuilder::text_note("hello")
+            .finalize(&note_keys)
+            .unwrap();
         let repost = EventBuilder::repost(&note, Some(relay_url.clone()))
-            .sign(&repost_keys)
+            .finalize(&repost_keys)
             .unwrap();
 
         assert_eq!(repost.kind, Kind::Repost);
@@ -2166,9 +1967,11 @@ mod tests {
         let keys = Keys::generate();
         let protected = EventBuilder::text_note("secret")
             .tag(Tag::protected())
-            .sign(&keys)
+            .finalize(&keys)
             .unwrap();
-        let repost = EventBuilder::repost(&protected, None).sign(&keys).unwrap();
+        let repost = EventBuilder::repost(&protected, None)
+            .finalize(&keys)
+            .unwrap();
 
         assert!(repost.content.is_empty());
     }
@@ -2185,7 +1988,7 @@ mod benches {
     pub fn builder_to_event(bh: &mut Bencher) {
         let keys = Keys::generate();
         bh.iter(|| {
-            black_box(EventBuilder::text_note("hello").sign(&keys)).unwrap();
+            black_box(EventBuilder::text_note("hello").finalize(&keys)).unwrap();
         });
     }
 }

--- a/crates/nostr/src/event/mod.rs
+++ b/crates/nostr/src/event/mod.rs
@@ -35,6 +35,7 @@ use crate::SECP256K1;
 use crate::nips::nip01::Coordinate;
 use crate::nips::nip19::{self, Nip19Event, ToBech32};
 use crate::nips::nip21::ToNostrUri;
+use crate::util::BoxedFuture;
 use crate::{JsonUtil, Metadata, PublicKey, Timestamp};
 
 const ID: &str = "id";
@@ -365,6 +366,33 @@ impl<'de> Deserialize<'de> for Event {
     }
 }
 
+/// Finalize a builder into a signed event.
+pub trait FinalizeEvent<S>: Sized
+where
+    S: ?Sized,
+{
+    /// Finalization error.
+    type Error: core::error::Error;
+
+    /// Build and sign the event.
+    fn finalize(self, signer: &S) -> Result<Event, Self::Error>;
+}
+
+/// Finalize a builder into a signed event with an asynchronous signer.
+pub trait FinalizeEventAsync<S>: Sized
+where
+    S: ?Sized,
+{
+    /// Finalization error.
+    type Error: core::error::Error;
+
+    /// Build and sign the event.
+    fn finalize_async<'a>(self, signer: &'a S) -> BoxedFuture<'a, Result<Event, Self::Error>>
+    where
+        Self: 'a,
+        S: 'a;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -383,7 +411,7 @@ mod tests {
     fn test_custom_kind() {
         let keys = Keys::generate();
         let e: Event = EventBuilder::new(Kind::Custom(123), "my content")
-            .sign(&keys)
+            .finalize(&keys)
             .unwrap();
 
         let serialized = e.as_json();
@@ -400,7 +428,7 @@ mod tests {
         let my_keys = Keys::generate();
         let event = EventBuilder::text_note("my content")
             .tags([Tag::expiration(Timestamp::from(1600000000))])
-            .sign(&my_keys)
+            .finalize(&my_keys)
             .unwrap();
 
         assert!(&event.is_expired());
@@ -415,7 +443,7 @@ mod tests {
         let my_keys = Keys::generate();
         let event = EventBuilder::text_note("my content")
             .tags([Tag::expiration(Timestamp::from(expiry_date))])
-            .sign(&my_keys)
+            .finalize(&my_keys)
             .unwrap();
 
         assert!(!&event.is_expired());
@@ -426,7 +454,7 @@ mod tests {
     fn test_event_without_expiration_tag() {
         let my_keys = Keys::generate();
         let event = EventBuilder::text_note("my content")
-            .sign(&my_keys)
+            .finalize(&my_keys)
             .unwrap();
         assert!(!&event.is_expired());
     }

--- a/crates/nostr/src/event/unsigned.rs
+++ b/crates/nostr/src/event/unsigned.rs
@@ -4,6 +4,7 @@
 
 //! Unsigned Event
 
+use alloc::boxed::Box;
 use alloc::string::String;
 use core::num::NonZeroU8;
 
@@ -11,10 +12,12 @@ use secp256k1::schnorr::Signature;
 use secp256k1::{Secp256k1, Verification};
 
 use super::error::Error;
+use super::{FinalizeEvent, FinalizeEventAsync};
 #[cfg(feature = "std")]
 use crate::SECP256K1;
 use crate::nips::nip13::{AsyncPowAdapter, PowAdapter};
-use crate::signer::{AsyncSignEvent, SignEvent};
+use crate::signer::{AsyncSignEvent, SignEvent, SignerError};
+use crate::util::BoxedFuture;
 use crate::{Event, EventId, JsonUtil, Kind, PublicKey, Tag, Tags, Timestamp};
 
 /// Unsigned event
@@ -121,24 +124,6 @@ impl UnsignedEvent {
         adapter.compute_async(self, difficulty).await
     }
 
-    /// Sign an unsigned event
-    #[inline]
-    pub fn sign<T>(self, signer: &T) -> Result<Event, Error>
-    where
-        T: SignEvent,
-    {
-        Ok(signer.sign_event(self)?)
-    }
-
-    /// Sign an unsigned event
-    #[inline]
-    pub async fn sign_async<T>(self, signer: &T) -> Result<Event, Error>
-    where
-        T: AsyncSignEvent,
-    {
-        Ok(signer.sign_event_async(self).await?)
-    }
-
     /// Add a signature to an unsigned event
     ///
     /// This method internally verifies the event ID and signature.
@@ -190,6 +175,34 @@ impl UnsignedEvent {
     }
 }
 
+impl<S> FinalizeEvent<S> for UnsignedEvent
+where
+    S: SignEvent + ?Sized,
+{
+    type Error = SignerError;
+
+    #[inline]
+    fn finalize(self, signer: &S) -> Result<Event, Self::Error> {
+        signer.sign_event(self)
+    }
+}
+
+impl<S> FinalizeEventAsync<S> for UnsignedEvent
+where
+    S: AsyncSignEvent + ?Sized,
+{
+    type Error = SignerError;
+
+    #[inline]
+    fn finalize_async<'a>(self, signer: &'a S) -> BoxedFuture<'a, Result<Event, Self::Error>>
+    where
+        Self: 'a,
+        S: 'a,
+    {
+        Box::pin(async move { signer.sign_event_async(self).await })
+    }
+}
+
 impl JsonUtil for UnsignedEvent {
     type Err = Error;
 }
@@ -205,6 +218,20 @@ impl From<Event> for UnsignedEvent {
             content: event.content,
         }
     }
+}
+
+/// Finalize a builder into an unsigned event.
+pub trait FinalizeUnsignedEvent: Sized {
+    /// Build the unsigned event with the supplied public key.
+    fn finalize_unsigned(self, public_key: PublicKey) -> UnsignedEvent;
+}
+
+/// Finalize a builder into an unsigned event asynchronously.
+pub trait FinalizeUnsignedEventAsync: Sized {
+    /// Build the unsigned event with the supplied public key.
+    fn finalize_unsigned_async<'a>(self, public_key: PublicKey) -> BoxedFuture<'a, UnsignedEvent>
+    where
+        Self: 'a;
 }
 
 #[cfg(test)]

--- a/crates/nostr/src/nips/nip02.rs
+++ b/crates/nostr/src/nips/nip02.rs
@@ -11,6 +11,8 @@ use alloc::vec::Vec;
 use core::fmt;
 
 use super::util::{take_and_parse_optional_relay_url, take_optional_string, take_public_key};
+use crate::event::Kind;
+use crate::event::builder::{EventBuilder, EventBuilderTemplate};
 use crate::event::tag::{Tag, TagCodec, TagCodecError, impl_tag_codec_conversions};
 use crate::key::{self, PublicKey};
 use crate::types::url::{self, RelayUrl};
@@ -175,9 +177,47 @@ where
     Ok((public_key, relay_hint, alias))
 }
 
+/// Contact list event builder
+///
+/// <https://github.com/nostr-protocol/nips/blob/master/02.md>
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub struct ContactListBuilder {
+    /// Contacts
+    pub contacts: Vec<Contact>,
+}
+
+impl ContactListBuilder {
+    /// Create a new contact list builder
+    #[inline]
+    pub fn new<I>(contacts: I) -> Self
+    where
+        I: IntoIterator<Item = Contact>,
+    {
+        Self {
+            contacts: contacts.into_iter().collect(),
+        }
+    }
+}
+
+impl EventBuilderTemplate for ContactListBuilder {
+    fn build(self) -> EventBuilder {
+        let tags = self.contacts.into_iter().map(|contact| {
+            Nip02Tag::PublicKey {
+                public_key: contact.public_key,
+                relay_hint: contact.relay_url,
+                alias: contact.alias,
+            }
+            .to_tag()
+        });
+        EventBuilder::new(Kind::ContactList, "").tags(tags)
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{Error, *};
+    use crate::prelude::*;
 
     #[test]
     fn test_standardized_p_tag() {
@@ -245,5 +285,37 @@ mod tests {
         let tag = vec!["p"];
         let err = Nip02Tag::parse(&tag).unwrap_err();
         assert_eq!(err, Error::Codec(TagCodecError::Missing("public key")));
+    }
+
+    #[test]
+    #[cfg(all(feature = "std", feature = "os-rng"))]
+    fn test_make_contact_list_event() {
+        let keys = Keys::generate();
+
+        let contact = Contact {
+            public_key: PublicKey::from_hex(
+                "0000000000000000000000000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
+            relay_url: None,
+            alias: None,
+        };
+
+        let event = ContactListBuilder::new([contact.clone()])
+            .finalize(&keys)
+            .unwrap();
+
+        assert_eq!(event.kind, Kind::ContactList);
+        assert_eq!(event.pubkey, keys.public_key());
+        assert_eq!(event.tags.len(), 1);
+        assert_eq!(
+            event.tags[0],
+            Nip02Tag::PublicKey {
+                public_key: contact.public_key,
+                relay_hint: contact.relay_url,
+                alias: contact.alias,
+            }
+            .to_tag()
+        );
     }
 }

--- a/crates/nostr/src/nips/nip09.rs
+++ b/crates/nostr/src/nips/nip09.rs
@@ -87,16 +87,14 @@ impl EventDeletionRequest {
             tags.push(Tag::coordinate(coordinate, None));
         }
 
-        EventBuilder::new(Kind::EventDeletion, self.reason.unwrap_or_default())
-            .tags(tags)
-            .dedup_tags()
+        EventBuilder::new(Kind::EventDeletion, self.reason.unwrap_or_default()).tags(tags)
     }
 }
 
 #[cfg(all(test, feature = "std", feature = "os-rng"))]
 mod tests {
     use super::*;
-    use crate::{Event, Keys, Tags};
+    use crate::prelude::*;
 
     #[test]
     fn test_event_deletion_request() {
@@ -116,7 +114,7 @@ mod tests {
             .coordinate(coordinate)
             .reason("these posts were published by accident");
 
-        let event: Event = request.to_event_builder().sign(&keys).unwrap();
+        let event: Event = request.to_event_builder().finalize(&keys).unwrap();
 
         assert_eq!(event.kind, Kind::EventDeletion);
         assert_eq!(event.content, "these posts were published by accident");
@@ -137,7 +135,7 @@ mod tests {
         // Event ID without reason
         let request = EventDeletionRequest::new().id(event_id);
 
-        let event: Event = request.to_event_builder().sign(&keys).unwrap();
+        let event: Event = request.to_event_builder().finalize(&keys).unwrap();
 
         assert_eq!(event.kind, Kind::EventDeletion);
         assert!(event.content.is_empty());

--- a/crates/nostr/src/nips/nip13/mod.rs
+++ b/crates/nostr/src/nips/nip13/mod.rs
@@ -207,10 +207,8 @@ pub mod tests {
 
     use hashes::sha256::Hash as Sha256Hash;
 
-    use super::*;
-    use crate::Tag;
-    #[cfg(feature = "std")]
-    use crate::{EventBuilder, PublicKey};
+    use super::{Error, *};
+    use crate::prelude::*;
 
     #[test]
     fn test_parse_nonce_tag() {
@@ -629,7 +627,7 @@ pub mod tests {
         let unsigned = EventBuilder::text_note(
             "Why must I find leading zero bits? Is there no beauty in the ones?",
         )
-        .build(PublicKey::from_slice(&[0; 32]).unwrap());
+        .finalize_unsigned(PublicKey::from_slice(&[0; 32]).unwrap());
 
         let unsigned = unsigned
             .mine(&TestAdapter, NonZeroU8::new(2).unwrap())
@@ -673,7 +671,7 @@ pub mod tests {
         let unsigned = EventBuilder::text_note(
             "Why must I find leading zero bits? Is there no beauty in the ones?",
         )
-        .build(PublicKey::from_slice(&[0; 32]).unwrap());
+        .finalize_unsigned(PublicKey::from_slice(&[0; 32]).unwrap());
 
         let unsigned = unsigned
             .mine_async(&AsyncTestAdapter, NonZeroU8::new(2).unwrap())

--- a/crates/nostr/src/nips/nip13/multi_thread.rs
+++ b/crates/nostr/src/nips/nip13/multi_thread.rs
@@ -133,13 +133,14 @@ pub mod tests {
 
     use super::*;
     use crate::event::EventBuilder;
+    use crate::event::unsigned::FinalizeUnsignedEvent;
     use crate::key::PublicKey;
     use crate::nips::nip13::get_leading_zero_bits;
 
     #[test]
     fn threaded_adapter() {
         let unsigned = EventBuilder::text_note("Wait, you guys are getting paid to find nonces? I'm just doing it for the leading zeros")
-            .build(PublicKey::from_slice(&[0; 32]).unwrap());
+            .finalize_unsigned(PublicKey::from_slice(&[0; 32]).unwrap());
 
         let unsigned = unsigned
             .mine(&MultiThreadPow, NonZeroU8::new(2).unwrap())
@@ -158,7 +159,7 @@ pub mod tests {
     fn multi_thread_mining_can_be_cancelled() {
         let cancel: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
         let unsigned = EventBuilder::text_note("multi thread cancellation test")
-            .build(PublicKey::from_slice(&[0; 32]).unwrap());
+            .finalize_unsigned(PublicKey::from_slice(&[0; 32]).unwrap());
 
         let worker_cancel: Arc<AtomicBool> = cancel.clone();
         let handle = thread::spawn(move || mine(unsigned, u8::MAX, worker_cancel));

--- a/crates/nostr/src/nips/nip13/single_thread.rs
+++ b/crates/nostr/src/nips/nip13/single_thread.rs
@@ -94,7 +94,7 @@ pub mod tests {
         let unsigned = EventBuilder::text_note(
             "Proof of Work: The only workout my CPU gets since I stopped gaming",
         )
-        .build(PublicKey::from_slice(&[0; 32]).unwrap());
+        .finalize_unsigned(PublicKey::from_slice(&[0; 32]).unwrap());
 
         // Mine the event
         let unsigned = unsigned
@@ -114,7 +114,7 @@ pub mod tests {
     fn single_thread_mining_can_be_cancelled() {
         let cancel: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
         let unsigned = EventBuilder::text_note("single thread cancellation test")
-            .build(PublicKey::from_slice(&[0; 32]).unwrap());
+            .finalize_unsigned(PublicKey::from_slice(&[0; 32]).unwrap());
 
         let worker_cancel: Arc<AtomicBool> = cancel.clone();
         let handle = thread::spawn(move || mine(unsigned, u8::MAX, Some(worker_cancel.as_ref())));

--- a/crates/nostr/src/nips/nip17.rs
+++ b/crates/nostr/src/nips/nip17.rs
@@ -6,15 +6,30 @@
 //!
 //! <https://github.com/nostr-protocol/nips/blob/master/17.md>
 
+#![allow(rustdoc::redundant_explicit_links)]
+
 use alloc::string::{String, ToString};
 use alloc::vec;
 use alloc::vec::Vec;
 use core::fmt;
 
+#[cfg(all(feature = "std", feature = "os-rng", feature = "nip59"))]
+use super::nip44::{AsyncNip44, Nip44};
+#[cfg(all(feature = "std", feature = "os-rng", feature = "nip59"))]
+use super::nip59::{self, GiftWrapBuilder};
+use super::util::take_relay_url;
+use crate::event::Event;
 use crate::event::tag::{Tag, TagCodec, TagCodecError, impl_tag_codec_conversions};
-use crate::nips::util::take_relay_url;
-use crate::types::url;
-use crate::{Event, RelayUrl};
+#[cfg(all(feature = "std", feature = "os-rng", feature = "nip59"))]
+use crate::event::unsigned::FinalizeUnsignedEvent;
+#[cfg(all(feature = "std", feature = "os-rng", feature = "nip59"))]
+use crate::event::{EventBuilder, FinalizeEvent, FinalizeEventAsync, Kind, UnsignedEvent};
+use crate::key::PublicKey;
+#[cfg(all(feature = "std", feature = "os-rng", feature = "nip59"))]
+use crate::signer::{AsyncGetPublicKey, AsyncSignEvent, GetPublicKey, SignEvent, SignerError};
+use crate::types::url::{self, RelayUrl};
+#[cfg(all(feature = "std", feature = "os-rng", feature = "nip59"))]
+use crate::util::BoxedFuture;
 
 const RELAY: &str = "relay";
 
@@ -25,6 +40,12 @@ pub enum Error {
     Url(url::Error),
     /// Codec error
     Codec(TagCodecError),
+    /// Signer error
+    #[cfg(all(feature = "std", feature = "os-rng", feature = "nip59"))]
+    Signer(SignerError),
+    /// NIP-59 error
+    #[cfg(all(feature = "std", feature = "os-rng", feature = "nip59"))]
+    NIP59(nip59::Error),
 }
 
 impl core::error::Error for Error {}
@@ -34,6 +55,10 @@ impl fmt::Display for Error {
         match self {
             Self::Url(e) => e.fmt(f),
             Self::Codec(e) => e.fmt(f),
+            #[cfg(all(feature = "std", feature = "os-rng", feature = "nip59"))]
+            Self::Signer(e) => e.fmt(f),
+            #[cfg(all(feature = "std", feature = "os-rng", feature = "nip59"))]
+            Self::NIP59(e) => e.fmt(f),
         }
     }
 }
@@ -48,6 +73,150 @@ impl From<TagCodecError> for Error {
     fn from(e: TagCodecError) -> Self {
         Self::Codec(e)
     }
+}
+
+#[cfg(all(feature = "std", feature = "os-rng", feature = "nip59"))]
+impl From<SignerError> for Error {
+    fn from(e: SignerError) -> Self {
+        Self::Signer(e)
+    }
+}
+
+#[cfg(all(feature = "std", feature = "os-rng", feature = "nip59"))]
+impl From<nip59::Error> for Error {
+    fn from(e: nip59::Error) -> Self {
+        Self::NIP59(e)
+    }
+}
+
+/// Private Direct Message event builder.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// # use nostr::prelude::*;
+/// # #[cfg(all(feature = "std", feature = "os-rng", feature = "nip59"))]
+/// # fn main() -> Result<(), Box<dyn core::error::Error>> {
+/// let receiver = PublicKey::from_hex("<receiver-public-key>")?;
+/// let signer = Keys::parse("<my-secret-key>")?;
+/// let private_msg: Event =
+///     PrivateDirectMessageBuilder::new(receiver, "Hello, world!").finalize(&signer)?;
+/// # Ok(())
+/// # }
+/// # #[cfg(not(all(feature = "std", feature = "os-rng", feature = "nip59")))]
+/// # fn main() {}
+/// ```
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub struct PrivateDirectMessageBuilder {
+    /// Receiver public key.
+    pub receiver: PublicKey,
+    /// Message.
+    pub message: String,
+    /// Extra tags to add to the **rumor** event.
+    pub rumor_extra_tags: Vec<Tag>,
+    /// Extra tags to add to the **gift wrap** event.
+    pub extra_tags: Vec<Tag>,
+}
+
+// TODO: should this be under the required features, like for the Finalize traits?
+impl PrivateDirectMessageBuilder {
+    /// Create a new private direct message event builder.
+    #[inline]
+    pub fn new<M>(receiver: PublicKey, message: M) -> Self
+    where
+        M: Into<String>,
+    {
+        Self {
+            receiver,
+            message: message.into(),
+            rumor_extra_tags: Vec::new(),
+            extra_tags: Vec::new(),
+        }
+    }
+
+    /// Extra tags to add to the **rumor** event.
+    #[inline]
+    pub fn rumor_extra_tags<T>(mut self, tags: T) -> Self
+    where
+        T: IntoIterator<Item = Tag>,
+    {
+        self.rumor_extra_tags.extend(tags);
+        self
+    }
+
+    /// Extra tags to add to the **gift wrap** event.
+    #[inline]
+    pub fn extra_tags<T>(mut self, tags: T) -> Self
+    where
+        T: IntoIterator<Item = Tag>,
+    {
+        self.extra_tags.extend(tags);
+        self
+    }
+}
+
+#[cfg(all(feature = "std", feature = "os-rng", feature = "nip59"))]
+impl<S> FinalizeEvent<S> for PrivateDirectMessageBuilder
+where
+    S: GetPublicKey + SignEvent + Nip44,
+{
+    type Error = Error;
+
+    fn finalize(self, signer: &S) -> Result<Event, Self::Error> {
+        let public_key: PublicKey = signer.get_public_key()?;
+        let rumor: UnsignedEvent = make_rumor(
+            public_key,
+            self.receiver,
+            self.message,
+            self.rumor_extra_tags,
+        );
+        Ok(GiftWrapBuilder::new(self.receiver, rumor)
+            .extra_tags(self.extra_tags)
+            .finalize(signer)?)
+    }
+}
+
+#[cfg(all(feature = "std", feature = "os-rng", feature = "nip59"))]
+impl<S> FinalizeEventAsync<S> for PrivateDirectMessageBuilder
+where
+    S: AsyncGetPublicKey + AsyncSignEvent + AsyncNip44,
+{
+    type Error = Error;
+
+    fn finalize_async<'a>(self, signer: &'a S) -> BoxedFuture<'a, Result<Event, Self::Error>>
+    where
+        Self: 'a,
+        S: 'a,
+    {
+        Box::pin(async move {
+            let public_key: PublicKey = signer.get_public_key_async().await?;
+            let rumor: UnsignedEvent = make_rumor(
+                public_key,
+                self.receiver,
+                self.message,
+                self.rumor_extra_tags,
+            );
+            Ok(GiftWrapBuilder::new(self.receiver, rumor)
+                .extra_tags(self.extra_tags)
+                .finalize_async(signer)
+                .await?)
+        })
+    }
+}
+
+#[inline]
+#[cfg(all(feature = "std", feature = "os-rng", feature = "nip59"))]
+fn make_rumor(
+    sender: PublicKey,
+    receiver: PublicKey,
+    message: String,
+    extra_tags: Vec<Tag>,
+) -> UnsignedEvent {
+    EventBuilder::new(Kind::PrivateDirectMessage, message)
+        .tag(Tag::public_key(receiver))
+        .tags(extra_tags)
+        .finalize_unsigned(sender)
 }
 
 /// Standardized NIP-17 tags

--- a/crates/nostr/src/nips/nip34.rs
+++ b/crates/nostr/src/nips/nip34.rs
@@ -927,6 +927,7 @@ mod tests {
     use core::str::FromStr;
 
     use super::*;
+    use crate::event::FinalizeEvent;
     use crate::{Event, Keys, Tags};
 
     #[test]
@@ -949,7 +950,7 @@ mod tests {
         };
 
         let keys = Keys::generate();
-        let event: Event = repo.to_event_builder().unwrap().sign(&keys).unwrap();
+        let event: Event = repo.to_event_builder().unwrap().finalize(&keys).unwrap();
 
         assert_eq!(event.kind, Kind::GitRepoAnnouncement);
         assert!(event.content.is_empty());
@@ -1009,7 +1010,7 @@ mod tests {
         };
 
         let keys = Keys::generate();
-        let event: Event = repo.to_event_builder().unwrap().sign(&keys).unwrap();
+        let event: Event = repo.to_event_builder().unwrap().finalize(&keys).unwrap();
 
         assert_eq!(event.kind, Kind::GitIssue);
         assert_eq!(event.content, "My issue content");
@@ -1057,7 +1058,7 @@ mod tests {
         };
 
         let keys = Keys::generate();
-        let event: Event = repo.to_event_builder().unwrap().sign(&keys).unwrap();
+        let event: Event = repo.to_event_builder().unwrap().finalize(&keys).unwrap();
 
         assert_eq!(event.kind, Kind::GitPatch);
         assert_eq!(event.content, "<patch>");
@@ -1114,7 +1115,7 @@ mod tests {
         };
 
         let keys = Keys::generate();
-        let event: Event = update.to_event_builder().unwrap().sign(&keys).unwrap();
+        let event: Event = update.to_event_builder().unwrap().finalize(&keys).unwrap();
 
         assert_eq!(event.kind, Kind::GitPullRequestUpdate);
         assert!(event.content.is_empty());

--- a/crates/nostr/src/nips/nip42.rs
+++ b/crates/nostr/src/nips/nip42.rs
@@ -135,6 +135,7 @@ pub fn is_valid_auth_event(event: &Event, relay_url: &RelayUrl, challenge: &str)
 #[cfg(all(test, feature = "std", feature = "os-rng"))]
 mod tests {
     use super::*;
+    use crate::event::FinalizeEvent;
     use crate::{EventBuilder, Keys};
 
     #[test]
@@ -167,7 +168,7 @@ mod tests {
         let challenge = "1234567890";
 
         let event = EventBuilder::auth(challenge, relay_url.clone())
-            .sign(&keys)
+            .finalize(&keys)
             .unwrap();
 
         assert!(is_valid_auth_event(&event, &relay_url, challenge));
@@ -181,18 +182,18 @@ mod tests {
 
         // Wrong challenge
         let event = EventBuilder::auth("abcd", relay_url.clone())
-            .sign(&keys)
+            .finalize(&keys)
             .unwrap();
         assert!(!is_valid_auth_event(&event, &relay_url, challenge));
 
         // Wrong relay url
         let event = EventBuilder::auth(challenge, RelayUrl::parse("wss://example.com").unwrap())
-            .sign(&keys)
+            .finalize(&keys)
             .unwrap();
         assert!(!is_valid_auth_event(&event, &relay_url, challenge));
 
         // Wrong kind
-        let event = EventBuilder::text_note("abcd").sign(&keys).unwrap();
+        let event = EventBuilder::text_note("abcd").finalize(&keys).unwrap();
         assert!(!is_valid_auth_event(&event, &relay_url, challenge));
     }
 }

--- a/crates/nostr/src/nips/nip44/traits.rs
+++ b/crates/nostr/src/nips/nip44/traits.rs
@@ -9,6 +9,7 @@ use core::fmt::Debug;
 use crate::key::PublicKey;
 use crate::util::BoxedFuture;
 
+// TODO: add a trait/method for encrypting using a specific version?
 /// Synchronous NIP-44
 pub trait Nip44: Any + Debug + Send + Sync {
     /// NIP-44 error

--- a/crates/nostr/src/nips/nip46.rs
+++ b/crates/nostr/src/nips/nip46.rs
@@ -22,10 +22,14 @@ use rand::rngs::OsRng;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::event::unsigned::UnsignedEvent;
+use crate::event::{FinalizeEvent, FinalizeEventAsync};
+use crate::prelude::{AsyncNip44, Nip44};
+use crate::signer::{AsyncGetPublicKey, AsyncSignEvent, GetPublicKey, SignEvent, SignerError};
 use crate::types::url::{self, ParseError, RelayUrl, Url};
 #[cfg(all(feature = "std", feature = "os-rng"))]
 use crate::util;
-use crate::{Event, JsonUtil, PublicKey, event, key};
+use crate::util::BoxedFuture;
+use crate::{Event, EventBuilder, JsonUtil, Kind, PublicKey, Tag, event, key};
 
 /// NIP46 URI Scheme
 pub const NOSTR_CONNECT_URI_SCHEME: &str = "nostrconnect";
@@ -35,6 +39,8 @@ pub const NOSTR_CONNECT_BUNKER_URI_SCHEME: &str = "bunker";
 /// NIP46 error
 #[derive(Debug, PartialEq)]
 pub enum Error {
+    /// Signer error
+    Signer(SignerError),
     /// Key error
     Key(key::Error),
     /// JSON error
@@ -71,6 +77,7 @@ impl core::error::Error for Error {}
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::Signer(e) => e.fmt(f),
             Self::Key(e) => e.fmt(f),
             Self::Json(e) => e.fmt(f),
             Self::RelayUrl(e) => e.fmt(f),
@@ -90,6 +97,12 @@ impl fmt::Display for Error {
                 "Unexpected response: method={method}, expected={expected}, received={received}"
             ),
         }
+    }
+}
+
+impl From<SignerError> for Error {
+    fn from(e: SignerError) -> Self {
+        Self::Signer(e)
     }
 }
 
@@ -1006,6 +1019,68 @@ impl NostrConnectUri {
             Self::Client { secret, .. } => Some(secret.as_str()),
         }
     }
+}
+
+/// Nostr Connect event builder
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub struct NostrConnectEventBuilder {
+    /// Receiver public key
+    pub receiver: PublicKey,
+    /// The Nostr Connect message
+    pub message: NostrConnectMessage,
+}
+
+impl NostrConnectEventBuilder {
+    /// Create a new Nostr Connect event builder
+    #[inline]
+    pub fn new(receiver: PublicKey, message: NostrConnectMessage) -> Self {
+        Self { receiver, message }
+    }
+}
+
+impl<S> FinalizeEvent<S> for NostrConnectEventBuilder
+where
+    S: GetPublicKey + SignEvent + Nip44,
+{
+    type Error = Error;
+
+    fn finalize(self, signer: &S) -> Result<Event, Self::Error> {
+        let json: String = self.message.as_json();
+        let content: String = signer
+            .nip44_encrypt(&self.receiver, &json)
+            .map_err(SignerError::backend)?;
+        Ok(make_event_builder(content, self.receiver).finalize(signer)?)
+    }
+}
+
+impl<S> FinalizeEventAsync<S> for NostrConnectEventBuilder
+where
+    S: AsyncGetPublicKey + AsyncSignEvent + AsyncNip44,
+{
+    type Error = Error;
+
+    fn finalize_async<'a>(self, signer: &'a S) -> BoxedFuture<'a, Result<Event, Self::Error>>
+    where
+        Self: 'a,
+        S: 'a,
+    {
+        Box::pin(async move {
+            let json: String = self.message.as_json();
+            let content: String = signer
+                .nip44_encrypt_async(&self.receiver, &json)
+                .await
+                .map_err(SignerError::backend)?;
+            Ok(make_event_builder(content, self.receiver)
+                .finalize_async(signer)
+                .await?)
+        })
+    }
+}
+
+#[inline]
+fn make_event_builder(nip44_encrypted_content: String, receiver: PublicKey) -> EventBuilder {
+    EventBuilder::new(Kind::NostrConnect, nip44_encrypted_content).tag(Tag::public_key(receiver))
 }
 
 impl FromStr for NostrConnectUri {

--- a/crates/nostr/src/nips/nip47.rs
+++ b/crates/nostr/src/nips/nip47.rs
@@ -20,8 +20,10 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
 
 use super::nip04;
-#[cfg(feature = "std")]
-use crate::event;
+#[cfg(all(feature = "std", feature = "os-rng"))]
+use crate::event::FinalizeEvent;
+#[cfg(all(feature = "std", feature = "os-rng"))]
+use crate::signer::SignerError;
 use crate::types::url::form_urlencoded::byte_serialize;
 use crate::types::url::{RelayUrl, Url};
 use crate::{Event, JsonUtil, PublicKey, SecretKey, Timestamp};
@@ -35,9 +37,9 @@ pub enum Error {
     Json(serde_json::Error),
     /// NIP04 error
     NIP04(nip04::Error),
-    /// Event Builder error
-    #[cfg(feature = "std")]
-    EventBuilder(event::builder::Error),
+    /// Signer error
+    #[cfg(all(feature = "std", feature = "os-rng"))]
+    Signer(SignerError),
     /// Error code
     ErrorCode(NIP47Error),
     /// Can't deserialize NIP-47 response
@@ -62,8 +64,8 @@ impl fmt::Display for Error {
         match self {
             Self::Json(e) => e.fmt(f),
             Self::NIP04(e) => e.fmt(f),
-            #[cfg(feature = "std")]
-            Self::EventBuilder(e) => e.fmt(f),
+            #[cfg(all(feature = "std", feature = "os-rng"))]
+            Self::Signer(e) => e.fmt(f),
             Self::ErrorCode(e) => e.fmt(f),
             Self::CantDeserializeResponse { response, error } => write!(
                 f,
@@ -88,10 +90,10 @@ impl From<nip04::Error> for Error {
     }
 }
 
-#[cfg(feature = "std")]
-impl From<event::builder::Error> for Error {
-    fn from(e: event::builder::Error) -> Self {
-        Self::EventBuilder(e)
+#[cfg(all(feature = "std", feature = "os-rng"))]
+impl From<SignerError> for Error {
+    fn from(e: SignerError) -> Self {
+        Self::Signer(e)
     }
 }
 
@@ -626,7 +628,7 @@ impl Request {
         let keys: Keys = Keys::new(uri.secret.clone());
         Ok(EventBuilder::new(Kind::WalletConnectRequest, encrypted)
             .tag(Tag::public_key(uri.public_key))
-            .sign(&keys)?)
+            .finalize(&keys)?)
     }
 }
 

--- a/crates/nostr/src/nips/nip59.rs
+++ b/crates/nostr/src/nips/nip59.rs
@@ -6,8 +6,12 @@
 //!
 //! <https://github.com/nostr-protocol/nips/blob/master/59.md>
 
+#[cfg(all(feature = "std", feature = "os-rng"))]
+use alloc::boxed::Box;
 use alloc::string::{String, ToString};
+use alloc::vec::Vec;
 use core::fmt;
+#[cfg(all(feature = "std", feature = "os-rng"))]
 use core::ops::Range;
 
 use secp256k1::{Secp256k1, Verification};
@@ -16,17 +20,30 @@ use secp256k1::{Secp256k1, Verification};
 use crate::SECP256K1;
 use crate::event::unsigned::UnsignedEvent;
 use crate::event::{self, Event};
+#[cfg(all(feature = "std", feature = "os-rng"))]
+use crate::event::{FinalizeEvent, FinalizeEventAsync};
+#[cfg(all(feature = "std", feature = "os-rng"))]
+use crate::key::Keys;
+#[cfg(all(feature = "std", feature = "os-rng"))]
+use crate::nips::nip44;
 use crate::nips::nip44::{AsyncNip44, Nip44};
 #[cfg(all(feature = "std", feature = "os-rng"))]
+use crate::signer::{AsyncGetPublicKey, AsyncSignEvent, GetPublicKey, SignEvent, SignerError};
+#[cfg(all(feature = "std", feature = "os-rng"))]
+use crate::util::BoxedFuture;
+#[cfg(all(feature = "std", feature = "os-rng"))]
 use crate::{EventBuilder, Timestamp};
-use crate::{JsonUtil, Kind, PublicKey};
+use crate::{JsonUtil, Kind, PublicKey, Tag};
 
-/// Range for random timestamp tweak (up to 2 days)
-pub const RANGE_RANDOM_TIMESTAMP_TWEAK: Range<u64> = 0..172800; // From 0 secs to 2 days
+#[cfg(all(feature = "std", feature = "os-rng"))]
+const RANGE_RANDOM_TIMESTAMP_TWEAK: Range<u64> = 0..172800; // From 0 secs to 2 days
 
 /// NIP59 error
 #[derive(Debug, PartialEq)]
 pub enum Error {
+    /// Signer error
+    #[cfg(all(feature = "std", feature = "os-rng"))]
+    Signer(SignerError),
     /// Event error
     Event(event::Error),
     /// NIP-44 error
@@ -42,11 +59,20 @@ impl core::error::Error for Error {}
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            #[cfg(all(feature = "std", feature = "os-rng"))]
+            Self::Signer(e) => e.fmt(f),
             Self::Event(e) => e.fmt(f),
             Self::NIP44(e) => e.fmt(f),
             Self::NotGiftWrap => f.write_str("Not a Gift Wrap"),
             Self::SenderMismatch => f.write_str("sender public key mismatch"),
         }
+    }
+}
+
+#[cfg(all(feature = "std", feature = "os-rng"))]
+impl From<SignerError> for Error {
+    fn from(e: SignerError) -> Self {
+        Self::Signer(e)
     }
 }
 
@@ -155,6 +181,194 @@ impl UnwrappedGift {
     }
 }
 
+/// Gift wrap seal event builder.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// # use nostr::prelude::*;
+/// # #[cfg(all(feature = "std", feature = "os-rng"))]
+/// # fn main() -> Result<(), Box<dyn core::error::Error>> {
+/// let receiver = PublicKey::from_hex("<receiver-public-key>")?;
+/// let rumor = UnsignedEvent::from_json("<rumor-json>")?;
+/// let signer = Keys::parse("<my-secret-key>")?;
+/// let seal: Event = GiftWrapSealBuilder::new(rumor, receiver).finalize(&signer)?;
+/// # Ok(())
+/// # }
+/// # #[cfg(not(all(feature = "std", feature = "os-rng")))]
+/// # fn main() {}
+/// ```
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub struct GiftWrapSealBuilder {
+    /// The rumor
+    pub rumor: UnsignedEvent,
+    /// The public key of the receiver
+    pub receiver: PublicKey,
+}
+
+impl GiftWrapSealBuilder {
+    /// Create a new gift wrap builder.
+    #[inline]
+    pub fn new(rumor: UnsignedEvent, receiver: PublicKey) -> Self {
+        Self { rumor, receiver }
+    }
+}
+
+#[cfg(all(feature = "std", feature = "os-rng"))]
+impl<S> FinalizeEvent<S> for GiftWrapSealBuilder
+where
+    S: GetPublicKey + SignEvent + Nip44,
+{
+    type Error = Error;
+
+    fn finalize(self, signer: &S) -> Result<Event, Self::Error> {
+        // Encrypt content
+        let content: String = signer
+            .nip44_encrypt(&self.receiver, &self.rumor.as_json())
+            .map_err(|e| Error::NIP44(e.to_string()))?;
+
+        let seal: EventBuilder = build_seal(self.rumor, content);
+        Ok(seal.finalize(signer)?)
+    }
+}
+
+#[cfg(all(feature = "std", feature = "os-rng"))]
+impl<S> FinalizeEventAsync<S> for GiftWrapSealBuilder
+where
+    S: AsyncGetPublicKey + AsyncSignEvent + AsyncNip44,
+{
+    type Error = Error;
+
+    fn finalize_async<'a>(self, signer: &'a S) -> BoxedFuture<'a, Result<Event, Self::Error>>
+    where
+        Self: 'a,
+        S: 'a,
+    {
+        Box::pin(async move {
+            // Encrypt content
+            let content: String = signer
+                .nip44_encrypt_async(&self.receiver, &self.rumor.as_json())
+                .await
+                .map_err(|e| Error::NIP44(e.to_string()))?;
+
+            let seal: EventBuilder = build_seal(self.rumor, content);
+            Ok(seal.finalize_async(signer).await?)
+        })
+    }
+}
+
+/// Gift wrap event builder.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// # use nostr::prelude::*;
+/// # #[cfg(all(feature = "std", feature = "os-rng"))]
+/// # fn main() -> Result<(), Box<dyn core::error::Error>> {
+/// let receiver = PublicKey::from_hex("<receiver-public-key>")?;
+/// let rumor = UnsignedEvent::from_json("<rumor-json>")?;
+/// let signer = Keys::parse("<my-secret-key>")?;
+/// let gift_wrap: Event = GiftWrapBuilder::new(receiver, rumor).finalize(&signer)?;
+/// # Ok(())
+/// # }
+/// # #[cfg(not(all(feature = "std", feature = "os-rng")))]
+/// # fn main() {}
+/// ```
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub struct GiftWrapBuilder {
+    /// The public key of the receiver
+    pub receiver: PublicKey,
+    /// The rumor
+    pub rumor: UnsignedEvent,
+    /// Extra tags to add to the event
+    pub extra_tags: Vec<Tag>,
+}
+
+impl GiftWrapBuilder {
+    /// Create a new gift wrap builder.
+    #[inline]
+    pub fn new(receiver: PublicKey, rumor: UnsignedEvent) -> Self {
+        Self {
+            receiver,
+            rumor,
+            extra_tags: Vec::new(),
+        }
+    }
+
+    /// Add extra tags.
+    #[inline]
+    pub fn extra_tags<T>(mut self, tags: T) -> Self
+    where
+        T: IntoIterator<Item = Tag>,
+    {
+        self.extra_tags.extend(tags);
+        self
+    }
+}
+
+#[cfg(all(feature = "std", feature = "os-rng"))]
+impl<S> FinalizeEvent<S> for GiftWrapBuilder
+where
+    S: GetPublicKey + SignEvent + Nip44,
+{
+    type Error = Error;
+
+    fn finalize(self, signer: &S) -> Result<Event, Self::Error> {
+        let seal: Event = GiftWrapSealBuilder::new(self.rumor, self.receiver).finalize(signer)?;
+        make_gift_wrap(seal, self.receiver, self.extra_tags)
+    }
+}
+
+#[cfg(all(feature = "std", feature = "os-rng"))]
+impl<S> FinalizeEventAsync<S> for GiftWrapBuilder
+where
+    S: AsyncGetPublicKey + AsyncSignEvent + AsyncNip44,
+{
+    type Error = Error;
+
+    fn finalize_async<'a>(self, signer: &'a S) -> BoxedFuture<'a, Result<Event, Self::Error>>
+    where
+        Self: 'a,
+        S: 'a,
+    {
+        Box::pin(async move {
+            let seal: Event = GiftWrapSealBuilder::new(self.rumor, self.receiver)
+                .finalize_async(signer)
+                .await?;
+            make_gift_wrap(seal, self.receiver, self.extra_tags)
+        })
+    }
+}
+
+#[cfg(all(feature = "std", feature = "os-rng"))]
+fn make_gift_wrap(seal: Event, receiver: PublicKey, extra_tags: Vec<Tag>) -> Result<Event, Error> {
+    // Generate the random keys
+    let keys: Keys = Keys::generate();
+
+    // Encrypt content
+    let content: String = nip44::encrypt(
+        keys.secret_key(),
+        &receiver,
+        seal.as_json(),
+        nip44::Version::default(),
+    )
+    .map_err(|e| Error::NIP44(e.to_string()))?;
+
+    // Collect extra tags
+    let mut tags: Vec<Tag> = extra_tags;
+
+    // Push received public key
+    tags.push(Tag::public_key(receiver));
+
+    // Build the event with a tweaked timestamp
+    Ok(EventBuilder::new(Kind::GiftWrap, content)
+        .tags(tags)
+        .custom_created_at(Timestamp::tweaked(RANGE_RANDOM_TIMESTAMP_TWEAK))
+        .finalize(&keys)?)
+}
+
 fn parse_and_verify_seal<C>(secp: &Secp256k1<C>, seal: String) -> Result<Event, Error>
 where
     C: Verification,
@@ -198,49 +412,6 @@ where
     UnwrappedGift::from_gift_wrap_async(signer, gift_wrap).await
 }
 
-/// Make a seal
-///
-/// The `rumor` can be an [`EventBuilder`] or an [`UnsignedEvent`].
-#[cfg(all(feature = "std", feature = "os-rng"))]
-pub fn make_seal<T>(
-    signer: &T,
-    receiver_pubkey: &PublicKey,
-    // TODO: allow to pass a reference
-    rumor: UnsignedEvent, // Don't take the `EventBuilder`, read note below.
-) -> Result<EventBuilder, Error>
-where
-    T: Nip44,
-{
-    // Encrypt content
-    let content: String = signer
-        .nip44_encrypt(receiver_pubkey, &rumor.as_json())
-        .map_err(|e| Error::NIP44(e.to_string()))?;
-
-    Ok(build_seal(rumor, content))
-}
-
-/// Make a seal
-///
-/// The `rumor` can be an [`EventBuilder`] or an [`UnsignedEvent`].
-#[cfg(all(feature = "std", feature = "os-rng"))]
-pub async fn make_seal_async<T>(
-    signer: &T,
-    receiver_pubkey: &PublicKey,
-    // TODO: allow to pass a reference
-    rumor: UnsignedEvent, // Don't take the `EventBuilder`, read note below.
-) -> Result<EventBuilder, Error>
-where
-    T: AsyncNip44,
-{
-    // Encrypt content
-    let content: String = signer
-        .nip44_encrypt_async(receiver_pubkey, &rumor.as_json())
-        .await
-        .map_err(|e| Error::NIP44(e.to_string()))?;
-
-    Ok(build_seal(rumor, content))
-}
-
 #[cfg(all(feature = "std", feature = "os-rng"))]
 fn build_seal(mut rumor: UnsignedEvent, content: String) -> EventBuilder {
     // Take an `UnsignedEvent` as rumor and not an `EventBuilder`!
@@ -259,8 +430,8 @@ fn build_seal(mut rumor: UnsignedEvent, content: String) -> EventBuilder {
 #[cfg(test)]
 #[cfg(all(feature = "std", feature = "os-rng"))]
 mod tests {
-    use super::*;
-    use crate::{EventBuilder, Keys};
+    use super::{Error, *};
+    use crate::prelude::*;
 
     #[test]
     fn test_extract_rumor() {
@@ -272,10 +443,11 @@ mod tests {
                 .unwrap();
 
         // Compose Gift Wrap event
-        let rumor: UnsignedEvent = EventBuilder::text_note("Test").build(sender_keys.public_key);
-        let event: Event =
-            EventBuilder::gift_wrap(&sender_keys, &receiver_keys.public_key(), rumor.clone(), [])
-                .unwrap();
+        let rumor: UnsignedEvent =
+            EventBuilder::text_note("Test").finalize_unsigned(sender_keys.public_key);
+        let event: Event = GiftWrapBuilder::new(receiver_keys.public_key(), rumor.clone())
+            .finalize(&sender_keys)
+            .unwrap();
         let unwrapped = extract_rumor(&receiver_keys, &event).unwrap();
         assert_eq!(unwrapped.sender, sender_keys.public_key());
         assert_eq!(unwrapped.rumor.kind, Kind::TextNote);
@@ -283,7 +455,7 @@ mod tests {
         assert!(unwrapped.rumor.tags.is_empty());
         assert!(extract_rumor(&sender_keys, &event).is_err());
 
-        let event: Event = EventBuilder::text_note("").sign(&sender_keys).unwrap();
+        let event: Event = EventBuilder::text_note("").finalize(&sender_keys).unwrap();
         assert!(matches!(
             extract_rumor(&receiver_keys, &event).unwrap_err(),
             Error::NotGiftWrap
@@ -299,9 +471,11 @@ mod tests {
             Keys::parse("7b911fd37cdf5c81d4c0adb1ab7fa822ed253ab0ad9aa18d77257c88b29b718e")
                 .unwrap();
 
-        let rumor: UnsignedEvent = EventBuilder::text_note("Test").build(sender_keys.public_key);
-        let event: Event =
-            EventBuilder::gift_wrap(&sender_keys, &receiver_keys.public_key(), rumor, []).unwrap();
+        let rumor: UnsignedEvent =
+            EventBuilder::text_note("Test").finalize_unsigned(sender_keys.public_key);
+        let event: Event = GiftWrapBuilder::new(receiver_keys.public_key(), rumor)
+            .finalize(&sender_keys)
+            .unwrap();
 
         let unwrapped = extract_rumor_async(&receiver_keys, &event).await.unwrap();
         assert_eq!(unwrapped.sender, sender_keys.public_key());
@@ -318,10 +492,10 @@ mod tests {
             Keys::parse("7b911fd37cdf5c81d4c0adb1ab7fa822ed253ab0ad9aa18d77257c88b29b718e")
                 .unwrap();
 
-        let rumor: UnsignedEvent = EventBuilder::text_note("Test").build(sender_keys.public_key);
-        let seal = make_seal(&sender_keys, &receiver_keys.public_key(), rumor)
-            .unwrap()
-            .sign(&sender_keys)
+        let rumor: UnsignedEvent =
+            EventBuilder::text_note("Test").finalize_unsigned(sender_keys.public_key);
+        let seal = GiftWrapSealBuilder::new(rumor, receiver_keys.public_key())
+            .finalize(&sender_keys)
             .unwrap();
 
         assert_eq!(seal.kind, Kind::Seal);
@@ -337,11 +511,11 @@ mod tests {
             Keys::parse("7b911fd37cdf5c81d4c0adb1ab7fa822ed253ab0ad9aa18d77257c88b29b718e")
                 .unwrap();
 
-        let rumor: UnsignedEvent = EventBuilder::text_note("Test").build(sender_keys.public_key);
-        let seal = make_seal_async(&sender_keys, &receiver_keys.public_key(), rumor)
+        let rumor: UnsignedEvent =
+            EventBuilder::text_note("Test").finalize_unsigned(sender_keys.public_key);
+        let seal = GiftWrapSealBuilder::new(rumor, receiver_keys.public_key())
+            .finalize_async(&sender_keys)
             .await
-            .unwrap()
-            .sign(&sender_keys)
             .unwrap();
 
         assert_eq!(seal.kind, Kind::Seal);
@@ -363,10 +537,11 @@ mod tests {
         // Construct a rumor that lies about its pubkey but is still wrapped/signed
         // by `sender_keys`. This mimics a spoofing attempt the recipient must reject.
         let rumor: UnsignedEvent =
-            EventBuilder::text_note("spoofed").build(impersonated_keys.public_key());
+            EventBuilder::text_note("spoofed").finalize_unsigned(impersonated_keys.public_key());
 
-        let gift_wrap: Event =
-            EventBuilder::gift_wrap(&sender_keys, &receiver_keys.public_key(), rumor, []).unwrap();
+        let gift_wrap: Event = GiftWrapBuilder::new(receiver_keys.public_key(), rumor)
+            .finalize(&sender_keys)
+            .unwrap();
 
         match extract_rumor(&receiver_keys, &gift_wrap) {
             Err(Error::SenderMismatch) => {}

--- a/crates/nostr/src/nips/nip62.rs
+++ b/crates/nostr/src/nips/nip62.rs
@@ -162,8 +162,7 @@ pub fn is_valid_vanish_request_for_relay(tags: &[Tag], relay_url: Option<&RelayU
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[cfg(feature = "std")]
-    use crate::{EventBuilder, PublicKey};
+    use crate::prelude::*;
 
     #[test]
     fn test_standardized_relay_tag() {
@@ -192,7 +191,7 @@ mod tests {
 
         let all_relays = EventBuilder::request_vanish(VanishTarget::all_relays())
             .unwrap()
-            .build(
+            .finalize_unsigned(
                 PublicKey::from_hex(
                     "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
                 )
@@ -210,7 +209,7 @@ mod tests {
 
         let single_relay = EventBuilder::request_vanish(VanishTarget::relay(relay_a.clone()))
             .unwrap()
-            .build(
+            .finalize_unsigned(
                 PublicKey::from_hex(
                     "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
                 )
@@ -226,7 +225,7 @@ mod tests {
             Some(&relay_b)
         ));
 
-        let other_kind = EventBuilder::text_note("hello").build(
+        let other_kind = EventBuilder::text_note("hello").finalize_unsigned(
             PublicKey::from_hex("79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798")
                 .unwrap(),
         );

--- a/crates/nostr/src/nips/nip98.rs
+++ b/crates/nostr/src/nips/nip98.rs
@@ -25,9 +25,13 @@ use super::util::take_and_parse_from_str;
 use crate::Url;
 #[cfg(all(feature = "std", feature = "rand"))]
 use crate::event::EventBuilder;
+#[cfg(all(feature = "std", feature = "rand"))]
+use crate::event::FinalizeEventAsync;
 use crate::event::tag::{Tag, TagCodec, TagCodecError, impl_tag_codec_conversions};
 #[cfg(feature = "std")]
-use crate::event::{self, Event, builder};
+use crate::event::{self, Event};
+#[cfg(feature = "std")]
+use crate::signer::SignerError;
 #[cfg(all(feature = "std", feature = "rand"))]
 use crate::signer::{AsyncGetPublicKey, AsyncSignEvent};
 use crate::types::url;
@@ -74,7 +78,7 @@ pub enum Error {
     Event(event::Error),
     /// Event builder error
     #[cfg(feature = "std")]
-    EventBuilder(builder::Error),
+    Signer(SignerError),
     /// URL parse error
     Url(url::ParseError),
     /// Hex decoding error
@@ -129,7 +133,7 @@ impl fmt::Display for Error {
             #[cfg(feature = "std")]
             Self::Event(e) => e.fmt(f),
             #[cfg(feature = "std")]
-            Self::EventBuilder(e) => e.fmt(f),
+            Self::Signer(e) => e.fmt(f),
             Self::Url(e) => e.fmt(f),
             Self::Hex(e) => e.fmt(f),
             Self::Codec(e) => e.fmt(f),
@@ -188,9 +192,9 @@ impl From<event::Error> for Error {
 }
 
 #[cfg(feature = "std")]
-impl From<builder::Error> for Error {
-    fn from(e: builder::Error) -> Self {
-        Self::EventBuilder(e)
+impl From<SignerError> for Error {
+    fn from(e: SignerError) -> Self {
+        Self::Signer(e)
     }
 }
 
@@ -345,7 +349,7 @@ impl HttpData {
     where
         T: AsyncGetPublicKey + AsyncSignEvent,
     {
-        let event: Event = EventBuilder::http_auth(self).sign_async(signer).await?;
+        let event: Event = EventBuilder::http_auth(self).finalize_async(signer).await?;
         let encoded: String = general_purpose::STANDARD.encode(event.as_json());
         Ok(format!("{AUTH_HEADER_PREFIX} {encoded}"))
     }

--- a/database/nostr-database-test-suite/src/lib.rs
+++ b/database/nostr-database-test-suite/src/lib.rs
@@ -40,7 +40,7 @@ macro_rules! database_unit_tests {
         }
 
         fn build_event(keys: &Keys, builder: EventBuilder) -> Event {
-            builder.sign(keys).expect("Failed to build and sign event")
+            builder.finalize(keys).expect("Failed to build and finalize event")
         }
 
         // Return the number of added events
@@ -82,7 +82,7 @@ macro_rules! database_unit_tests {
             builder: EventBuilder,
             keys: &Keys,
         ) -> (Event, SaveEventStatus) {
-            let event = builder.sign(keys).expect("Failed to sign event");
+            let event = builder.finalize(keys).expect("Failed to finalize event");
             let status = store.save_event(&event).await.expect("Failed to save event");
             (event, status)
         }
@@ -104,24 +104,24 @@ macro_rules! database_unit_tests {
             let helper = Keys::generate();
 
             let event1 = EventBuilder::text_note("Hi 1")
-                .sign(&to_vanish)
+                .finalize(&to_vanish)
                 .unwrap();
             let event2 = EventBuilder::text_note("Hi 2")
-                .sign(&to_vanish)
+                .finalize(&to_vanish)
                 .unwrap();
-            let replaceable = EventBuilder::contact_list([
+            let replaceable = ContactListBuilder::new([
                 Contact::new(Keys::generate().public_key),
                 Contact::new(Keys::generate().public_key),
             ])
-            .sign(&to_vanish)
+            .finalize(&to_vanish)
             .unwrap();
             let addresable = EventBuilder::long_form_text_note("LONG")
                 .tag(Tag::identifier("lorem-ipsum".to_string()))
-                .sign(&to_vanish)
+                .finalize(&to_vanish)
                 .unwrap();
             let dummy_gift_wrap = EventBuilder::new(Kind::GiftWrap, ":)")
                 .tag(Tag::public_key(to_vanish.public_key))
-                .sign(&helper)
+                .finalize(&helper)
                 .unwrap();
 
             store.save_event(&event1).await.unwrap();
@@ -279,8 +279,8 @@ macro_rules! database_unit_tests {
             let metadata1 = Metadata::new().name("First");
             let event1 = EventBuilder::metadata(&metadata1)
                 .custom_created_at(Timestamp::from_secs(1000))
-                .sign(&keys)
-                .expect("Failed to sign");
+                .finalize(&keys)
+                .expect("Failed to finalize");
 
             store.save_event(&event1).await.expect("Failed to save event");
 
@@ -288,8 +288,8 @@ macro_rules! database_unit_tests {
             let metadata2 = Metadata::new().name("Second");
             let event2 = EventBuilder::metadata(&metadata2)
                 .custom_created_at(Timestamp::from_secs(2000))
-                .sign(&keys)
-                .expect("Failed to sign");
+                .finalize(&keys)
+                .expect("Failed to finalize");
 
             store.save_event(&event2).await.expect("Failed to save event");
 
@@ -313,8 +313,8 @@ macro_rules! database_unit_tests {
             let event1 = EventBuilder::new(Kind::from(32121), "Content 1")
                 .tag(Tag::identifier("test-id"))
                 .custom_created_at(Timestamp::from_secs(1000))
-                .sign(&keys)
-                .expect("Failed to sign");
+                .finalize(&keys)
+                .expect("Failed to finalize");
 
             store.save_event(&event1).await.expect("Failed to save event");
 
@@ -322,8 +322,8 @@ macro_rules! database_unit_tests {
             let event2 = EventBuilder::new(Kind::from(32121), "Content 2")
                 .tag(Tag::identifier("test-id"))
                 .custom_created_at(Timestamp::from_secs(2000))
-                .sign(&keys)
-                .expect("Failed to sign");
+                .finalize(&keys)
+                .expect("Failed to finalize");
 
             store.save_event(&event2).await.expect("Failed to save event");
 
@@ -347,11 +347,11 @@ macro_rules! database_unit_tests {
 
             // Create events to delete
             let event1 = EventBuilder::text_note("To be deleted 1")
-                .sign(&keys)
-                .expect("Failed to sign");
+                .finalize(&keys)
+                .expect("Failed to finalize");
             let event2 = EventBuilder::text_note("To be deleted 2")
-                .sign(&keys)
-                .expect("Failed to sign");
+                .finalize(&keys)
+                .expect("Failed to finalize");
 
             store.save_event(&event1).await.expect("Failed to save event");
             store.save_event(&event2).await.expect("Failed to save event");
@@ -359,8 +359,8 @@ macro_rules! database_unit_tests {
             // Create deletion event
             let deletion =
                 EventBuilder::delete(EventDeletionRequest::new().id(event1.id).id(event2.id))
-                    .sign(&keys)
-                    .expect("Failed to sign");
+                    .finalize(&keys)
+                    .expect("Failed to finalize");
 
             store.save_event(&deletion)
                 .await
@@ -392,8 +392,8 @@ macro_rules! database_unit_tests {
 
             // Create events to delete
             let event = EventBuilder::new(Kind::Custom(11_111), "To be deleted 1")
-                .sign(&keys)
-                .expect("Failed to sign");
+                .finalize(&keys)
+                .expect("Failed to finalize");
 
             let status = store.save_event(&event).await.expect("Failed to save event");
 
@@ -404,8 +404,8 @@ macro_rules! database_unit_tests {
                 .coordinate(event.coordinate().unwrap());
             let deletion =
                 EventBuilder::delete(req)
-                    .sign(&keys)
-                    .expect("Failed to sign");
+                    .finalize(&keys)
+                    .expect("Failed to finalize");
 
             store.save_event(&deletion)
                 .await
@@ -945,7 +945,7 @@ macro_rules! database_unit_tests {
             // Request to vanish
             let request_to_vanish = EventBuilder::request_vanish(VanishTarget::AllRelays)
                 .unwrap()
-                .sign(&to_vanish)
+                .finalize(&to_vanish)
                 .unwrap();
             store.save_event(&request_to_vanish).await.unwrap();
 
@@ -970,7 +970,7 @@ macro_rules! database_unit_tests {
             );
 
             let new_event = EventBuilder::text_note("It was a mistake, please accept my event")
-                .sign(&to_vanish)
+                .finalize(&to_vanish)
                 .unwrap();
 
             // Try adding new event, should get rejected
@@ -996,7 +996,7 @@ macro_rules! database_unit_tests {
             // Request to vanish
             let request_to_vanish = EventBuilder::request_vanish(VanishTarget::relay(url))
                 .unwrap()
-                .sign(&to_vanish)
+                .finalize(&to_vanish)
                 .unwrap();
             store.save_event(&request_to_vanish).await.unwrap();
 
@@ -1021,7 +1021,7 @@ macro_rules! database_unit_tests {
             );
 
             let new_event = EventBuilder::text_note("It was a mistake, please accept my event")
-                .sign(&to_vanish)
+                .finalize(&to_vanish)
                 .unwrap();
 
             // Try adding new event, should get rejected

--- a/database/nostr-lmdb/src/store/filter.rs
+++ b/database/nostr-lmdb/src/store/filter.rs
@@ -170,13 +170,13 @@ impl From<Filter> for DatabaseFilter {
 
 #[cfg(test)]
 mod tests {
-    use nostr::{Event, EventBuilder, Keys, Tag};
+    use nostr::prelude::*;
 
     use super::*;
 
     fn create_test_event(content: &str) -> Event {
         let keys = Keys::generate();
-        EventBuilder::text_note(content).sign(&keys).unwrap()
+        EventBuilder::text_note(content).finalize(&keys).unwrap()
     }
 
     #[test]
@@ -203,7 +203,7 @@ mod tests {
         let keys = Keys::generate();
         let event = EventBuilder::text_note("content")
             .tag(Tag::parse(["title", "Search userfacing tags"]).unwrap())
-            .sign(&keys)
+            .finalize(&keys)
             .unwrap();
         let event: EventBorrow = (&event).into();
 

--- a/database/nostr-lmdb/src/store/ingester.rs
+++ b/database/nostr-lmdb/src/store/ingester.rs
@@ -370,6 +370,7 @@ mod tests {
     use std::sync::Arc;
 
     use futures::future::join_all;
+    use nostr::event::FinalizeEvent;
     use nostr::{EventBuilder, Keys, Kind};
     use tempfile::TempDir;
 
@@ -397,8 +398,8 @@ mod tests {
 
         // Create a mix of valid and duplicate events
         let event1 = EventBuilder::text_note("Event 1")
-            .sign(&keys)
-            .expect("Failed to sign event");
+            .finalize(&keys)
+            .expect("Failed to finalize event");
 
         // Save event1 first
         store
@@ -408,12 +409,12 @@ mod tests {
 
         // Now try to save a batch with duplicate and new events
         let event2 = EventBuilder::text_note("Event 2")
-            .sign(&keys)
-            .expect("Failed to sign event");
+            .finalize(&keys)
+            .expect("Failed to finalize event");
 
         let event3 = EventBuilder::text_note("Event 3")
-            .sign(&keys)
-            .expect("Failed to sign event");
+            .finalize(&keys)
+            .expect("Failed to finalize event");
 
         let futures = vec![
             store.save_event(&event1), // Duplicate
@@ -453,8 +454,8 @@ mod tests {
         let mut events = Vec::new();
         for i in 0..10 {
             let event = EventBuilder::text_note(format!("Event to delete {}", i))
-                .sign(&keys)
-                .expect("Failed to sign event");
+                .finalize(&keys)
+                .expect("Failed to finalize event");
             store
                 .save_event(&event)
                 .await
@@ -464,12 +465,12 @@ mod tests {
 
         // Now create a mixed batch of saves and deletes
         let new_event1 = EventBuilder::text_note("New event 1")
-            .sign(&keys)
-            .expect("Failed to sign event");
+            .finalize(&keys)
+            .expect("Failed to finalize event");
 
         let new_event2 = EventBuilder::text_note("New event 2")
-            .sign(&keys)
-            .expect("Failed to sign event");
+            .finalize(&keys)
+            .expect("Failed to finalize event");
 
         // Execute mixed operations concurrently
         let save_fut1 = store.save_event(&new_event1);

--- a/database/nostr-lmdb/src/store/lmdb/mod.rs
+++ b/database/nostr-lmdb/src/store/lmdb/mod.rs
@@ -1419,7 +1419,7 @@ mod tests {
         let keys = Keys::generate();
         EventBuilder::new(Kind::from(kind), "test content")
             .custom_created_at(Timestamp::from_secs(created_at))
-            .sign(&keys)
+            .finalize(&keys)
             .unwrap()
     }
 

--- a/database/nostr-sqlite/src/store.rs
+++ b/database/nostr-sqlite/src/store.rs
@@ -898,7 +898,7 @@ mod tests {
             .tag(Tag::parse(["subject", "gamma-token"]).unwrap())
             .tag(Tag::parse(["name", "delta-token"]).unwrap())
             .tag(Tag::identifier("epsilon-token"))
-            .sign(&keys)
+            .finalize(&keys)
             .unwrap();
 
         assert!(db.save_event(&event).await.unwrap().is_success());

--- a/gossip/nostr-gossip-test-suite/src/lib.rs
+++ b/gossip/nostr-gossip-test-suite/src/lib.rs
@@ -101,7 +101,7 @@ macro_rules! gossip_unit_tests {
                         relay_hint: Some(relay_url.clone()),
                     },
                 ))
-                .sign(&keys)
+                .finalize(&keys)
                 .unwrap();
 
             store.process(&event, None).await.unwrap();
@@ -128,7 +128,7 @@ macro_rules! gossip_unit_tests {
             // Process multiple events from the same relay
             for i in 0..5 {
                 let event = EventBuilder::text_note(format!("Test {i}"))
-                    .sign(&keys)
+                    .finalize(&keys)
                     .unwrap();
 
                 store.process(&event, Some(&relay_url)).await.unwrap();

--- a/rfs/nostr-blossom/src/client.rs
+++ b/rfs/nostr-blossom/src/client.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use base64::Engine;
 use base64::engine::general_purpose;
+use nostr::event::FinalizeEventAsync;
 use nostr::hashes::Hash;
 use nostr::hashes::sha256::Hash as Sha256Hash;
 use nostr::signer::{AsyncGetPublicKey, AsyncSignEvent};
@@ -332,7 +333,7 @@ impl BlossomClient {
         T: AsyncGetPublicKey + AsyncSignEvent,
     {
         let auth_event: Event = EventBuilder::blossom_auth(authz.clone())
-            .sign_async(signer)
+            .finalize_async(signer)
             .await?;
         let encoded_auth: String = general_purpose::STANDARD.encode(auth_event.as_json());
         let value: String = format!("Nostr {}", encoded_auth);

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -45,7 +45,7 @@ async fn main() -> Result<()> {
     client.connect().await;
 
     // Publish a text note
-    let event = EventBuilder::text_note("My first text note from rust-nostr!").sign(&keys)?;
+    let event = EventBuilder::text_note("My first text note from rust-nostr!").finalize(&keys)?;
     client.send_event(&event).await?;
 
     Ok(())

--- a/sdk/examples/bot.rs
+++ b/sdk/examples/bot.rs
@@ -48,7 +48,8 @@ async fn main() -> Result<()> {
                             };
 
                             // Send private message
-                            let msg = EventBuilder::private_msg(&keys, sender, content, [])?;
+                            let msg = PrivateDirectMessageBuilder::new(sender, content)
+                                .finalize(&keys)?;
                             client.send_event(&msg).to_nip17().await?;
                         }
                     }

--- a/sdk/examples/client.rs
+++ b/sdk/examples/client.rs
@@ -21,18 +21,19 @@ async fn main() -> Result<()> {
     let keys = Keys::parse("nsec1ufnus6pju578ste3v90xd5m2decpuzpql2295m3sknqcjzyys9ls0qlc85")?;
 
     // Publish a text note
-    let event = EventBuilder::text_note("Hello world").sign(&keys)?;
+    let event = EventBuilder::text_note("Hello world").finalize(&keys)?;
     let output = client.send_event(&event).await?;
     println!("Event ID: {}", output.id().to_bech32()?);
     println!("Sent to: {:?}", output.success);
     println!("Not sent to: {:?}", output.failed);
 
     // Create a text note POW event to relays
-    let unsigned = EventBuilder::text_note("POW text note from rust-nostr").build(keys.public_key);
+    let unsigned =
+        EventBuilder::text_note("POW text note from rust-nostr").finalize_unsigned(keys.public_key);
     let unsigned = unsigned
         .mine_async(&SingleThreadPow, NonZeroU8::new(20).unwrap())
         .await?;
-    let event = unsigned.sign(&keys)?;
+    let event = unsigned.finalize(&keys)?;
     client.send_event(&event).await?;
 
     Ok(())

--- a/sdk/examples/code_snippet.rs
+++ b/sdk/examples/code_snippet.rs
@@ -28,7 +28,7 @@ async fn main() -> Result<()> {
         .extension("rs")
         .license("MIT");
 
-    let event = EventBuilder::code_snippet(snippet).sign(&keys)?;
+    let event = EventBuilder::code_snippet(snippet).finalize(&keys)?;
 
     let output = client.send_event(&event).await?;
 

--- a/sdk/examples/comment.rs
+++ b/sdk/examples/comment.rs
@@ -28,7 +28,7 @@ async fn main() -> Result<()> {
 
     let comment_to = events.first().unwrap();
     let event = EventBuilder::comment("This is a reply", CommentTarget::from(comment_to), None)
-        .sign(&keys)?;
+        .finalize(&keys)?;
 
     let output = client.send_event(&event).await?;
     println!("Output: {:?}", output);

--- a/sdk/examples/gossip.rs
+++ b/sdk/examples/gossip.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<()> {
         "Hello world nostr:npub1drvpzev3syqt0kjrls50050uzf25gehpz9vgdw08hvex7e0vgfeq0eseet",
     )
     .tag(Tag::public_key(pubkey))
-    .sign(&keys)?;
+    .finalize(&keys)?;
 
     let output = client.send_event(&event).await?;
     println!("Event ID: {}", output.to_bech32()?);

--- a/sdk/examples/lmdb.rs
+++ b/sdk/examples/lmdb.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<()> {
     let keys = Keys::parse("nsec1ufnus6pju578ste3v90xd5m2decpuzpql2295m3sknqcjzyys9ls0qlc85")?;
 
     // Publish a text note
-    let event = EventBuilder::text_note("Hello world").sign(&keys)?;
+    let event = EventBuilder::text_note("Hello world").finalize(&keys)?;
     client.send_event(&event).await?;
 
     // Negentropy sync

--- a/sdk/examples/nip42.rs
+++ b/sdk/examples/nip42.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<()> {
     client.connect().and_wait(Duration::from_secs(10)).await;
 
     // Publish a text note
-    let event = EventBuilder::text_note("Hello world").sign(&keys)?;
+    let event = EventBuilder::text_note("Hello world").finalize(&keys)?;
     let output = client.send_event(&event).await?;
     println!("Event ID: {}", output.id().to_bech32()?);
     println!("Sent to: {:?}", output.success);

--- a/sdk/examples/nostr-connect.rs
+++ b/sdk/examples/nostr-connect.rs
@@ -39,15 +39,16 @@ async fn main() -> Result<()> {
 
     // Publish events
     let event = EventBuilder::text_note("Testing rust-nostr NIP46 signer [bunker]")
-        .sign_async(&signer)
+        .finalize_async(&signer)
         .await?;
     let output = client.send_event(&event).await?;
     println!("Published text note: {}\n", output.id());
 
     let receiver =
         PublicKey::from_bech32("npub1drvpzev3syqt0kjrls50050uzf25gehpz9vgdw08hvex7e0vgfeq0eseet")?;
-    let msg =
-        EventBuilder::private_msg_async(&signer, receiver, "Hello from rust-nostr", []).await?;
+    let msg = PrivateDirectMessageBuilder::new(receiver, "Hello from rust-nostr")
+        .finalize_async(&signer)
+        .await?;
     let output = client.send_event(&msg).to_nip17().await?;
     println!("Sent DM: {}", output.id());
 

--- a/sdk/examples/nostrdb.rs
+++ b/sdk/examples/nostrdb.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<()> {
     let keys = Keys::parse("nsec1ufnus6pju578ste3v90xd5m2decpuzpql2295m3sknqcjzyys9ls0qlc85")?;
 
     // Publish a text note
-    let event = EventBuilder::text_note("Hello world").sign(&keys)?;
+    let event = EventBuilder::text_note("Hello world").finalize(&keys)?;
     client.send_event(&event).await?;
 
     // Negentropy reconcile

--- a/sdk/examples/status.rs
+++ b/sdk/examples/status.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<()> {
 
     // Send a General statuses event to relays
     let general = LiveStatus::new(StatusType::General);
-    let event = EventBuilder::live_status(general, "Building rust-nostr").sign(&keys)?;
+    let event = EventBuilder::live_status(general, "Building rust-nostr").finalize(&keys)?;
     client.send_event(&event).await?;
 
     // Send a Music statuses event to relays
@@ -31,7 +31,7 @@ async fn main() -> Result<()> {
         expiration: Some(Timestamp::now() + Duration::from_secs(60 * 60 * 24)),
         reference: Some("spotify:search:Intergalatic%20-%20Beastie%20Boys".into()),
     };
-    let event = EventBuilder::live_status(music, "Intergalatic - Beastie Boys").sign(&keys)?;
+    let event = EventBuilder::live_status(music, "Intergalatic - Beastie Boys").finalize(&keys)?;
     client.send_event(&event).await?;
 
     Ok(())

--- a/sdk/src/authenticator.rs
+++ b/sdk/src/authenticator.rs
@@ -3,6 +3,7 @@
 use std::any::Any;
 use std::fmt::Debug;
 
+use nostr::event::FinalizeEventAsync;
 use nostr::signer::{AsyncGetPublicKey, AsyncSignEvent};
 use nostr::{Event, EventBuilder, RelayUrl};
 
@@ -65,7 +66,7 @@ where
     ) -> BoxedFuture<'a, Result<Event, AuthenticationError>> {
         Box::pin(async move {
             Ok(EventBuilder::auth(challenge, relay_url.clone())
-                .sign_async(&self.signer)
+                .finalize_async(&self.signer)
                 .await?)
         })
     }

--- a/sdk/src/client/api/send_event.rs
+++ b/sdk/src/client/api/send_event.rs
@@ -472,7 +472,7 @@ mod tests {
 
         let keys = Keys::generate();
         let event = EventBuilder::text_note("Broadcast test")
-            .sign(&keys)
+            .finalize(&keys)
             .unwrap();
 
         // Send event (broadcast to all WRITE relays by default)
@@ -500,7 +500,7 @@ mod tests {
 
         let keys = Keys::generate();
         let event = EventBuilder::text_note("Targeted test")
-            .sign(&keys)
+            .finalize(&keys)
             .unwrap();
 
         // Send only to relay 1
@@ -541,7 +541,7 @@ mod tests {
 
         let keys = Keys::generate();
         let event = EventBuilder::text_note("Force to all test")
-            .sign(&keys)
+            .finalize(&keys)
             .unwrap();
 
         // Force send to all WRITE instead of using gossip
@@ -572,7 +572,7 @@ mod tests {
         // Setup User A keys and their Relay List (NIP-65) pointing to the Outbox Relay
         let keys_a = Keys::generate();
         let relay_list = EventBuilder::relay_list([(outbox_url.clone(), None)])
-            .sign(&keys_a)
+            .finalize(&keys_a)
             .unwrap();
         let res = discovery_mock.add_event(relay_list).await.unwrap();
         assert!(res.is_success());
@@ -621,7 +621,7 @@ mod tests {
         // - Automatically connect to 'outbox_url'
         // - Send the event to the outbox and public relay
         let event = EventBuilder::text_note("Gossip test")
-            .sign(&keys_a)
+            .finalize(&keys_a)
             .unwrap();
 
         // Send event using default config (must be sent to gossip)
@@ -654,7 +654,7 @@ mod tests {
 
         let keys = Keys::generate();
         let event = EventBuilder::text_note("Broadcast test")
-            .sign(&keys)
+            .finalize(&keys)
             .unwrap();
 
         // Send event
@@ -678,7 +678,7 @@ mod tests {
         // Setup Bob keys and NIP-17 list pointing to the Inbox Relay
         let bob_keys = Keys::generate();
         let relay_list = EventBuilder::nip17_relay_list([inbox_url.clone()])
-            .sign(&bob_keys)
+            .finalize(&bob_keys)
             .unwrap();
         let res = discovery_mock.add_event(relay_list).await.unwrap();
         assert!(res.is_success());
@@ -711,7 +711,7 @@ mod tests {
         // NOTE: this is not a NIP-17 event, as the nip59 feature is required, so we are sending a fake gift wrap tagging the recipient
         let event = EventBuilder::new(Kind::GiftWrap, "payload")
             .tag(Tag::public_key(bob_keys.public_key))
-            .sign(&Keys::generate())
+            .finalize(&Keys::generate())
             .unwrap();
         let output = client.send_event(&event).to_nip17().await.unwrap();
 
@@ -741,7 +741,7 @@ mod tests {
         let bob_keys = Keys::generate();
         let event = EventBuilder::new(Kind::GiftWrap, "payload")
             .tag(Tag::public_key(bob_keys.public_key))
-            .sign(&Keys::generate())
+            .finalize(&Keys::generate())
             .unwrap();
 
         // Send event

--- a/sdk/src/client/gossip/resolver.rs
+++ b/sdk/src/client/gossip/resolver.rs
@@ -337,7 +337,7 @@ mod tests {
         let list = relays
             .into_iter()
             .filter_map(|(url, m)| Some((RelayUrl::parse(url).ok()?, m)));
-        EventBuilder::relay_list(list).sign(&keys).unwrap()
+        EventBuilder::relay_list(list).finalize(&keys).unwrap()
     }
 
     async fn setup() -> GossipRelayResolver {

--- a/sdk/src/relay/api/fetch_events.rs
+++ b/sdk/src/relay/api/fetch_events.rs
@@ -117,7 +117,9 @@ mod tests {
 
         // Send some events
         for i in 0..num_events {
-            let event = EventBuilder::text_note(i.to_string()).sign(&keys).unwrap();
+            let event = EventBuilder::text_note(i.to_string())
+                .finalize(&keys)
+                .unwrap();
             relay.send_event(&event).await.unwrap();
         }
 
@@ -182,7 +184,7 @@ mod tests {
         let keys = Keys::generate();
 
         // Send an event
-        let event = EventBuilder::text_note("Test").sign(&keys).unwrap();
+        let event = EventBuilder::text_note("Test").finalize(&keys).unwrap();
         relay.send_event(&event).await.unwrap();
 
         let filter = Filter::new().kind(Kind::TextNote).limit(3);
@@ -223,7 +225,7 @@ mod tests {
         relay.connect();
 
         // Send an event
-        let event = EventBuilder::text_note("Test").sign(&keys).unwrap();
+        let event = EventBuilder::text_note("Test").finalize(&keys).unwrap();
         relay.send_event(&event).await.unwrap();
 
         let filter = Filter::new().kind(Kind::TextNote).limit(3);
@@ -280,7 +282,7 @@ mod tests {
 
             // Build and send event
             let event = EventBuilder::metadata(&Metadata::new().name("Test"))
-                .sign(&keys)
+                .finalize(&keys)
                 .unwrap();
             r.send_event(&event).await.unwrap();
         });
@@ -310,7 +312,9 @@ mod tests {
                 tokio::time::sleep(Duration::from_secs(2)).await;
 
                 // Build and send event
-                let event = EventBuilder::text_note("Additional").sign(&keys).unwrap();
+                let event = EventBuilder::text_note("Additional")
+                    .finalize(&keys)
+                    .unwrap();
                 r.send_event(&event).await.unwrap();
             }
         });
@@ -339,7 +343,9 @@ mod tests {
             // Send more events
             for _ in 0..2 {
                 // Build and send event
-                let event = EventBuilder::text_note("Additional").sign(&keys).unwrap();
+                let event = EventBuilder::text_note("Additional")
+                    .finalize(&keys)
+                    .unwrap();
                 r.send_event(&event).await.unwrap();
 
                 tokio::time::sleep(Duration::from_secs(2)).await;

--- a/sdk/src/relay/api/send_event.rs
+++ b/sdk/src/relay/api/send_event.rs
@@ -291,7 +291,7 @@ mod tests {
 
         // Make an event
         let keys = Keys::generate();
-        let event = EventBuilder::text_note("Test").sign(&keys).unwrap();
+        let event = EventBuilder::text_note("Test").finalize(&keys).unwrap();
 
         // Send the event
         let output = relay.send_event(&event).await.unwrap();
@@ -324,7 +324,7 @@ mod tests {
             .unwrap();
 
         let keys = Keys::generate();
-        let event = EventBuilder::text_note("Test").sign(&keys).unwrap();
+        let event = EventBuilder::text_note("Test").finalize(&keys).unwrap();
         let output = relay.send_event(&event).wait_for_ok(false).await.unwrap();
 
         assert_eq!(output.id(), &event.id);
@@ -348,7 +348,7 @@ mod tests {
 
         // Signer and event
         let keys = Keys::generate();
-        let event = EventBuilder::text_note("Test").sign(&keys).unwrap();
+        let event = EventBuilder::text_note("Test").finalize(&keys).unwrap();
 
         // Auth disabled, so must fails as is unauthenticated
         match relay.send_event(&event).await.unwrap_err() {
@@ -380,7 +380,7 @@ mod tests {
 
         relay.connect();
 
-        let event = EventBuilder::text_note("Test").sign(&keys).unwrap();
+        let event = EventBuilder::text_note("Test").finalize(&keys).unwrap();
 
         // Send as authenticated
         assert!(relay.send_event(&event).await.is_ok());

--- a/sdk/src/relay/api/stream_events.rs
+++ b/sdk/src/relay/api/stream_events.rs
@@ -162,7 +162,7 @@ mod tests {
     use std::time::Duration;
 
     use futures::StreamExt;
-    use nostr::event::EventBuilder;
+    use nostr::event::{EventBuilder, FinalizeEvent};
     use nostr::key::Keys;
     use nostr::{Filter, Kind, SubscriptionId};
     use nostr_relay_builder::MockRelay;
@@ -212,7 +212,7 @@ mod tests {
     #[tokio::test]
     async fn test_stream_with_subscription_verification_single_filter() {
         let keys = Keys::generate();
-        let event = EventBuilder::text_note("test").sign(&keys).unwrap();
+        let event = EventBuilder::text_note("test").finalize(&keys).unwrap();
 
         let mock = MockRelay::run().await.unwrap();
         let url = mock.url().await;
@@ -245,7 +245,7 @@ mod tests {
     #[tokio::test]
     async fn test_stream_with_subscription_verification_multiple_filters() {
         let keys = Keys::generate();
-        let event = EventBuilder::text_note("test").sign(&keys).unwrap();
+        let event = EventBuilder::text_note("test").finalize(&keys).unwrap();
 
         let mock = MockRelay::run().await.unwrap();
         let url = mock.url().await;

--- a/sdk/src/relay/api/subscribe.rs
+++ b/sdk/src/relay/api/subscribe.rs
@@ -218,7 +218,7 @@ mod tests {
 
         // Event
         let kind = Kind::Custom(22_222); // Ephemeral kind
-        let event: Event = EventBuilder::new(kind, "").sign(&keys).unwrap();
+        let event: Event = EventBuilder::new(kind, "").finalize(&keys).unwrap();
 
         let event_id: EventId = event.id;
 

--- a/sdk/src/relay/api/sync.rs
+++ b/sdk/src/relay/api/sync.rs
@@ -647,13 +647,13 @@ mod tests {
         // Build events to store in the local database
         let local_events = [
             EventBuilder::text_note("Local 1")
-                .sign(&Keys::generate())
+                .finalize(&Keys::generate())
                 .unwrap(),
             EventBuilder::text_note("Local 2")
-                .sign(&Keys::generate())
+                .finalize(&Keys::generate())
                 .unwrap(),
             EventBuilder::new(Kind::Custom(123), "Local 123")
-                .sign(&Keys::generate())
+                .finalize(&Keys::generate())
                 .unwrap(),
         ];
 
@@ -678,13 +678,13 @@ mod tests {
             // Event in common with the local database
             local_events[0].clone(),
             EventBuilder::text_note("Test 2")
-                .sign(&Keys::generate())
+                .finalize(&Keys::generate())
                 .unwrap(),
             EventBuilder::text_note("Test 3")
-                .sign(&Keys::generate())
+                .finalize(&Keys::generate())
                 .unwrap(),
             EventBuilder::new(Kind::Custom(123), "Test 4")
-                .sign(&Keys::generate())
+                .finalize(&Keys::generate())
                 .unwrap(),
         ];
 

--- a/sdk/src/relay/inner.rs
+++ b/sdk/src/relay/inner.rs
@@ -1796,7 +1796,7 @@ mod tests {
     #[tokio::test]
     async fn test_subscription_verification_accepts_event_matching_any_filter() {
         let keys = Keys::generate();
-        let event = EventBuilder::text_note("test").sign(&keys).unwrap();
+        let event = EventBuilder::text_note("test").finalize(&keys).unwrap();
 
         let filter = Filter::new().kind(Kind::TextNote).since(event.created_at);
         let matching_filter = filter.clone().author(event.pubkey);

--- a/sdk/src/relay/mod.rs
+++ b/sdk/src/relay/mod.rs
@@ -967,7 +967,7 @@ mod tests {
 
         // Test wake up when sending an event
         let event = EventBuilder::text_note("text wake-up")
-            .sign(&Keys::generate())
+            .finalize(&Keys::generate())
             .unwrap();
         relay.send_event(&event).await.unwrap();
         assert_eq!(relay.status(), RelayStatus::Connected);

--- a/signer/nostr-browser-signer-proxy/examples/browser-signer-proxy.rs
+++ b/signer/nostr-browser-signer-proxy/examples/browser-signer-proxy.rs
@@ -31,15 +31,17 @@ async fn main() -> Result<()> {
 
     // Sign event
     let event = EventBuilder::text_note("Testing browser signer proxy")
-        .sign_async(&proxy)
+        .finalize_async(&proxy)
         .await?;
     println!("Event: {}", event.as_json());
 
     // Build a gift wrap
     let receiver =
         PublicKey::parse("npub1drvpzev3syqt0kjrls50050uzf25gehpz9vgdw08hvex7e0vgfeq0eseet")?;
-    let rumor = EventBuilder::new(Kind::Custom(123), "test").build(public_key);
-    let gift_wrap = EventBuilder::gift_wrap_async(&proxy, &receiver, rumor, []).await?;
+    let rumor = EventBuilder::new(Kind::Custom(123), "test").finalize_unsigned(public_key);
+    let gift_wrap = GiftWrapBuilder::new(receiver, rumor)
+        .finalize_async(&proxy)
+        .await?;
     println!("Gift wrap: {}", gift_wrap.as_json());
 
     // Keep up the program

--- a/signer/nostr-browser-signer-proxy/examples/custom_html.rs
+++ b/signer/nostr-browser-signer-proxy/examples/custom_html.rs
@@ -49,15 +49,17 @@ async fn main() -> Result<()> {
 
     // Sign event
     let event = EventBuilder::text_note("Testing browser signer proxy")
-        .sign_async(&proxy)
+        .finalize_async(&proxy)
         .await?;
     println!("Event: {}", event.as_json());
 
     // Build a gift wrap
     let receiver =
         PublicKey::parse("npub1drvpzev3syqt0kjrls50050uzf25gehpz9vgdw08hvex7e0vgfeq0eseet")?;
-    let rumor = EventBuilder::new(Kind::Custom(123), "test").build(public_key);
-    let gift_wrap = EventBuilder::gift_wrap_async(&proxy, &receiver, rumor, []).await?;
+    let rumor = EventBuilder::new(Kind::Custom(123), "test").finalize_unsigned(public_key);
+    let gift_wrap = GiftWrapBuilder::new(receiver, rumor)
+        .finalize_async(&proxy)
+        .await?;
     println!("Gift wrap: {}", gift_wrap.as_json());
 
     // Keep up the program

--- a/signer/nostr-connect/examples/handle-auth-url.rs
+++ b/signer/nostr-connect/examples/handle-auth-url.rs
@@ -40,7 +40,7 @@ async fn main() -> Result<()> {
     println!("Content: {content}");
 
     let event = EventBuilder::text_note("Testing rust-nostr")
-        .sign_async(&connect)
+        .finalize_async(&connect)
         .await?;
     println!("Event: {}", event.as_json());
 

--- a/signer/nostr-connect/src/client.rs
+++ b/signer/nostr-connect/src/client.rs
@@ -224,9 +224,8 @@ impl NostrConnect {
         tracing::debug!("Sending '{msg}' NIP46 message");
 
         let req_id = msg.id().to_string();
-        let event: Event =
-            EventBuilder::nostr_connect(&self.client_keys, remote_signer_public_key, msg)?
-                .sign(&self.client_keys)?;
+        let event: Event = NostrConnectEventBuilder::new(remote_signer_public_key, msg)
+            .finalize(&self.client_keys)?;
 
         let mut notifications = self.client.notifications();
 

--- a/signer/nostr-connect/src/error.rs
+++ b/signer/nostr-connect/src/error.rs
@@ -9,6 +9,7 @@ use std::fmt;
 use nostr::PublicKey;
 use nostr::event::builder;
 use nostr::nips::{nip04, nip44, nip46};
+use nostr::signer::SignerError;
 use nostr::types::url;
 use nostr_sdk::client;
 use tokio::sync::SetError;
@@ -16,6 +17,8 @@ use tokio::sync::SetError;
 /// Nostr Connect error
 #[derive(Debug)]
 pub enum Error {
+    /// Signer error
+    Signer(SignerError),
     /// Event builder error
     Builder(builder::Error),
     /// NIP04 error
@@ -51,6 +54,7 @@ impl std::error::Error for Error {}
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::Signer(e) => e.fmt(f),
             Self::Builder(e) => e.fmt(f),
             Self::NIP04(e) => e.fmt(f),
             Self::NIP44(e) => e.fmt(f),
@@ -66,6 +70,12 @@ impl fmt::Display for Error {
             Self::PublicKeyNotMatchAppKeys => f.write_str("public key not match app keys"),
             Self::NoClientSecret => f.write_str("missing client secret"),
         }
+    }
+}
+
+impl From<SignerError> for Error {
+    fn from(e: SignerError) -> Self {
+        Self::Signer(e)
     }
 }
 

--- a/signer/nostr-connect/src/signer.rs
+++ b/signer/nostr-connect/src/signer.rs
@@ -120,8 +120,8 @@ impl NostrConnectRemoteSigner {
         // TODO: Fix the request id, should we?
         let res = NostrConnectResponse::with_result(ResponseResult::ConnectSecret(secret));
         let msg: NostrConnectMessage = NostrConnectMessage::response("urmom", res);
-        let event: Event = EventBuilder::nostr_connect(&self.keys.signer, public_key, msg)?
-            .sign(&self.keys.signer)?;
+        let event: Event =
+            NostrConnectEventBuilder::new(public_key, msg).finalize(&self.keys.signer)?;
         self.client.send_event(&event).await?;
         Ok(())
     }
@@ -299,7 +299,7 @@ impl NostrConnectRemoteSigner {
                                             }
                                         }
                                         NostrConnectRequest::SignEvent(unsigned) => {
-                                            match unsigned.sign(&self.keys.user) {
+                                            match unsigned.finalize(&self.keys.user) {
                                                 Ok(event) => NostrConnectResponse::with_result(
                                                     ResponseResult::SignEvent(Box::new(event)),
                                                 ),
@@ -321,12 +321,8 @@ impl NostrConnectRemoteSigner {
                                     NostrConnectMessage::response(id, response);
 
                                 // Compose and publish event
-                                let event = EventBuilder::nostr_connect(
-                                    &self.keys.signer,
-                                    event.pubkey,
-                                    msg,
-                                )?
-                                .sign(&self.keys.signer)?;
+                                let event = NostrConnectEventBuilder::new(event.pubkey, msg)
+                                    .finalize(&self.keys.signer)?;
                                 self.client.send_event(&event).await?;
                             }
                         }

--- a/signer/nostr-connect/tests/nostr-connect.rs
+++ b/signer/nostr-connect/tests/nostr-connect.rs
@@ -4,7 +4,7 @@
 
 use std::time::Duration;
 
-use nostr::event::EventBuilder;
+use nostr::event::{EventBuilder, FinalizeEventAsync};
 use nostr::key::{Keys, PublicKey};
 use nostr::nips::nip46::{NostrConnectRequest, NostrConnectUri};
 use nostr::types::RelayUrl;
@@ -53,7 +53,7 @@ async fn test_bunker_uri(user_keys: Keys, relay_url: RelayUrl) {
     .unwrap();
 
     let event = EventBuilder::text_note("GM")
-        .sign_async(&nostr_connect_signer)
+        .finalize_async(&nostr_connect_signer)
         .await
         .unwrap();
 
@@ -91,7 +91,7 @@ async fn test_bunker_uri_no_secret(user_keys: Keys, relay_url: RelayUrl) {
     .unwrap();
 
     let event = EventBuilder::text_note("GM")
-        .sign_async(&nostr_connect_signer)
+        .finalize_async(&nostr_connect_signer)
         .await
         .unwrap();
 
@@ -124,7 +124,7 @@ async fn test_nostrconnect_uri(relay_url: RelayUrl, user_keys: Keys) {
         NostrConnect::new(connect_uri, app_keys, Duration::from_secs(5), None).unwrap();
 
     let event = EventBuilder::text_note("GM")
-        .sign_async(&nostr_connect_signer)
+        .finalize_async(&nostr_connect_signer)
         .await
         .unwrap();
 


### PR DESCRIPTION
### Description

Introduce event finalization traits. In addition, add some NIP-specific builders.

Partially addresses https://github.com/rust-nostr/nostr/issues/1328

### Notes to the reviewers

Other NIP-specific builders will be addresses in other PRs.

### Examples

New API for building gift wraps:

```rust
use nostr::prelude::*;

fn main() -> Result<(), Box<dyn core::error::Error>> {
    let receiver = PublicKey::from_hex("<receiver-public-key>")?;
    let rumor = UnsignedEvent::from_json("<rumor-json>")?;
    let signer = Keys::parse("<my-secret-key>")?;
    let gift_wrap: Event = EventBuilder::gift_wrap(receiver, rumor).finalize(&signer)?; // finalize_async for async signers
}
```

In case extra tags are needed:

```rust
let gift_wrap: Event = EventBuilder::gift_wrap(receiver, rumor).extra_tags([Tag::expiration(...)]).finalize(&signer)?;
```

New API for building a private direct message (NIP-17):

```rust
use nostr::prelude::*;

fn main() -> Result<(), Box<dyn core::error::Error>> {
    let receiver = PublicKey::from_hex("<receiver-public-key>")?;
    let signer = Keys::parse("<my-secret-key>")?;
    let gift_wrap: Event = EventBuilder::private_msg(receiver, "Hello, World!").finalize(&signer)?; // finalize_async for async signers
}
```

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [ ] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
