### PR TITLE
backport "connect(fix): subscribe to notifications before sending connect response"

### DIFF
--- a/signer/nostr-connect/CHANGELOG.md
+++ b/signer/nostr-connect/CHANGELOG.md
@@ -23,6 +23,12 @@
 
 -->
 
+## Unreleased
+
+### Fixed
+
+- Fixed race condition in `NostrConnectRemoteSigner::serve()` where notifications subscription happened after sending connect response, potentially causing missed client messages (https://github.com/rust-nostr/nostr/pull/1353)
+
 ## v0.44.0 - 2025/11/06
 
 ### Fixed

--- a/signer/nostr-connect/src/signer.rs
+++ b/signer/nostr-connect/src/signer.rs
@@ -168,189 +168,173 @@ impl NostrConnectRemoteSigner {
     {
         self.bootstrap().await?;
 
-        // TODO: move into bootstrap method?
+        // Subscribe to notifications before sending the connect response
+        // to avoid missing any client messages that arrive immediately after.
+        let mut notifications = self.pool.notifications();
+
         if let Some(public_key) = self.nostr_connect_client_public_key {
             self.send_connect_ack(public_key).await?;
         }
 
-        self.pool
-            .handle_notifications(|notification| async {
-                if let RelayPoolNotification::Event { event, .. } = notification {
-                    if event.kind == Kind::NostrConnect {
-                        match nip44::decrypt(
-                            self.keys.signer.secret_key(),
-                            &event.pubkey,
-                            &event.content,
-                        ) {
-                            Ok(msg) => {
-                                tracing::debug!("New Nostr Connect message received: {msg}");
+        while let Ok(notification) = notifications.recv().await {
+            if notification == RelayPoolNotification::Shutdown {
+                break;
+            }
 
-                                let msg: NostrConnectMessage = NostrConnectMessage::from_json(msg)?;
-                                let id: String = msg.id().to_string();
+            if let RelayPoolNotification::Event { event, .. } = notification {
+                if event.kind == Kind::NostrConnect {
+                    match nip44::decrypt(
+                        self.keys.signer.secret_key(),
+                        &event.pubkey,
+                        &event.content,
+                    ) {
+                        Ok(msg) => {
+                            tracing::debug!("New Nostr Connect message received: {msg}");
 
-                                if let Ok(req) = msg.to_request() {
-                                    // Generate response
-                                    let response: NostrConnectResponse = if actions
-                                        .approve(&event.pubkey, &req)
-                                    {
-                                        match req {
-                                            NostrConnectRequest::Connect {
-                                                remote_signer_public_key,
-                                                secret,
-                                            } => {
-                                                if remote_signer_public_key
-                                                    == self.keys.signer.public_key
-                                                {
-                                                    if self.match_secret(secret) {
-                                                        NostrConnectResponse::with_result(
-                                                            ResponseResult::Ack,
-                                                        )
-                                                    } else {
-                                                        NostrConnectResponse::with_error(
-                                                            "Secret not match",
-                                                        )
-                                                    }
+                            let msg: NostrConnectMessage = NostrConnectMessage::from_json(msg)?;
+                            let id: String = msg.id().to_string();
+
+                            if let Ok(req) = msg.to_request() {
+                                // Generate response
+                                let response: NostrConnectResponse = if actions
+                                    .approve(&event.pubkey, &req)
+                                {
+                                    match req {
+                                        NostrConnectRequest::Connect {
+                                            remote_signer_public_key,
+                                            secret,
+                                        } => {
+                                            if remote_signer_public_key
+                                                == self.keys.signer.public_key
+                                            {
+                                                if self.match_secret(secret) {
+                                                    NostrConnectResponse::with_result(
+                                                        ResponseResult::Ack,
+                                                    )
                                                 } else {
                                                     NostrConnectResponse::with_error(
-                                                        "Remote signer public key not match",
+                                                        "Secret not match",
                                                     )
                                                 }
-                                            }
-                                            NostrConnectRequest::GetPublicKey => {
-                                                NostrConnectResponse::with_result(
-                                                    ResponseResult::GetPublicKey(
-                                                        self.keys.user.public_key(),
-                                                    ),
-                                                )
-                                            }
-                                            NostrConnectRequest::Nip04Encrypt {
-                                                public_key,
-                                                text,
-                                            } => {
-                                                match nip04::encrypt(
-                                                    self.keys.user.secret_key(),
-                                                    &public_key,
-                                                    text,
-                                                ) {
-                                                    Ok(ciphertext) => {
-                                                        NostrConnectResponse::with_result(
-                                                            ResponseResult::Nip04Encrypt {
-                                                                ciphertext,
-                                                            },
-                                                        )
-                                                    }
-                                                    Err(e) => NostrConnectResponse::with_error(
-                                                        e.to_string(),
-                                                    ),
-                                                }
-                                            }
-                                            NostrConnectRequest::Nip04Decrypt {
-                                                public_key,
-                                                ciphertext,
-                                            } => {
-                                                match nip04::decrypt(
-                                                    self.keys.user.secret_key(),
-                                                    &public_key,
-                                                    ciphertext,
-                                                ) {
-                                                    Ok(plaintext) => {
-                                                        NostrConnectResponse::with_result(
-                                                            ResponseResult::Nip04Decrypt {
-                                                                plaintext,
-                                                            },
-                                                        )
-                                                    }
-                                                    Err(e) => NostrConnectResponse::with_error(
-                                                        e.to_string(),
-                                                    ),
-                                                }
-                                            }
-                                            NostrConnectRequest::Nip44Encrypt {
-                                                public_key,
-                                                text,
-                                            } => {
-                                                match nip44::encrypt(
-                                                    self.keys.user.secret_key(),
-                                                    &public_key,
-                                                    text,
-                                                    nip44::Version::default(),
-                                                ) {
-                                                    Ok(ciphertext) => {
-                                                        NostrConnectResponse::with_result(
-                                                            ResponseResult::Nip44Encrypt {
-                                                                ciphertext,
-                                                            },
-                                                        )
-                                                    }
-                                                    Err(e) => NostrConnectResponse::with_error(
-                                                        e.to_string(),
-                                                    ),
-                                                }
-                                            }
-                                            NostrConnectRequest::Nip44Decrypt {
-                                                public_key,
-                                                ciphertext,
-                                            } => {
-                                                match nip44::decrypt(
-                                                    self.keys.user.secret_key(),
-                                                    &public_key,
-                                                    ciphertext,
-                                                ) {
-                                                    Ok(plaintext) => {
-                                                        NostrConnectResponse::with_result(
-                                                            ResponseResult::Nip44Decrypt {
-                                                                plaintext,
-                                                            },
-                                                        )
-                                                    }
-                                                    Err(e) => NostrConnectResponse::with_error(
-                                                        e.to_string(),
-                                                    ),
-                                                }
-                                            }
-                                            NostrConnectRequest::SignEvent(unsigned) => {
-                                                match unsigned.sign_with_keys(&self.keys.user) {
-                                                    Ok(event) => NostrConnectResponse::with_result(
-                                                        ResponseResult::SignEvent(Box::new(event)),
-                                                    ),
-                                                    Err(e) => NostrConnectResponse::with_error(
-                                                        e.to_string(),
-                                                    ),
-                                                }
-                                            }
-                                            NostrConnectRequest::Ping => {
-                                                NostrConnectResponse::with_result(
-                                                    ResponseResult::Pong,
+                                            } else {
+                                                NostrConnectResponse::with_error(
+                                                    "Remote signer public key not match",
                                                 )
                                             }
                                         }
-                                    } else {
-                                        NostrConnectResponse::with_error("Rejected")
-                                    };
+                                        NostrConnectRequest::GetPublicKey => {
+                                            NostrConnectResponse::with_result(
+                                                ResponseResult::GetPublicKey(
+                                                    self.keys.user.public_key(),
+                                                ),
+                                            )
+                                        }
+                                        NostrConnectRequest::Nip04Encrypt { public_key, text } => {
+                                            match nip04::encrypt(
+                                                self.keys.user.secret_key(),
+                                                &public_key,
+                                                text,
+                                            ) {
+                                                Ok(ciphertext) => {
+                                                    NostrConnectResponse::with_result(
+                                                        ResponseResult::Nip04Encrypt { ciphertext },
+                                                    )
+                                                }
+                                                Err(e) => {
+                                                    NostrConnectResponse::with_error(e.to_string())
+                                                }
+                                            }
+                                        }
+                                        NostrConnectRequest::Nip04Decrypt {
+                                            public_key,
+                                            ciphertext,
+                                        } => {
+                                            match nip04::decrypt(
+                                                self.keys.user.secret_key(),
+                                                &public_key,
+                                                ciphertext,
+                                            ) {
+                                                Ok(plaintext) => NostrConnectResponse::with_result(
+                                                    ResponseResult::Nip04Decrypt { plaintext },
+                                                ),
+                                                Err(e) => {
+                                                    NostrConnectResponse::with_error(e.to_string())
+                                                }
+                                            }
+                                        }
+                                        NostrConnectRequest::Nip44Encrypt { public_key, text } => {
+                                            match nip44::encrypt(
+                                                self.keys.user.secret_key(),
+                                                &public_key,
+                                                text,
+                                                nip44::Version::default(),
+                                            ) {
+                                                Ok(ciphertext) => {
+                                                    NostrConnectResponse::with_result(
+                                                        ResponseResult::Nip44Encrypt { ciphertext },
+                                                    )
+                                                }
+                                                Err(e) => {
+                                                    NostrConnectResponse::with_error(e.to_string())
+                                                }
+                                            }
+                                        }
+                                        NostrConnectRequest::Nip44Decrypt {
+                                            public_key,
+                                            ciphertext,
+                                        } => {
+                                            match nip44::decrypt(
+                                                self.keys.user.secret_key(),
+                                                &public_key,
+                                                ciphertext,
+                                            ) {
+                                                Ok(plaintext) => NostrConnectResponse::with_result(
+                                                    ResponseResult::Nip44Decrypt { plaintext },
+                                                ),
+                                                Err(e) => {
+                                                    NostrConnectResponse::with_error(e.to_string())
+                                                }
+                                            }
+                                        }
+                                        NostrConnectRequest::SignEvent(unsigned) => {
+                                            match unsigned.sign_with_keys(&self.keys.user) {
+                                                Ok(event) => NostrConnectResponse::with_result(
+                                                    ResponseResult::SignEvent(Box::new(event)),
+                                                ),
+                                                Err(e) => {
+                                                    NostrConnectResponse::with_error(e.to_string())
+                                                }
+                                            }
+                                        }
+                                        NostrConnectRequest::Ping => {
+                                            NostrConnectResponse::with_result(ResponseResult::Pong)
+                                        }
+                                    }
+                                } else {
+                                    NostrConnectResponse::with_error("Rejected")
+                                };
 
-                                    // Compose message
-                                    let msg: NostrConnectMessage =
-                                        NostrConnectMessage::response(id, response);
+                                // Compose message
+                                let msg: NostrConnectMessage =
+                                    NostrConnectMessage::response(id, response);
 
-                                    // Compose and publish event
-                                    let event = EventBuilder::nostr_connect(
-                                        &self.keys.signer,
-                                        event.pubkey,
-                                        msg,
-                                    )?
-                                    .sign_with_keys(&self.keys.signer)?;
-                                    self.pool.send_event(&event).await?;
-                                }
+                                // Compose and publish event
+                                let event = EventBuilder::nostr_connect(
+                                    &self.keys.signer,
+                                    event.pubkey,
+                                    msg,
+                                )?
+                                .sign_with_keys(&self.keys.signer)?;
+                                self.pool.send_event(&event).await?;
                             }
-                            Err(e) => {
-                                tracing::error!(error = %e, "Impossible to decrypt message.")
-                            }
+                        }
+                        Err(e) => {
+                            tracing::error!(error = %e, "Impossible to decrypt message.")
                         }
                     }
                 }
-                Ok(false) // Set to true to exit from the loop
-            })
-            .await?;
+            }
+        }
 
         Ok(())
     }


### PR DESCRIPTION
Prevents race condition where client messages arriving immediately after connect response could be missed

(cherry picked from commit 667e5277d8a240a8b9346713ba2c1ddaa3e7c454)


### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
