### PR TITLE
nostr: add NIP-40 expiration to gift wrap and private DM builders

### DIFF
--- a/crates/nostr/CHANGELOG.md
+++ b/crates/nostr/CHANGELOG.md
@@ -89,6 +89,7 @@
 - Add `restricted_writes`, `default_limit` to `Limitation` (https://github.com/rust-nostr/nostr/pull/1336)
 - Add NIP-66 kinds and relay discovery tags (https://github.com/rust-nostr/nostr/pull/1346)
 - Add `Filter::tag` to add a generic single-letter tag from an already-constructed `Tag` (https://github.com/rust-nostr/nostr/issues/1359)
+- Add `GiftWrapBuilder::expiration` and `PrivateDirectMessageBuilder::expiration` to set a NIP-40 expiration relative to the gift wrap's `created_at` (https://github.com/rust-nostr/nostr/pull/1384)
 
 ### Removed
 

--- a/crates/nostr/src/nips/nip17.rs
+++ b/crates/nostr/src/nips/nip17.rs
@@ -11,6 +11,7 @@
 use alloc::string::{String, ToString};
 use alloc::vec;
 use alloc::vec::Vec;
+use core::time::Duration;
 
 #[cfg(all(feature = "std", feature = "os-rng", feature = "nip59"))]
 use super::nip44::{AsyncNip44, Nip44};
@@ -61,6 +62,8 @@ pub struct PrivateDirectMessageBuilder {
     pub rumor_extra_tags: Vec<Tag>,
     /// Extra tags to add to the **gift wrap** event.
     pub extra_tags: Vec<Tag>,
+    /// NIP-40 expiration for the **gift wrap**, relative to `created_at`.
+    pub expiration: Option<Duration>,
 }
 
 // TODO: should this be under the required features, like for the Finalize traits?
@@ -76,6 +79,7 @@ impl PrivateDirectMessageBuilder {
             message: message.into(),
             rumor_extra_tags: Vec::new(),
             extra_tags: Vec::new(),
+            expiration: None,
         }
     }
 
@@ -98,6 +102,18 @@ impl PrivateDirectMessageBuilder {
         self.extra_tags.extend(tags);
         self
     }
+
+    /// Set a NIP-40 expiration on the **gift wrap**.
+    ///
+    /// The expiration tag is relative to the gift wrap's `created_at`
+    /// so it doesn't leak the real send time.
+    /// Choose a `duration` greater than the 2 days
+    /// or the event may be created in an expired state.
+    #[inline]
+    pub fn expiration(mut self, duration: Duration) -> Self {
+        self.expiration = Some(duration);
+        self
+    }
 }
 
 #[cfg(all(feature = "std", feature = "os-rng", feature = "nip59"))]
@@ -115,9 +131,11 @@ where
             self.message,
             self.rumor_extra_tags,
         );
-        GiftWrapBuilder::new(self.receiver, rumor)
-            .extra_tags(self.extra_tags)
-            .finalize(signer)
+        let mut builder = GiftWrapBuilder::new(self.receiver, rumor).extra_tags(self.extra_tags);
+        if let Some(duration) = self.expiration {
+            builder = builder.expiration(duration);
+        }
+        builder.finalize(signer)
     }
 }
 
@@ -142,10 +160,12 @@ where
                 self.message,
                 self.rumor_extra_tags,
             );
-            GiftWrapBuilder::new(self.receiver, rumor)
-                .extra_tags(self.extra_tags)
-                .finalize_async(signer)
-                .await
+            let mut builder =
+                GiftWrapBuilder::new(self.receiver, rumor).extra_tags(self.extra_tags);
+            if let Some(duration) = self.expiration {
+                builder = builder.expiration(duration);
+            }
+            builder.finalize_async(signer).await
         })
     }
 }
@@ -255,5 +275,75 @@ mod tests {
         let tag = vec!["relay"];
         let err = Nip17Tag::parse(&tag).unwrap_err();
         assert_eq!(err.kind(), ErrorKind::Missing);
+    }
+}
+
+#[cfg(test)]
+#[cfg(all(feature = "std", feature = "os-rng", feature = "nip59"))]
+mod expiration_tests {
+    use core::time::Duration;
+
+    use super::*;
+    use crate::key::Keys;
+    use crate::nips::nip59::extract_rumor;
+
+    #[test]
+    fn test_private_dm_expiration_on_gift_wrap() {
+        let sender = Keys::generate();
+        let receiver = Keys::generate();
+        let duration: Duration = Duration::from_secs(7 * 24 * 3600);
+
+        let gift_wrap: Event = PrivateDirectMessageBuilder::new(receiver.public_key(), "hello")
+            .expiration(duration)
+            .finalize(&sender)
+            .unwrap();
+
+        assert_eq!(gift_wrap.kind, Kind::GiftWrap);
+
+        // Anchored to the gift wrap's tweaked `created_at`: no send-time leak.
+        let expiration = gift_wrap.tags.expiration().expect("missing expiration tag");
+        assert_eq!(
+            expiration.as_secs() - gift_wrap.created_at.as_secs(),
+            duration.as_secs()
+        );
+
+        // The DM still unwraps and the sender is verified.
+        let unwrapped = extract_rumor(&receiver, &gift_wrap).unwrap();
+        assert_eq!(unwrapped.sender, sender.public_key());
+        assert_eq!(unwrapped.rumor.kind, Kind::PrivateDirectMessage);
+
+        // Decision: expiration goes on the gift wrap only, not the inner rumor.
+        assert!(unwrapped.rumor.tags.expiration().is_none());
+    }
+
+    #[test]
+    fn test_private_dm_without_expiration() {
+        let sender = Keys::generate();
+        let receiver = Keys::generate();
+
+        let gift_wrap: Event = PrivateDirectMessageBuilder::new(receiver.public_key(), "hello")
+            .finalize(&sender)
+            .unwrap();
+
+        assert!(gift_wrap.tags.expiration().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_private_dm_expiration_async() {
+        let sender = Keys::generate();
+        let receiver = Keys::generate();
+        let duration: Duration = Duration::from_secs(7 * 24 * 3600);
+
+        let gift_wrap: Event = PrivateDirectMessageBuilder::new(receiver.public_key(), "hello")
+            .expiration(duration)
+            .finalize_async(&sender)
+            .await
+            .unwrap();
+
+        let expiration = gift_wrap.tags.expiration().expect("missing expiration tag");
+        assert_eq!(
+            expiration.as_secs() - gift_wrap.created_at.as_secs(),
+            duration.as_secs()
+        );
     }
 }

--- a/crates/nostr/src/nips/nip59.rs
+++ b/crates/nostr/src/nips/nip59.rs
@@ -12,6 +12,7 @@ use alloc::string::String;
 use alloc::vec::Vec;
 #[cfg(all(feature = "std", feature = "os-rng"))]
 use core::ops::Range;
+use core::time::Duration;
 
 use secp256k1::{Secp256k1, Verification};
 
@@ -247,6 +248,8 @@ pub struct GiftWrapBuilder {
     pub rumor: UnsignedEvent,
     /// Extra tags to add to the event
     pub extra_tags: Vec<Tag>,
+    /// NIP-40 expiration, relative to the gift wrap's `created_at`
+    pub expiration: Option<Duration>,
 }
 
 impl GiftWrapBuilder {
@@ -257,6 +260,7 @@ impl GiftWrapBuilder {
             receiver,
             rumor,
             extra_tags: Vec::new(),
+            expiration: None,
         }
     }
 
@@ -267,6 +271,18 @@ impl GiftWrapBuilder {
         T: IntoIterator<Item = Tag>,
     {
         self.extra_tags.extend(tags);
+        self
+    }
+
+    /// Set a NIP-40 expiration on the gift wrap.
+    ///
+    /// The expiration tag is anchored to the gift wrap's randomized `created_at`
+    /// so it doesn't leak the real send time.
+    /// `duration` should be greater than 2 days
+    /// or it may created in an expired state.
+    #[inline]
+    pub fn expiration(mut self, duration: Duration) -> Self {
+        self.expiration = Some(duration);
         self
     }
 }
@@ -280,7 +296,7 @@ where
 
     fn finalize(self, signer: &S) -> Result<Event, Self::Error> {
         let seal: Event = GiftWrapSealBuilder::new(self.rumor, self.receiver).finalize(signer)?;
-        make_gift_wrap(seal, self.receiver, self.extra_tags)
+        make_gift_wrap(seal, self.receiver, self.extra_tags, self.expiration)
     }
 }
 
@@ -300,13 +316,18 @@ where
             let seal: Event = GiftWrapSealBuilder::new(self.rumor, self.receiver)
                 .finalize_async(signer)
                 .await?;
-            make_gift_wrap(seal, self.receiver, self.extra_tags)
+            make_gift_wrap(seal, self.receiver, self.extra_tags, self.expiration)
         })
     }
 }
 
 #[cfg(all(feature = "std", feature = "os-rng"))]
-fn make_gift_wrap(seal: Event, receiver: PublicKey, extra_tags: Vec<Tag>) -> Result<Event, Error> {
+fn make_gift_wrap(
+    seal: Event,
+    receiver: PublicKey,
+    extra_tags: Vec<Tag>,
+    expiration: Option<Duration>,
+) -> Result<Event, Error> {
     // Generate the random keys
     let keys: Keys = Keys::generate();
 
@@ -325,10 +346,19 @@ fn make_gift_wrap(seal: Event, receiver: PublicKey, extra_tags: Vec<Tag>) -> Res
     // Push received public key
     tags.push(Tag::public_key(receiver));
 
-    // Build the event with a tweaked timestamp
+    // Use a tweaked timestamp to thwart time-analysis attacks
+    let created_at: Timestamp = Timestamp::tweaked(RANGE_RANDOM_TIMESTAMP_TWEAK);
+
+    // Anchor the NIP-40 expiration to the tweaked `created_at` so we don't
+    // leak the real creation time.
+    // `expiration - created_at` stays constant.
+    if let Some(duration) = expiration {
+        tags.push(Tag::expiration(created_at + duration));
+    }
+
     EventBuilder::new(Kind::GiftWrap, content)
         .tags(tags)
-        .custom_created_at(Timestamp::tweaked(RANGE_RANDOM_TIMESTAMP_TWEAK))
+        .custom_created_at(created_at)
         .finalize(&keys)
 }
 
@@ -511,6 +541,77 @@ mod tests {
                 .unwrap_err()
                 .kind(),
             sender_mismatch().kind()
+        );
+    }
+
+    #[test]
+    fn test_gift_wrap_expiration_anchored_to_created_at() {
+        let sender_keys =
+            Keys::parse("6b911fd37cdf5c81d4c0adb1ab7fa822ed253ab0ad9aa18d77257c88b29b718e")
+                .unwrap();
+        let receiver_keys =
+            Keys::parse("7b911fd37cdf5c81d4c0adb1ab7fa822ed253ab0ad9aa18d77257c88b29b718e")
+                .unwrap();
+
+        let duration: Duration = Duration::from_secs(7 * 24 * 3600);
+        let rumor: UnsignedEvent =
+            EventBuilder::text_note("Test").finalize_unsigned(sender_keys.public_key);
+        let event: Event = GiftWrapBuilder::new(receiver_keys.public_key(), rumor)
+            .expiration(duration)
+            .finalize(&sender_keys)
+            .unwrap();
+
+        assert_eq!(event.kind, Kind::GiftWrap);
+
+        // The expiration is anchored to the (tweaked) `created_at`, so the
+        // difference is exactly the requested duration and leaks no send time.
+        let expiration = event.tags.expiration().expect("missing expiration tag");
+        assert_eq!(
+            expiration.as_secs() - event.created_at.as_secs(),
+            duration.as_secs()
+        );
+    }
+
+    #[test]
+    fn test_gift_wrap_without_expiration() {
+        let sender_keys =
+            Keys::parse("6b911fd37cdf5c81d4c0adb1ab7fa822ed253ab0ad9aa18d77257c88b29b718e")
+                .unwrap();
+        let receiver_keys =
+            Keys::parse("7b911fd37cdf5c81d4c0adb1ab7fa822ed253ab0ad9aa18d77257c88b29b718e")
+                .unwrap();
+
+        let rumor: UnsignedEvent =
+            EventBuilder::text_note("Test").finalize_unsigned(sender_keys.public_key);
+        let event: Event = GiftWrapBuilder::new(receiver_keys.public_key(), rumor)
+            .finalize(&sender_keys)
+            .unwrap();
+
+        assert!(event.tags.expiration().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_gift_wrap_expiration_anchored_to_created_at_async() {
+        let sender_keys =
+            Keys::parse("6b911fd37cdf5c81d4c0adb1ab7fa822ed253ab0ad9aa18d77257c88b29b718e")
+                .unwrap();
+        let receiver_keys =
+            Keys::parse("7b911fd37cdf5c81d4c0adb1ab7fa822ed253ab0ad9aa18d77257c88b29b718e")
+                .unwrap();
+
+        let duration: Duration = Duration::from_secs(7 * 24 * 3600);
+        let rumor: UnsignedEvent =
+            EventBuilder::text_note("Test").finalize_unsigned(sender_keys.public_key);
+        let event: Event = GiftWrapBuilder::new(receiver_keys.public_key(), rumor)
+            .expiration(duration)
+            .finalize_async(&sender_keys)
+            .await
+            .unwrap();
+
+        let expiration = event.tags.expiration().expect("missing expiration tag");
+        assert_eq!(
+            expiration.as_secs() - event.created_at.as_secs(),
+            duration.as_secs()
         );
     }
 }


### PR DESCRIPTION
### Description

Add an expiration option to GiftWrapBuilder and PrivateDirectMessageBuilder. The NIP-40 expiration tag is anchored to the gift wrap's randomized created_at (created_at + duration) instead of the real send time, so it doesn't leak when the message was actually sent.

Closes #1381

### Notes to the reviewers

One design decision:
expiration is a builder method taking a Duration rather than something you pass through extra_tags.
It has to be anchored to the gift wrap's created_at, which is randomized internally and not exposed to the caller.

Setting an absolute timestamp from outside would leak the real send time (subtract the duration and you've got it).

So by setting Duration, the library does created_at + duration and nothing leaks.

NIP-17 just hands the same value down to the gift wrap builder. The tag goes on the gift wrap, not the kind:13 seal, which NIP-59 requires to be empty.

### Checklist

- [x] I followed the [contribution guidelines](https://github.com/rust-nostr/nostr/blob/master/CONTRIBUTING.md)
- [x] I updated the [CHANGELOG](https://github.com/rust-nostr/nostr/blob/master/CHANGELOG.md) (if applicable)
- [x] I personally wrote and understood all code in this PR
