### PR TITLE
Keys drop

### DIFF
--- a/crates/nostr/src/key/mod.rs
+++ b/crates/nostr/src/key/mod.rs
@@ -265,6 +265,16 @@ impl FromStr for Keys {
     }
 }
 
+impl Drop for Keys {
+    #[inline]
+    fn drop(&mut self) {
+        // Erase the keypair.
+        //
+        // NOTE: we already erase the secret key in 'impl Drop for SecretKey'.
+        self.keypair.non_secure_erase();
+    }
+}
+
 impl GetPublicKey for Keys {
     type Error = Infallible;
 

--- a/crates/nostr/src/key/mod.rs
+++ b/crates/nostr/src/key/mod.rs
@@ -209,12 +209,6 @@ impl Keys {
         &self.secret_key
     }
 
-    /// Get keypair
-    #[inline]
-    pub fn keypair(&self) -> &Keypair {
-        &self.keypair
-    }
-
     /// Creates a schnorr signature of the [`Message`].
     ///
     /// This method uses a random number generator that retrieves randomness from the operating system (see [`SysRng`]).


### PR DESCRIPTION
### Description

Erase the keypair in `Keys` on `Drop`.

Closes https://github.com/rust-nostr/nostr/issues/1378

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [ ] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
