### PR TITLE
contrib(just): add recipe for generating differential coverage reports

### DIFF
--- a/justfile
+++ b/justfile
@@ -47,6 +47,47 @@ coverage package='none':
     @echo
     @echo 'open {{ justfile_directory() }}/target/llvm-cov/html/index.html'
 
+# Generate an HTML diff‑coverage report for the current branch (compared to master).
+# Requires: cargo-llvm-cov, diff-cover, Git.
+# Examples:
+#   just diff-coverage                         # full workspace
+#   just diff-coverage package=my-crate        # single crate
+#   just diff-coverage features="feat1,feat2"  # with features
+diff-coverage package='none' features='none':
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    BRANCH=$(git rev-parse --abbrev-ref HEAD)
+    if [[ "$BRANCH" == "master" ]]; then
+        echo "Error: This recipe cannot run on the master branch." >&2
+        exit 1
+    fi
+
+    cargo llvm-cov clean --workspace
+
+    # Pick workspace or package
+    if [[ "{{ package }}" == "none" ]]; then
+        PKG="--workspace"
+    else
+        PKG="--package {{ package }}"
+    fi
+
+    # Only add --features if needed
+    FEAT=""
+    if [[ "{{ features }}" != "none" ]]; then
+        FEAT="--features {{ features }}"
+    fi
+
+    cargo llvm-cov --cobertura $PKG $FEAT --output-path coverage.xml
+
+    mkdir -p "{{ justfile_directory() }}/target/diff-cover/"
+    diff-cover coverage.xml \
+        --compare-branch master \
+        --format "html:{{ justfile_directory() }}/target/diff-cover/report.html"
+
+    rm coverage.xml
+    echo "Report: file://{{ justfile_directory() }}/target/diff-cover/report.html"
+
 # Run benches (unstable)
 bench:
     RUSTFLAGS='--cfg=bench' cargo +nightly bench


### PR DESCRIPTION
### Description

A just recipe to generate a differential coverage report highlighting untested code in your changes.

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/nostrdevkit/nostr/blob/master/CONTRIBUTING.md)
- [ ] I updated the [CHANGELOG](https://github.com/nostrdevkit/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
