### PR TITLE
sdk: enhance `Output` and send event results

### DIFF
--- a/sdk/examples/gossip.rs
+++ b/sdk/examples/gossip.rs
@@ -42,7 +42,7 @@ async fn main() -> Result<()> {
     println!("Event ID: {}", output.to_bech32()?);
 
     println!("Sent to:");
-    for url in output.success.into_iter() {
+    for url in output.success.into_keys() {
         println!("- {url}");
     }
 

--- a/sdk/examples/subscriptions.rs
+++ b/sdk/examples/subscriptions.rs
@@ -25,7 +25,7 @@ async fn main() -> Result<()> {
         .since(Timestamp::now());
 
     // Subscribe (auto generate subscription ID)
-    let Output { val: sub_id_1, .. } = client.subscribe(subscription).await?;
+    let output = client.subscribe(subscription).await?;
 
     // Subscribe with custom ID
     let sub_id_2 = SubscriptionId::new("other-id");
@@ -40,7 +40,10 @@ async fn main() -> Result<()> {
         .author(public_key)
         .kind(Kind::EncryptedDirectMessage)
         .since(Timestamp::now());
-    client.subscribe(filter).with_id(sub_id_1.clone()).await?;
+    client
+        .subscribe(filter)
+        .with_id(output.id().clone())
+        .await?;
 
     let mut notifications = client.notifications();
 
@@ -52,7 +55,7 @@ async fn main() -> Result<()> {
         } = notification
         {
             // Check subscription ID
-            if subscription_id == sub_id_1 {
+            if &subscription_id == output.id() {
                 // Handle (ex. update specific UI)
             }
 

--- a/sdk/src/client/api/output.rs
+++ b/sdk/src/client/api/output.rs
@@ -2,81 +2,62 @@
 // Copyright (c) 2023-2025 Rust Nostr Developers
 // Distributed under the MIT software license
 
-use std::collections::{HashMap, HashSet};
-use std::fmt::Debug;
+use std::collections::HashMap;
 use std::ops::{Deref, DerefMut};
 
 use nostr::{EventId, RelayUrl, SubscriptionId};
 
 /// Output
-///
-/// Send or negentropy reconciliation output
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct Output<T>
-where
-    T: Debug,
-{
-    /// Value
-    pub val: T,
-    /// Set of relays that success
-    pub success: HashSet<RelayUrl>,
-    /// Map of relays that failed, with related errors.
-    pub failed: HashMap<RelayUrl, String>,
+pub struct Output<T, S = (), F = String> {
+    /// The output value
+    pub value: T,
+    /// Successful relays and their operation-specific output.
+    pub success: HashMap<RelayUrl, S>,
+    /// Map of relays that failed with related errors.
+    pub failed: HashMap<RelayUrl, F>,
 }
 
-impl<T> Deref for Output<T>
-where
-    T: Debug,
-{
+impl<T, S, F> Deref for Output<T, S, F> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
-        &self.val
+        &self.value
     }
 }
 
-impl<T> DerefMut for Output<T>
-where
-    T: Debug,
-{
+impl<T, S, F> DerefMut for Output<T, S, F> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.val
+        &mut self.value
     }
 }
 
-impl<T> Output<T>
-where
-    T: Debug,
-{
+impl<T, S, F> Output<T, S, F> {
     /// Create a new output
+    #[inline]
     #[must_use]
-    pub fn new(val: T) -> Self {
+    pub fn new(value: T) -> Self {
         Self {
-            val,
-            success: HashSet::new(),
+            value,
+            success: HashMap::new(),
             failed: HashMap::new(),
         }
     }
-
-    /// Get inner value
-    #[inline]
-    #[must_use]
-    pub fn into_inner(self) -> T {
-        self.val
-    }
 }
 
-impl Output<EventId> {
+impl<S, F> Output<EventId, S, F> {
     /// Get event ID
     #[inline]
+    #[must_use]
     pub fn id(&self) -> &EventId {
         self.deref()
     }
 }
 
-impl Output<SubscriptionId> {
+impl<S, F> Output<SubscriptionId, S, F> {
     /// Get subscription ID
     #[inline]
+    #[must_use]
     pub fn id(&self) -> &SubscriptionId {
         self.deref()
     }

--- a/sdk/src/client/api/send_event.rs
+++ b/sdk/src/client/api/send_event.rs
@@ -6,11 +6,13 @@ use std::time::Duration;
 use nostr::{Event, EventId, Kind, PublicKey, RelayUrl, RelayUrlArg};
 use nostr_gossip::{BestRelaySelection, GossipListKind};
 
-use super::output::Output;
 use crate::client::gossip::Gossip;
-use crate::client::{Client, Error};
+use crate::client::{Client, Error, Output};
 use crate::future::BoxedFuture;
-use crate::relay::RelayCapabilities;
+use crate::relay::{EventSendStatus, RelayCapabilities};
+
+/// Output returned when sending an event.
+pub type SendEventOutput = Output<EventId, EventSendStatus, String>;
 
 enum OverwritePolicy<'url> {
     // All WRITE relays
@@ -373,7 +375,7 @@ where
     'event: 'client,
     'url: 'client,
 {
-    type Output = Result<Output<EventId>, Error>;
+    type Output = Result<SendEventOutput, Error>;
     type IntoFuture = BoxedFuture<'client, Self::Output>;
 
     fn into_future(self) -> Self::IntoFuture {
@@ -477,11 +479,11 @@ mod tests {
         let output = client.send_event(&event).await.unwrap();
 
         assert_eq!(output.success.len(), 2);
-        assert!(output.success.contains(&url1));
-        assert!(output.success.contains(&url2));
-        assert!(!output.success.contains(&url3));
+        assert!(output.success.contains_key(&url1));
+        assert!(output.success.contains_key(&url2));
+        assert!(!output.success.contains_key(&url3));
         assert!(output.failed.is_empty());
-        assert_eq!(output.val, event.id);
+        assert_eq!(output.value, event.id);
     }
 
     #[tokio::test]
@@ -505,10 +507,10 @@ mod tests {
         let output = client.send_event(&event).to([&url1]).await.unwrap();
 
         assert_eq!(output.success.len(), 1);
-        assert!(output.success.contains(&url1));
-        assert!(!output.success.contains(&url2));
+        assert!(output.success.contains_key(&url1));
+        assert!(!output.success.contains_key(&url2));
         assert!(output.failed.is_empty());
-        assert_eq!(output.val, event.id);
+        assert_eq!(output.value, event.id);
     }
 
     #[tokio::test]
@@ -546,11 +548,11 @@ mod tests {
         let output = client.send_event(&event).broadcast().await.unwrap();
 
         assert_eq!(output.success.len(), 2);
-        assert!(output.success.contains(&url1));
-        assert!(output.success.contains(&url2));
-        assert!(!output.success.contains(&url3));
+        assert!(output.success.contains_key(&url1));
+        assert!(output.success.contains_key(&url2));
+        assert!(!output.success.contains_key(&url3));
         assert!(output.failed.is_empty());
-        assert_eq!(output.val, event.id);
+        assert_eq!(output.value, event.id);
     }
 
     #[tokio::test]
@@ -627,11 +629,11 @@ mod tests {
 
         // Verify output
         assert_eq!(output.success.len(), 2);
-        assert!(output.success.contains(&outbox_url));
-        assert!(output.success.contains(&public_url));
-        assert!(!output.success.contains(&discovery_url));
+        assert!(output.success.contains_key(&outbox_url));
+        assert!(output.success.contains_key(&public_url));
+        assert!(!output.success.contains_key(&discovery_url));
         assert!(output.failed.is_empty());
-        assert_eq!(output.val, event.id);
+        assert_eq!(output.value, event.id);
 
         // Verify the client now has the outbox relay in its pool with GOSSIP capability
         let outbox_relay = client.relay(&outbox_url).await.unwrap().unwrap();
@@ -715,11 +717,11 @@ mod tests {
 
         // Should be sent ONLY to Bob's discovered inbox
         assert_eq!(output.success.len(), 1);
-        assert!(output.success.contains(&inbox_url));
-        assert!(!output.success.contains(&public_url));
-        assert!(!output.success.contains(&discovery_url));
+        assert!(output.success.contains_key(&inbox_url));
+        assert!(!output.success.contains_key(&public_url));
+        assert!(!output.success.contains_key(&discovery_url));
         assert!(output.failed.is_empty());
-        assert_eq!(output.val, event.id);
+        assert_eq!(output.value, event.id);
 
         // Verify the client now has the outbox relay in its pool with GOSSIP capability
         let inbox_relay = client.relay(&inbox_url).await.unwrap().unwrap();

--- a/sdk/src/client/api/send_msg.rs
+++ b/sdk/src/client/api/send_msg.rs
@@ -146,9 +146,9 @@ mod tests {
         let output = client.send_msg(msg).await.unwrap();
 
         assert_eq!(output.success.len(), 2);
-        assert!(output.success.contains(&url1));
-        assert!(output.success.contains(&url2));
-        assert!(!output.success.contains(&url3));
+        assert!(output.success.contains_key(&url1));
+        assert!(output.success.contains_key(&url2));
+        assert!(!output.success.contains_key(&url3));
         assert!(output.failed.is_empty());
     }
 
@@ -170,8 +170,8 @@ mod tests {
         let output = client.send_msg(msg).to([&url1]).await.unwrap();
 
         assert_eq!(output.success.len(), 1);
-        assert!(output.success.contains(&url1));
-        assert!(!output.success.contains(&url2));
+        assert!(output.success.contains_key(&url1));
+        assert!(!output.success.contains_key(&url2));
         assert!(output.failed.is_empty());
     }
 }

--- a/sdk/src/client/mod.rs
+++ b/sdk/src/client/mod.rs
@@ -634,7 +634,7 @@ impl Client {
     ///
     /// // Send REQ
     /// let output = client.subscribe(filter).await?;
-    /// println!("Subscription ID: {}", output.val);
+    /// println!("Subscription ID: {}", output.id());
     /// println!("Successful relays: {:?}", output.success);
     /// println!("Failed relays: {:?}", output.failed);
     ///
@@ -675,7 +675,7 @@ impl Client {
     ///
     /// // Send REQ
     /// let output = client.subscribe(targets).await?;
-    /// println!("Subscription ID: {}", output.val);
+    /// println!("Subscription ID: {}", output.id());
     /// println!("Successful relays: {:?}", output.success);
     /// println!("Failed relays: {:?}", output.failed);
     ///
@@ -1169,7 +1169,7 @@ impl Client {
     /// - The event cannot be saved to the database,
     /// - Or sending cannot be initiated.
     ///
-    /// Relay-specific delivery failures are reported in the returned [`Output`].
+    /// Relay-specific delivery results are reported in the returned [`SendEventOutput`].
     #[inline]
     pub fn send_event<'event, 'url>(&self, event: &'event Event) -> SendEvent<'_, 'event, 'url> {
         SendEvent::new(self, event)
@@ -1189,7 +1189,7 @@ impl Client {
         &self,
         urls: I,
         event: &Event,
-    ) -> Result<Output<EventId>, Error>
+    ) -> Result<SendEventOutput, Error>
     where
         I: IntoIterator<Item = U>,
         U: Into<RelayUrlArg<'a>>,

--- a/sdk/src/pool/mod.rs
+++ b/sdk/src/pool/mod.rs
@@ -21,7 +21,7 @@ mod error;
 
 pub(crate) use self::builder::RelayPoolBuilder;
 pub(crate) use self::error::Error;
-use crate::client::{ClientNotification, InnerAckPolicy, Output, SyncSummary};
+use crate::client::{ClientNotification, InnerAckPolicy, Output, SendEventOutput, SyncSummary};
 use crate::monitor::Monitor;
 use crate::policy::AdmitStatus;
 use crate::relay::{
@@ -314,7 +314,7 @@ impl RelayPool {
         for (url, result) in urls.into_iter().zip(list) {
             match result {
                 Ok(..) => {
-                    output.success.insert(url);
+                    output.success.insert(url, ());
                 }
                 Err(e) => {
                     output.failed.insert(url, e.to_string());
@@ -468,7 +468,7 @@ impl RelayPool {
             match result {
                 Ok(()) => {
                     // Success, insert relay url in 'success' set result
-                    output.success.insert(url);
+                    output.success.insert(url, ());
                 }
                 Err(e) => {
                     output.failed.insert(url, e.to_string());
@@ -486,7 +486,7 @@ impl RelayPool {
         wait_policy: InnerAckPolicy,
         wait_for_ok_timeout: Duration,
         wait_for_authentication_timeout: Duration,
-    ) -> Result<Output<EventId>, Error>
+    ) -> Result<SendEventOutput, Error>
     where
         I: IntoIterator<Item = RelayUrl>,
     {
@@ -502,7 +502,7 @@ impl RelayPool {
         let relays = self.relays.read().await;
 
         let mut futures: FuturesUnordered<_> = FuturesUnordered::new();
-        let mut output: Output<EventId> = Output::new(event.id);
+        let mut output: SendEventOutput = Output::new(event.id);
 
         let wait_for_ok: bool = match wait_policy {
             InnerAckPolicy::All => true,
@@ -531,12 +531,14 @@ impl RelayPool {
 
         while let Some((url, result)) = futures.next().await {
             match result {
-                Ok(id) => {
+                Ok(relay_output) => {
+                    let (id, status) = relay_output.into_parts();
+
                     // The ID must match
                     assert_eq!(id, event.id);
 
                     // Success, insert relay url in 'success' set result
-                    output.success.insert(url);
+                    output.success.insert(url, status);
                 }
                 Err(e) => {
                     output.failed.insert(url, e.to_string());
@@ -598,7 +600,7 @@ impl RelayPool {
             match result {
                 Ok(..) => {
                     // Success, insert relay url in 'success' set result
-                    output.success.insert(url);
+                    output.success.insert(url, ());
                 }
                 Err(e) => {
                     output.failed.insert(url, e.to_string());
@@ -633,7 +635,7 @@ impl RelayPool {
             match result {
                 Ok(true) => {
                     // Success, insert relay url in 'success' set result
-                    output.success.insert(url.clone());
+                    output.success.insert(url.clone(), ());
                 }
                 // Subscription isn't found or auto-closing: do nothing
                 Ok(false) => {}
@@ -670,7 +672,7 @@ impl RelayPool {
             match result {
                 Ok(()) => {
                     // Success, insert relay url in 'success' set result
-                    output.success.insert(url);
+                    output.success.insert(url, ());
                 }
                 Err(e) => {
                     output.failed.insert(url, e.to_string());
@@ -723,7 +725,7 @@ impl RelayPool {
             match result {
                 Ok(reconciliation) => {
                     // Success, insert relay url in 'success' set result
-                    output.success.insert(url.clone());
+                    output.success.insert(url.clone(), ());
                     output.merge_relay_summary(url, reconciliation);
                 }
                 Err(e) => {

--- a/sdk/src/relay/api/send_event.rs
+++ b/sdk/src/relay/api/send_event.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 use std::future::IntoFuture;
+use std::ops::Deref;
 use std::time::Duration;
 
 use async_utility::time;
@@ -9,6 +10,108 @@ use tokio::sync::broadcast;
 
 use crate::future::BoxedFuture;
 use crate::relay::{Error, Relay, RelayNotification};
+
+/// Output returned when sending an event to a single relay.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RelaySendEventOutput {
+    event_id: EventId,
+    status: EventSendStatus,
+}
+
+impl RelaySendEventOutput {
+    #[inline]
+    fn new(event_id: EventId, status: EventSendStatus) -> Self {
+        Self { event_id, status }
+    }
+
+    /// Get the event ID.
+    #[inline]
+    #[must_use]
+    pub fn id(&self) -> &EventId {
+        &self.event_id
+    }
+
+    /// Get the per-relay send status.
+    #[inline]
+    #[must_use]
+    pub fn status(&self) -> &EventSendStatus {
+        &self.status
+    }
+
+    /// Split into event ID and per-relay send status.
+    #[inline]
+    #[must_use]
+    pub fn into_parts(self) -> (EventId, EventSendStatus) {
+        (self.event_id, self.status)
+    }
+}
+
+impl Deref for RelaySendEventOutput {
+    type Target = EventId;
+
+    fn deref(&self) -> &Self::Target {
+        &self.event_id
+    }
+}
+
+/// Per-relay success status for an event send operation.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum EventSendStatus {
+    /// The event was sent without waiting for a relay `OK` acknowledgement.
+    Sent,
+    /// The relay returned an `OK true` acknowledgement.
+    Ack(EventSendAcknowledgement),
+}
+
+/// Relay acknowledgement for a successful event send.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct EventSendAcknowledgement {
+    message: Option<String>,
+}
+
+impl EventSendAcknowledgement {
+    #[inline]
+    fn new(message: String) -> Self {
+        Self {
+            message: if message.is_empty() {
+                None
+            } else {
+                Some(message)
+            },
+        }
+    }
+
+    /// Return the relay `OK true` message, if available.
+    #[inline]
+    #[must_use]
+    pub fn message(&self) -> Option<&str> {
+        self.message.as_deref()
+    }
+}
+
+impl EventSendStatus {
+    #[inline]
+    fn ack(message: String) -> Self {
+        Self::Ack(EventSendAcknowledgement::new(message))
+    }
+
+    /// Return `true` if the relay returned an `OK true` acknowledgement.
+    #[inline]
+    #[must_use]
+    pub fn is_ack(&self) -> bool {
+        matches!(self, Self::Ack(..))
+    }
+
+    /// Return the relay `OK true` message, if available.
+    #[inline]
+    #[must_use]
+    pub fn message(&self) -> Option<&str> {
+        match self {
+            Self::Ack(ack) => ack.message(),
+            Self::Sent => None,
+        }
+    }
+}
 
 /// Send event to relay
 #[must_use = "Does nothing unless you await!"]
@@ -105,7 +208,7 @@ impl<'relay, 'event> IntoFuture for SendEvent<'relay, 'event>
 where
     'event: 'relay,
 {
-    type Output = Result<EventId, Error>;
+    type Output = Result<RelaySendEventOutput, Error>;
     type IntoFuture = BoxedFuture<'relay, Self::Output>;
 
     fn into_future(self) -> Self::IntoFuture {
@@ -120,7 +223,13 @@ where
 
             // Check status
             if status {
-                return Ok(self.event.id);
+                let status: EventSendStatus = if self.wait_for_ok {
+                    EventSendStatus::ack(message)
+                } else {
+                    EventSendStatus::Sent
+                };
+
+                return Ok(RelaySendEventOutput::new(self.event.id, status));
             }
 
             // If auth required, wait for authentication adn resend it
@@ -141,7 +250,10 @@ where
 
                     // Check status
                     return if status {
-                        Ok(self.event.id)
+                        Ok(RelaySendEventOutput::new(
+                            self.event.id,
+                            EventSendStatus::ack(message),
+                        ))
                     } else {
                         Err(Error::RelayMessage(message))
                     };
@@ -177,9 +289,47 @@ mod tests {
             .await
             .unwrap();
 
+        // Make an event
         let keys = Keys::generate();
         let event = EventBuilder::text_note("Test").sign(&keys).unwrap();
-        relay.send_event(&event).await.unwrap();
+
+        // Send the event
+        let output = relay.send_event(&event).await.unwrap();
+        assert_eq!(output.id(), &event.id);
+        assert!(output.status().is_ack());
+        assert_eq!(output.status().message(), None);
+
+        // Resend the same event
+        let output = relay.send_event(&event).await.unwrap();
+        assert_eq!(output.id(), &event.id);
+        assert!(output.status().is_ack());
+        assert_eq!(
+            output.status().message(),
+            Some("duplicate: already have this event")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_without_ok_msg() {
+        // Mock relay
+        let mock = MockRelay::run().await.unwrap();
+        let url = mock.url().await;
+
+        let relay: Relay = Relay::new(url);
+
+        relay
+            .try_connect()
+            .timeout(Duration::from_secs(3))
+            .await
+            .unwrap();
+
+        let keys = Keys::generate();
+        let event = EventBuilder::text_note("Test").sign(&keys).unwrap();
+        let output = relay.send_event(&event).wait_for_ok(false).await.unwrap();
+
+        assert_eq!(output.id(), &event.id);
+        assert_eq!(output.status(), &EventSendStatus::Sent);
+        assert_eq!(output.status().message(), None);
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Description

Refactor `Output` to carry typed relay success and failure details.

Send event results now include relay `OK true` messages.

Replaces https://github.com/rust-nostr/nostr/pull/1273
Replaces https://github.com/rust-nostr/nostr/pull/1274

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [ ] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
