### PR TITLE
sdk: add an option to exit early for stream events API

### DIFF
--- a/sdk/examples/stream-events.rs
+++ b/sdk/examples/stream-events.rs
@@ -2,7 +2,7 @@
 // Copyright (c) 2023-2025 Rust Nostr Developers
 // Distributed under the MIT software license
 
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use nostr_sdk::prelude::*;
 
@@ -16,8 +16,9 @@ async fn main() -> Result<()> {
 
     client.connect().await;
 
+    let start = Instant::now();
     // Stream events from all connected relays
-    let filter = Filter::new().kind(Kind::TextNote).limit(100);
+    let filter = Filter::new().kind(Kind::TextNote).limit(1);
     let mut stream = client
         .stream_events(filter)
         .timeout(Duration::from_secs(15))
@@ -28,6 +29,31 @@ async fn main() -> Result<()> {
         let event = res?;
         println!("Received event from '{url}': {}", event.as_json());
     }
+    let duration = start.elapsed();
+    println!(
+        "stream with PoolExitPolicy::ExitOnAllResponses: {:?}",
+        duration
+    );
+
+    let start = Instant::now();
+    // Stream events from all connected relays
+    let filter = Filter::new().kind(Kind::TextNote).limit(1);
+    let mut stream = client
+        .stream_events(filter)
+        .timeout(Duration::from_secs(15))
+        .exit_early()
+        .policy(ReqExitPolicy::ExitOnEOSE)
+        .await?;
+
+    while let Some((url, res)) = stream.next().await {
+        let event = res?;
+        println!("Received event from '{url}': {}", event.as_json());
+    }
+    let duration = start.elapsed();
+    println!(
+        "stream with PoolExitPolicy::ExitOnFirstResponse: {:?}",
+        duration
+    );
 
     Ok(())
 }

--- a/sdk/examples/stream-events.rs
+++ b/sdk/examples/stream-events.rs
@@ -2,7 +2,7 @@
 // Copyright (c) 2023-2025 Rust Nostr Developers
 // Distributed under the MIT software license
 
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use nostr_sdk::prelude::*;
 
@@ -10,15 +10,24 @@ use nostr_sdk::prelude::*;
 async fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
 
+    let public_key =
+        PublicKey::parse("npub1zfss807aer0j26mwp2la0ume0jqde3823rmu97ra6sgyyg956e0s6xw445")?;
+
     let client = Client::default();
-    client.add_relay("wss://relay.damus.io").await?;
     client.add_relay("wss://nos.lol").await?;
+    client.add_relay("wss://user.kindpag.es").await?;
+    client.add_relay("wss://purplepag.es").await?;
+    client.add_relay("wss://relay.primal.net").await?;
+    client.add_relay("wss://relay.damus.io").await?;
 
     client.connect().await;
 
-    let start = Instant::now();
     // Stream events from all connected relays
-    let filter = Filter::new().kind(Kind::TextNote).limit(1);
+    let filter = Filter::new()
+        .author(public_key)
+        .kind(Kind::RelayList)
+        .limit(1);
+
     let mut stream = client
         .stream_events(filter)
         .timeout(Duration::from_secs(15))
@@ -27,33 +36,8 @@ async fn main() -> Result<()> {
 
     while let Some((url, res)) = stream.next().await {
         let event = res?;
-        println!("Received event from '{url}': {}", event.as_json());
+        println!("Received event from '{url}': {}", event.id);
     }
-    let duration = start.elapsed();
-    println!(
-        "stream with PoolExitPolicy::ExitOnAllResponses: {:?}",
-        duration
-    );
-
-    let start = Instant::now();
-    // Stream events from all connected relays
-    let filter = Filter::new().kind(Kind::TextNote).limit(1);
-    let mut stream = client
-        .stream_events(filter)
-        .timeout(Duration::from_secs(15))
-        .exit_early()
-        .policy(ReqExitPolicy::ExitOnEOSE)
-        .await?;
-
-    while let Some((url, res)) = stream.next().await {
-        let event = res?;
-        println!("Received event from '{url}': {}", event.as_json());
-    }
-    let duration = start.elapsed();
-    println!(
-        "stream with PoolExitPolicy::ExitOnFirstResponse: {:?}",
-        duration
-    );
 
     Ok(())
 }

--- a/sdk/src/client/api/stream_events.rs
+++ b/sdk/src/client/api/stream_events.rs
@@ -11,6 +11,7 @@ use super::req_target::ReqTarget;
 use super::util::build_targets;
 use crate::client::{Client, Error};
 use crate::future::BoxedFuture;
+use crate::pool::PoolExitPolicy;
 use crate::relay::{self, ReqExitPolicy};
 
 type EventStream = Pin<Box<dyn Stream<Item = (RelayUrl, Result<Event, relay::Error>)> + Send>>;
@@ -27,6 +28,7 @@ pub struct StreamEvents<'client, 'url> {
     target: ReqTarget<'url>,
     id: Option<SubscriptionId>,
     timeout: Option<Duration>,
+    pool_policy: Option<PoolExitPolicy>,
     policy: ReqExitPolicy,
 }
 
@@ -37,6 +39,7 @@ impl<'client, 'url> StreamEvents<'client, 'url> {
             target,
             id: None,
             timeout: None,
+            pool_policy: None,
             policy: ReqExitPolicy::ExitOnEOSE,
         }
     }
@@ -54,6 +57,13 @@ impl<'client, 'url> StreamEvents<'client, 'url> {
     #[inline]
     pub fn timeout(mut self, timeout: Duration) -> Self {
         self.timeout = Some(timeout);
+        self
+    }
+
+    /// Set pool exit policy to [`PoolExitPolicy::ExitOnFirstResponse`].
+    #[inline]
+    pub fn exit_early(mut self) -> Self {
+        self.pool_policy = Some(PoolExitPolicy::ExitOnFirstResponse);
         self
     }
 
@@ -82,7 +92,13 @@ where
             Ok(self
                 .client
                 .pool()
-                .stream_events(targets, self.id, self.timeout, self.policy)
+                .stream_events(
+                    targets,
+                    self.id,
+                    self.timeout,
+                    self.pool_policy,
+                    self.policy,
+                )
                 .await?)
         })
     }

--- a/sdk/src/client/gossip/updater.rs
+++ b/sdk/src/client/gossip/updater.rs
@@ -11,6 +11,7 @@ use super::{
     BrokenDownFilters, Gossip, GossipFilterPattern, GossipSemaphorePermit, find_filter_pattern,
 };
 use crate::client::{Client, Error, Output, SyncSummary};
+use crate::pool::PoolExitPolicy;
 use crate::relay::{RelayCapabilities, ReqExitPolicy, SyncDirection, SyncOptions};
 
 impl Client {
@@ -259,6 +260,7 @@ impl Client {
                     targets,
                     None,
                     Some(self.config().gossip_config.fetch_timeout),
+                    Some(PoolExitPolicy::ExitOnFirstResponse),
                     ReqExitPolicy::ExitOnEOSE,
                 )
                 .await?;
@@ -318,6 +320,7 @@ impl Client {
                 targets,
                 None,
                 Some(self.config().gossip_config.fetch_timeout),
+                Some(PoolExitPolicy::ExitOnFirstResponse),
                 ReqExitPolicy::ExitOnEOSE,
             )
             .await?;

--- a/sdk/src/pool/mod.rs
+++ b/sdk/src/pool/mod.rs
@@ -762,8 +762,8 @@ impl RelayPool {
         let id: SubscriptionId = id.unwrap_or_else(SubscriptionId::generate);
 
         // Shared state for deduplication and early exit.
-        let ids: Arc<Mutex<HashSet<EventId>>> = Arc::new(Mutex::new(HashSet::new()));
-        let exit_flag: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
+        let processed_events: Arc<Mutex<HashSet<EventId>>> = Arc::new(Mutex::new(HashSet::new()));
+        let should_exit: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
 
         // Lock with read shared access
         let relays = self.relays.read().await;
@@ -786,14 +786,15 @@ impl RelayPool {
             for (relay, filter) in relay_map {
                 let url = relay.url().clone();
                 let tx = tx.clone();
-                let ids = ids.clone();
-                let exit_flag = exit_flag.clone();
+
                 let id = id.clone();
+                let should_exit = should_exit.clone();
+                let processed_events = processed_events.clone();
 
                 let future = async move {
                     let stream = relay
                         .stream_events(filter)
-                        .with_id(id)
+                        .with_id(id.clone())
                         .maybe_timeout(timeout)
                         .policy(policy) // per‑relay policy, unchanged
                         .into_future()
@@ -805,7 +806,8 @@ impl RelayPool {
                         }
                         Ok(mut stream) => {
                             loop {
-                                if exit_flag.load(Ordering::SeqCst) {
+                                if should_exit.load(Ordering::SeqCst) {
+                                    let _ = relay.unsubscribe(&id).await;
                                     break;
                                 }
 
@@ -817,13 +819,14 @@ impl RelayPool {
                                         match res {
                                             Some(Ok(event)) => {
                                                 // Deduplicate across relays.
-                                                let mut id_set = ids.lock().await;
+                                                let mut ids = processed_events.lock().await;
 
-                                                if id_set.insert(event.id) {
-                                                    drop(id_set);
+                                                if ids.insert(event.id) {
+                                                    drop(ids);
 
+                                                    // Exit on first response if configured.
                                                     if pool_policy.exit_on_first_response() {
-                                                        exit_flag.store(true, Ordering::SeqCst);
+                                                        should_exit.store(true, Ordering::SeqCst);
                                                     }
 
                                                     if tx.send((url.clone(), Ok(event))).await.is_err() {
@@ -856,10 +859,8 @@ impl RelayPool {
                     break;
                 }
                 tokio::select! {
-                    _ = tx.closed() => {
-                        break;
-                    }
-                    Some(_) = futures.next() => {}
+                    Some(_) = futures.next() => {},
+                    _ = tx.closed() => break,
                 }
             }
 

--- a/sdk/src/pool/mod.rs
+++ b/sdk/src/pool/mod.rs
@@ -1,14 +1,12 @@
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::future::{Future, IntoFuture};
-use std::iter::Zip;
 use std::mem;
 use std::num::NonZeroUsize;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
-use std::vec::IntoIter;
 
 use async_utility::task;
 use futures::stream::FuturesUnordered;
@@ -18,6 +16,9 @@ use tokio::sync::{Mutex, RwLock, broadcast, mpsc};
 
 mod builder;
 mod error;
+mod policy;
+
+pub(crate) use policy::PoolExitPolicy;
 
 pub(crate) use self::builder::RelayPoolBuilder;
 pub(crate) use self::error::Error;
@@ -742,6 +743,7 @@ impl RelayPool {
         filters: HashMap<RelayUrl, Vec<Filter>>,
         id: Option<SubscriptionId>,
         timeout: Option<Duration>,
+        pool_policy: Option<PoolExitPolicy>,
         policy: ReqExitPolicy,
     ) -> Result<EventStream, Error> {
         // Check if `targets` map is empty
@@ -749,18 +751,23 @@ impl RelayPool {
             return Err(Error::NoRelaysSpecified);
         }
 
-        // Lock with read shared access
-        let relays = self.relays.read().await;
+        // Define the pool exit policy
+        let pool_policy = pool_policy.unwrap_or_default();
 
         // Create a new channel
         // NOTE: the events are deduplicated and the send method awaits, so a huge capacity isn't necessary.
         let (tx, rx) = mpsc::channel(1024);
 
-        let mut urls: Vec<RelayUrl> = Vec::with_capacity(filters.len());
-        let mut futures = Vec::with_capacity(filters.len());
-
         // Get or generate a subscription ID
         let id: SubscriptionId = id.unwrap_or_else(SubscriptionId::generate);
+
+        // Shared state for deduplication and early exit.
+        let ids: Arc<Mutex<HashSet<EventId>>> = Arc::new(Mutex::new(HashSet::new()));
+        let exit_flag: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
+
+        // Lock with read shared access
+        let relays = self.relays.read().await;
+        let mut relay_map: Vec<(Relay, Vec<Filter>)> = vec![];
 
         for (url, filter) in filters {
             // Try to get the relay
@@ -768,106 +775,98 @@ impl RelayPool {
                 .get(&url)
                 .ok_or_else(|| Error::RelayNotFound(url.clone()))?;
 
-            // Push url
-            urls.push(url);
-
-            // Push stream events future
-            futures.push(
-                relay
-                    .stream_events(filter)
-                    .with_id(id.clone())
-                    .maybe_timeout(timeout)
-                    .policy(policy)
-                    .into_future(),
-            );
+            relay_map.push((relay.clone(), filter));
         }
 
-        // Wait that futures complete
-        let awaited = future::join_all(futures).await;
+        drop(relays);
 
-        // The urls and futures len MUST be the same!
-        assert_eq!(urls.len(), awaited.len());
-
-        // Zip-up urls and futures into a single iterator
-        let streams: Zip<IntoIter<RelayUrl>, IntoIter<Result<_, _>>> =
-            urls.into_iter().zip(awaited);
-
-        // Single driver task: polls all streams, de-duplicates, forwards
         task::spawn(async move {
-            #[cfg(not(target_arch = "wasm32"))]
-            type OutFuture = Pin<Box<dyn Future<Output = ()> + Send>>;
-            #[cfg(target_arch = "wasm32")]
-            type OutFuture = Pin<Box<dyn Future<Output = ()>>>;
+            let mut futures = FuturesUnordered::<Pin<Box<dyn Future<Output = ()> + Send>>>::new();
 
-            // IDs collection, needed to check if an event was already sent to the stream
-            let ids: Arc<Mutex<HashSet<EventId>>> = Arc::new(Mutex::new(HashSet::new()));
-
-            let mut futures: Vec<OutFuture> = Vec::with_capacity(streams.len());
-
-            for (url, res) in streams.into_iter() {
+            for (relay, filter) in relay_map {
+                let url = relay.url().clone();
                 let tx = tx.clone();
+                let ids = ids.clone();
+                let exit_flag = exit_flag.clone();
+                let id = id.clone();
 
-                let future: OutFuture = match res {
-                    // Streaming available
-                    Ok(mut stream) => {
-                        let ids = ids.clone();
+                let future = async move {
+                    let stream = relay
+                        .stream_events(filter)
+                        .with_id(id)
+                        .maybe_timeout(timeout)
+                        .policy(policy) // per‑relay policy, unchanged
+                        .into_future()
+                        .await;
 
-                        Box::pin(async move {
-                            // Start handling stream items
+                    match stream {
+                        Err(e) => {
+                            let _ = tx.send((url.clone(), Err(e))).await;
+                        }
+                        Ok(mut stream) => {
                             loop {
+                                if exit_flag.load(Ordering::SeqCst) {
+                                    break;
+                                }
+
                                 tokio::select! {
-                                    // The received dropped, we should terminate the stream
-                                    _ = tx.closed() => break,
-                                    // Handle stream item
+                                    _ = tx.closed() => {
+                                        break;
+                                    }
                                     res = stream.next() => {
                                         match res {
                                             Some(Ok(event)) => {
-                                                let mut ids = ids.lock().await;
+                                                // Deduplicate across relays.
+                                                let mut id_set = ids.lock().await;
 
-                                                // Check if ID was already seen or insert into set.
-                                                if ids.insert(event.id) {
-                                                    // Immediately drop the set
-                                                    drop(ids);
+                                                if id_set.insert(event.id) {
+                                                    drop(id_set);
 
-                                                    // Send event
+                                                    if pool_policy.exit_on_first_response() {
+                                                        exit_flag.store(true, Ordering::SeqCst);
+                                                    }
+
                                                     if tx.send((url.clone(), Ok(event))).await.is_err() {
                                                         break;
                                                     }
                                                 }
                                             }
                                             Some(Err(e)) => {
-                                                // Send error
+                                                // Relay returned an error.
                                                 if tx.send((url.clone(), Err(e))).await.is_err() {
                                                     break;
                                                 }
                                             }
-                                            None => break,
+                                            None => {
+                                                break;
+                                            }
                                         }
                                     }
                                 }
                             }
-                        })
-                    }
-                    // No streaming available
-                    Err(e) => {
-                        Box::pin(async move {
-                            // Send error
-                            let _ = tx.send((url, Err(e))).await;
-                        })
+                        }
                     }
                 };
 
-                futures.push(future);
+                futures.push(Box::pin(future));
             }
 
-            // Wait that all futures complete
-            future::join_all(futures).await;
+            loop {
+                if futures.is_empty() {
+                    break;
+                }
+                tokio::select! {
+                    _ = tx.closed() => {
+                        break;
+                    }
+                    Some(_) = futures.next() => {}
+                }
+            }
 
-            // Close the channel
             drop(tx);
         });
 
-        // Return stream
+        // Return the live event stream immediately.
         Ok(Box::pin(ReceiverStream::new(rx)))
     }
 }

--- a/sdk/src/pool/mod.rs
+++ b/sdk/src/pool/mod.rs
@@ -782,6 +782,7 @@ impl RelayPool {
 
         task::spawn(async move {
             let mut futures = FuturesUnordered::<Pin<Box<dyn Future<Output = ()> + Send>>>::new();
+            println!("Policy: {pool_policy:?}");
 
             for (relay, filter) in relay_map {
                 let url = relay.url().clone();
@@ -806,20 +807,22 @@ impl RelayPool {
                         }
                         Ok(mut stream) => {
                             loop {
-                                if should_exit.load(Ordering::SeqCst) {
-                                    let _ = relay.unsubscribe(&id).await;
-                                    break;
-                                }
-
                                 tokio::select! {
                                     _ = tx.closed() => {
                                         break;
                                     }
                                     res = stream.next() => {
+                                        if should_exit.load(Ordering::SeqCst) {
+                                            let _ = relay.unsubscribe(&id).await;
+                                            break;
+                                        }
+
                                         match res {
                                             Some(Ok(event)) => {
                                                 // Deduplicate across relays.
                                                 let mut ids = processed_events.lock().await;
+
+                                                println!("From '{url}': {}", event.id);
 
                                                 if ids.insert(event.id) {
                                                     drop(ids);

--- a/sdk/src/pool/policy.rs
+++ b/sdk/src/pool/policy.rs
@@ -10,8 +10,4 @@ impl PoolExitPolicy {
     pub fn exit_on_first_response(&self) -> bool {
         matches!(self, PoolExitPolicy::ExitOnFirstResponse)
     }
-
-    pub fn exit_on_all_responses(&self) -> bool {
-        matches!(self, PoolExitPolicy::ExitOnAllResponses)
-    }
 }

--- a/sdk/src/pool/policy.rs
+++ b/sdk/src/pool/policy.rs
@@ -1,0 +1,17 @@
+/// Pool exit policy
+#[derive(Debug, Clone, Copy, Default)]
+pub enum PoolExitPolicy {
+    ExitOnFirstResponse,
+    #[default]
+    ExitOnAllResponses,
+}
+
+impl PoolExitPolicy {
+    pub fn exit_on_first_response(&self) -> bool {
+        matches!(self, PoolExitPolicy::ExitOnFirstResponse)
+    }
+
+    pub fn exit_on_all_responses(&self) -> bool {
+        matches!(self, PoolExitPolicy::ExitOnAllResponses)
+    }
+}


### PR DESCRIPTION
Before:
```
Policy: ExitOnAllResponses
Timestamp NOW: 1779249554
[Pool] from 'wss://relay.damus.io': 10a257125d6fd9cc63eb5f133e2400061aad26a9e8d764e43ac412199d906895 at 1779249555
[Example] received event from 'wss://relay.damus.io': 10a257125d6fd9cc63eb5f133e2400061aad26a9e8d764e43ac412199d906895
[Pool] from 'wss://user.kindpag.es': 10a257125d6fd9cc63eb5f133e2400061aad26a9e8d764e43ac412199d906895 at 1779249555
[Pool] from 'wss://nos.lol': 10a257125d6fd9cc63eb5f133e2400061aad26a9e8d764e43ac412199d906895 at 1779249555
[Pool] from 'wss://purplepag.es': 10a257125d6fd9cc63eb5f133e2400061aad26a9e8d764e43ac412199d906895 at 1779249555
```

After:
```
Policy: ExitOnFirstResponse
Timestamp NOW: 1779249537
[Pool] from 'wss://relay.damus.io': 10a257125d6fd9cc63eb5f133e2400061aad26a9e8d764e43ac412199d906895 at 1779249538
[Pool] unsubscribe 'wss://relay.damus.io'
[Example] received event from 'wss://relay.damus.io': 10a257125d6fd9cc63eb5f133e2400061aad26a9e8d764e43ac412199d906895
[Pool] unsubscribe 'wss://relay.primal.net'
[Pool] unsubscribe 'wss://nos.lol'
[Pool] unsubscribe 'wss://user.kindpag.es'
[Pool] unsubscribe 'wss://purplepag.es'
```