### PR TITLE
sdk: avoid caching failed gossip lookups

### DIFF
--- a/sdk/src/client/api/stream_events.rs
+++ b/sdk/src/client/api/stream_events.rs
@@ -3,7 +3,7 @@ use std::future::IntoFuture;
 use std::pin::Pin;
 use std::time::Duration;
 
-use futures::Stream;
+use futures::{Stream, StreamExt};
 use nostr::types::url::RelayUrl;
 use nostr::{Event, Filter, SubscriptionId};
 
@@ -11,7 +11,7 @@ use super::req_target::ReqTarget;
 use super::util::build_targets;
 use crate::client::{Client, Error};
 use crate::future::BoxedFuture;
-use crate::relay::{self, ReqExitPolicy};
+use crate::relay::{self, RelayStreamEvent, ReqExitPolicy};
 
 type EventStream = Pin<Box<dyn Stream<Item = (RelayUrl, Result<Event, relay::Error>)> + Send>>;
 
@@ -78,12 +78,20 @@ where
             let targets: HashMap<RelayUrl, Vec<Filter>> =
                 build_targets(self.client, self.target).await?;
 
-            // Stream
-            Ok(self
+            // Make the stream
+            let stream = self
                 .client
                 .pool()
                 .stream_events(targets, self.id, self.timeout, self.policy)
-                .await?)
+                .await?;
+
+            Ok(Box::pin(stream.filter_map(|(url, item)| async move {
+                match item {
+                    RelayStreamEvent::Event(event) => Some((url, Ok(event))),
+                    RelayStreamEvent::Error(error) => Some((url, Err(error))),
+                    RelayStreamEvent::Completed => None,
+                }
+            })) as EventStream)
         })
     }
 }

--- a/sdk/src/client/gossip/updater.rs
+++ b/sdk/src/client/gossip/updater.rs
@@ -11,7 +11,9 @@ use super::{
     BrokenDownFilters, Gossip, GossipFilterPattern, GossipSemaphorePermit, find_filter_pattern,
 };
 use crate::client::{Client, Error, Output, SyncSummary};
-use crate::relay::{RelayCapabilities, ReqExitPolicy, SyncDirection, SyncOptions};
+use crate::relay::{
+    RelayCapabilities, RelayStreamEvent, ReqExitPolicy, SyncDirection, SyncOptions,
+};
 
 impl Client {
     async fn compute_gossip_update_candidates(
@@ -114,7 +116,11 @@ impl Client {
             missing_public_keys.remove(&event.pubkey);
         }
 
-        if !output.failed.is_empty() {
+        let has_success: bool = !output.success.is_empty();
+        let has_failed: bool = !output.failed.is_empty();
+
+        // At least one negentropy sync failed, so try a standard REQ fallback for those relays.
+        if has_failed {
             tracing::debug!(
                 sync_id,
                 relays = ?output.failed,
@@ -131,6 +137,7 @@ impl Client {
             )
             .await?;
 
+            // There are still missing public keys to update.
             if !missing_public_keys.is_empty() {
                 self.fetch_missing_gossip_lists_from_failed_relays(
                     sync_id,
@@ -141,7 +148,9 @@ impl Client {
                 )
                 .await?;
             }
-        } else if !missing_public_keys.is_empty() {
+        } else if !missing_public_keys.is_empty() && has_success {
+            // Mark the missing gossip public keys as checked only if we have at least one successful sync.
+            // A total failure, such as missing network, MUST NOT block retries until the TTL expires!
             self.mark_gossip_public_keys_checked(gossip.store(), gossip_kinds, missing_public_keys)
                 .await?;
         }
@@ -265,16 +274,17 @@ impl Client {
 
             while let Some((url, event)) = stream.next().await {
                 match event {
-                    Ok(event) => {
+                    RelayStreamEvent::Event(event) => {
                         for gossip_kind in gossip_kinds {
                             gossip
                                 .update_fetch_attempt(&event.pubkey, *gossip_kind)
                                 .await?;
                         }
                     }
-                    Err(e) => {
+                    RelayStreamEvent::Error(e) => {
                         tracing::error!(%url, error = %e, "Failed to fetch outdated gossip data from relay.");
                     }
+                    RelayStreamEvent::Completed => {}
                 }
             }
         }
@@ -322,11 +332,25 @@ impl Client {
             )
             .await?;
 
-        #[allow(clippy::redundant_pattern_matching)]
-        while let Some(..) = stream.next().await {}
+        let mut completed_fetch: bool = false;
 
-        self.mark_gossip_public_keys_checked(gossip, gossip_kinds, missing_public_keys)
-            .await?;
+        while let Some((url, event)) = stream.next().await {
+            match event {
+                RelayStreamEvent::Event(..) | RelayStreamEvent::Completed => {
+                    completed_fetch = true;
+                }
+                RelayStreamEvent::Error(e) => {
+                    tracing::error!(%url, error = %e, "Failed to fetch missing gossip data from relay.");
+                }
+            }
+        }
+
+        // Mark the missing gossip public keys as checked only if we have at least one successful fetch.
+        // A total failure, such as missing network, MUST NOT block retries until the TTL expires!
+        if completed_fetch {
+            self.mark_gossip_public_keys_checked(gossip, gossip_kinds, missing_public_keys)
+                .await?;
+        }
 
         Ok(())
     }
@@ -471,9 +495,57 @@ impl Client {
 
 #[cfg(test)]
 mod tests {
-    use nostr_gossip_memory::prelude::NostrGossipMemory;
+    use nostr_gossip_memory::prelude::*;
+    use nostr_relay_builder::prelude::*;
 
     use super::*;
+    use crate::client::GossipConfig;
+
+    fn client_with_gossip() -> Client {
+        let gossip = NostrGossipMemory::unbounded();
+        let config = GossipConfig::default()
+            .sync_initial_timeout(Duration::from_nanos(1))
+            .sync_idle_timeout(Duration::from_secs(1))
+            .fetch_timeout(Duration::from_secs(2))
+            .no_background_refresh();
+
+        Client::builder()
+            .gossip(gossip)
+            .gossip_config(config)
+            .build()
+    }
+
+    async fn assert_nip65_status(
+        client: &Client,
+        public_key: PublicKey,
+        expected_status: GossipPublicKeyStatus,
+    ) {
+        let status: GossipPublicKeyStatus = client
+            .gossip()
+            .unwrap()
+            .store()
+            .status(&public_key, GossipListKind::Nip65)
+            .await
+            .unwrap();
+
+        assert_eq!(status, expected_status);
+    }
+
+    async fn sync_nip65(client: &Client, public_key: PublicKey) {
+        let gossip = client.gossip().unwrap();
+
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            client.sync_gossip_public_keys(
+                gossip,
+                BTreeSet::from([public_key]),
+                &[GossipListKind::Nip65],
+            ),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    }
 
     #[tokio::test]
     async fn test_mark_missing_gossip_key_as_updated() {
@@ -501,5 +573,69 @@ mod tests {
             .await
             .unwrap();
         assert!(matches!(status, GossipPublicKeyStatus::Updated));
+    }
+
+    #[tokio::test]
+    async fn test_marks_missing_gossip_key_checked_when_all_fallback_relays_active() {
+        let mock1 = MockRelay::run().await.unwrap();
+        let url1 = mock1.url().await;
+        let mock2 = MockRelay::run().await.unwrap();
+        let url2 = mock2.url().await;
+
+        let client = client_with_gossip();
+        client.add_relay(&url1).await.unwrap();
+        client.add_relay(&url2).await.unwrap();
+
+        let connect_output = client.try_connect().timeout(Duration::from_secs(3)).await;
+        assert_eq!(connect_output.success.len(), 2);
+        assert!(connect_output.failed.is_empty());
+
+        let public_key = Keys::generate().public_key();
+        assert_nip65_status(&client, public_key, GossipPublicKeyStatus::Missing).await;
+
+        sync_nip65(&client, public_key).await;
+
+        assert_nip65_status(&client, public_key, GossipPublicKeyStatus::Updated).await;
+    }
+
+    #[tokio::test]
+    async fn test_marks_missing_gossip_key_checked_when_some_fallback_relays_active() {
+        let mock1 = MockRelay::run().await.unwrap();
+        let url1 = mock1.url().await;
+
+        let inactive1 = RelayUrl::parse("ws://inactive1-fake.myfakedomain.local").unwrap();
+
+        let client = client_with_gossip();
+        client.add_relay(&url1).await.unwrap();
+        client.add_relay(&inactive1).await.unwrap();
+
+        let connect_output = client.try_connect().timeout(Duration::from_secs(3)).await;
+        assert_eq!(connect_output.success.len(), 1);
+        assert_eq!(connect_output.failed.len(), 1);
+
+        let public_key = Keys::generate().public_key();
+        assert_nip65_status(&client, public_key, GossipPublicKeyStatus::Missing).await;
+
+        sync_nip65(&client, public_key).await;
+
+        assert_nip65_status(&client, public_key, GossipPublicKeyStatus::Updated).await;
+    }
+
+    #[tokio::test]
+    async fn test_keeps_missing_gossip_key_unchecked_when_all_fallback_relays_inactive() {
+        let inactive1 = RelayUrl::parse("wss://inactive1.example.com").unwrap();
+        let inactive2 = RelayUrl::parse("wss://inactive2.example.com").unwrap();
+
+        let client = client_with_gossip();
+        client.add_relay(&inactive1).await.unwrap();
+        client.add_relay(&inactive2).await.unwrap();
+
+        let public_key = Keys::generate().public_key();
+        assert_nip65_status(&client, public_key, GossipPublicKeyStatus::Missing).await;
+
+        sync_nip65(&client, public_key).await;
+
+        // All relays are inactive, so the key should still be missing.
+        assert_nip65_status(&client, public_key, GossipPublicKeyStatus::Missing).await;
     }
 }

--- a/sdk/src/pool/mod.rs
+++ b/sdk/src/pool/mod.rs
@@ -12,7 +12,7 @@ use std::vec::IntoIter;
 
 use async_utility::task;
 use futures::stream::FuturesUnordered;
-use futures::{Stream, StreamExt, future};
+use futures::{StreamExt, future};
 use nostr_database::prelude::*;
 use tokio::sync::{Mutex, RwLock, broadcast, mpsc};
 
@@ -25,14 +25,13 @@ use crate::client::{ClientNotification, InnerAckPolicy, Output, SendEventOutput,
 use crate::monitor::Monitor;
 use crate::policy::AdmitStatus;
 use crate::relay::{
-    self, AtomicRelayCapabilities, Relay, RelayCapabilities, RelayOptions, ReqExitPolicy,
-    SubscribeAutoCloseOptions, SyncOptions,
+    AtomicRelayCapabilities, Relay, RelayCapabilities, RelayOptions, RelayStreamEvent,
+    ReqExitPolicy, SubscribeAutoCloseOptions, SyncOptions,
 };
 use crate::shared::SharedState;
 use crate::stream::ReceiverStream;
 
 pub(super) type Relays = HashMap<RelayUrl, Relay>;
-type EventStream = Pin<Box<dyn Stream<Item = (RelayUrl, Result<Event, relay::Error>)> + Send>>;
 
 // IMPORTANT: we rely on the Drop trait for shutting down the pool,
 // so it's important that the RelayPool can't be cloned, otherwise may cause a non-expected shutdown.
@@ -744,7 +743,7 @@ impl RelayPool {
         id: Option<SubscriptionId>,
         timeout: Option<Duration>,
         policy: ReqExitPolicy,
-    ) -> Result<EventStream, Error> {
+    ) -> Result<ReceiverStream<(RelayUrl, RelayStreamEvent)>, Error> {
         // Check if `targets` map is empty
         if filters.is_empty() {
             return Err(Error::NoRelaysSpecified);
@@ -779,7 +778,7 @@ impl RelayPool {
                     .with_id(id.clone())
                     .maybe_timeout(timeout)
                     .policy(policy)
-                    .into_future(),
+                    .into_relay_event_stream(),
             );
         }
 
@@ -822,7 +821,7 @@ impl RelayPool {
                                     // Handle stream item
                                     res = stream.next() => {
                                         match res {
-                                            Some(Ok(event)) => {
+                                            Some(RelayStreamEvent::Event(event)) => {
                                                 let mut ids = ids.lock().await;
 
                                                 // Check if ID was already seen or insert into set.
@@ -831,16 +830,22 @@ impl RelayPool {
                                                     drop(ids);
 
                                                     // Send event
-                                                    if tx.send((url.clone(), Ok(event))).await.is_err() {
+                                                    if tx.send((url.clone(), RelayStreamEvent::Event(event))).await.is_err() {
                                                         break;
                                                     }
                                                 }
                                             }
-                                            Some(Err(e)) => {
+                                            Some(RelayStreamEvent::Error(e)) => {
                                                 // Send error
-                                                if tx.send((url.clone(), Err(e))).await.is_err() {
+                                                if tx.send((url.clone(), RelayStreamEvent::Error(e))).await.is_err() {
                                                     break;
                                                 }
+                                            }
+                                            Some(RelayStreamEvent::Completed) => {
+                                                if tx.send((url.clone(), RelayStreamEvent::Completed)).await.is_err() {
+                                                    break;
+                                                }
+                                                break;
                                             }
                                             None => break,
                                         }
@@ -853,7 +858,7 @@ impl RelayPool {
                     Err(e) => {
                         Box::pin(async move {
                             // Send error
-                            let _ = tx.send((url, Err(e))).await;
+                            let _ = tx.send((url, RelayStreamEvent::Error(e))).await;
                         })
                     }
                 };
@@ -869,7 +874,7 @@ impl RelayPool {
         });
 
         // Return stream
-        Ok(Box::pin(ReceiverStream::new(rx)))
+        Ok(ReceiverStream::new(rx))
     }
 }
 

--- a/sdk/src/relay/api/stream_events.rs
+++ b/sdk/src/relay/api/stream_events.rs
@@ -3,7 +3,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::Duration;
 
-use futures::Stream;
+use futures::{Stream, StreamExt};
 use nostr::{Event, Filter, SubscriptionId};
 use tokio::sync::{mpsc, oneshot};
 
@@ -15,6 +15,12 @@ use crate::relay::{
 };
 
 type EventStream = Pin<Box<dyn Stream<Item = Result<Event, Error>> + Send>>;
+
+pub(crate) enum RelayStreamEvent {
+    Event(Event),
+    Error(Error),
+    Completed,
+}
 
 /// Stream events
 #[must_use = "Does nothing unless you await!"]
@@ -65,6 +71,35 @@ impl<'relay> StreamEvents<'relay> {
         self.policy = policy;
         self
     }
+
+    pub(crate) async fn into_relay_event_stream(
+        self,
+    ) -> Result<SubscriptionActivityEventStream, Error> {
+        // Create channels
+        let (tx, rx) = mpsc::channel(512);
+
+        // Compose auto-closing options
+        let opts: SubscribeAutoCloseOptions = SubscribeAutoCloseOptions::default()
+            .exit_policy(self.policy)
+            .timeout(self.timeout);
+
+        // Get or generate a subscription ID
+        let id: SubscriptionId = self.id.unwrap_or_else(SubscriptionId::generate);
+
+        // Subscribe
+        let (cancel_tx, cancel_rx) = oneshot::channel();
+        subscribe_auto_closing(
+            self.relay,
+            id,
+            self.filters,
+            opts,
+            Some(tx),
+            Some(cancel_rx),
+        )
+        .await?;
+
+        Ok(SubscriptionActivityEventStream::new(rx, cancel_tx))
+    }
 }
 
 impl<'relay> IntoFuture for StreamEvents<'relay> {
@@ -73,35 +108,18 @@ impl<'relay> IntoFuture for StreamEvents<'relay> {
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(async move {
-            // Create channels
-            let (tx, rx) = mpsc::channel(512);
+            let stream = self.into_relay_event_stream().await?;
 
-            // Compose auto-closing options
-            let opts: SubscribeAutoCloseOptions = SubscribeAutoCloseOptions::default()
-                .exit_policy(self.policy)
-                .timeout(self.timeout);
-
-            // Get or generate a subscription ID
-            let id: SubscriptionId = self.id.unwrap_or_else(SubscriptionId::generate);
-
-            // Subscribe
-            let (cancel_tx, cancel_rx) = oneshot::channel();
-            subscribe_auto_closing(
-                self.relay,
-                id,
-                self.filters,
-                opts,
-                Some(tx),
-                Some(cancel_rx),
-            )
-            .await?;
-
-            Ok(Box::pin(SubscriptionActivityEventStream::new(rx, cancel_tx)) as EventStream)
+            Ok(Box::pin(stream.filter_map(async |e| match e {
+                RelayStreamEvent::Event(event) => Some(Ok(event)),
+                RelayStreamEvent::Error(e) => Some(Err(e)),
+                RelayStreamEvent::Completed => None,
+            })) as EventStream)
         })
     }
 }
 
-struct SubscriptionActivityEventStream {
+pub(crate) struct SubscriptionActivityEventStream {
     rx: mpsc::Receiver<SubscriptionActivity>,
     done: bool,
     cancel: Option<oneshot::Sender<()>>,
@@ -126,7 +144,7 @@ impl Drop for SubscriptionActivityEventStream {
 }
 
 impl Stream for SubscriptionActivityEventStream {
-    type Item = Result<Event, Error>;
+    type Item = RelayStreamEvent;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         if self.done {
@@ -135,19 +153,21 @@ impl Stream for SubscriptionActivityEventStream {
 
         match Pin::new(&mut self.rx).poll_recv(cx) {
             Poll::Ready(Some(activity)) => match activity {
-                SubscriptionActivity::ReceivedEvent(event) => Poll::Ready(Some(Ok(event))),
+                SubscriptionActivity::ReceivedEvent(event) => {
+                    Poll::Ready(Some(RelayStreamEvent::Event(event)))
+                }
                 SubscriptionActivity::Closed(reason) => match reason {
                     SubscriptionAutoClosedReason::AuthenticationFailed => {
                         self.done = true;
-                        Poll::Ready(Some(Err(Error::AuthenticationFailed)))
+                        Poll::Ready(Some(RelayStreamEvent::Error(Error::AuthenticationFailed)))
                     }
                     SubscriptionAutoClosedReason::Closed(message) => {
                         self.done = true;
-                        Poll::Ready(Some(Err(Error::RelayMessage(message))))
+                        Poll::Ready(Some(RelayStreamEvent::Error(Error::RelayMessage(message))))
                     }
                     SubscriptionAutoClosedReason::Completed => {
                         self.done = true;
-                        Poll::Ready(None)
+                        Poll::Ready(Some(RelayStreamEvent::Completed))
                     }
                 },
             },


### PR DESCRIPTION
### Description

Do not mark missing gossip public keys as checked when every relay operation fails. A total sync/fetch failure, such as missing network access, must not poison the gossip store and delay retries until the fetch-attempt TTL expires.

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [ ] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
