### PR TITLE
sdk(local_relay): support event kind blacklisting

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -97,6 +97,7 @@
 - Add `AdmitPolicy::admit_relay` (https://github.com/nostrdevkit/nostr/pull/1339)
 - Add `Proxy` with global, onion-only and custom relay proxy policies (https://github.com/nostrdevkit/nostr/pull/1351)
 - Add `Authenticator` and `SignerAuthenticator` for NIP-42 relay authentication (https://github.com/nostrdevkit/nostr/pull/1340)
+- local_relay: support event kind blacklisting via `LocalRelayBuilder::blacklist_kinds` (https://github.com/nostrdevkit/nostr/pull/1401)
 
 ### Fixed
 

--- a/sdk/src/local_relay/builder.rs
+++ b/sdk/src/local_relay/builder.rs
@@ -3,6 +3,7 @@
 // Distributed under the MIT software license
 
 use std::borrow::Cow;
+use std::collections::HashSet;
 use std::fmt;
 use std::future::Future;
 use std::net::{IpAddr, SocketAddr};
@@ -277,6 +278,8 @@ pub struct LocalRelayBuilder {
     pub(crate) auth_dm: bool,
     /// Min POW difficulty
     pub(crate) min_pow: Option<u8>,
+    /// Kinds blacklist
+    pub(crate) kinds_blacklist: HashSet<Kind>,
     /// Write policy
     pub(crate) write_policy: Option<Arc<dyn WritePolicy>>,
     /// Query policy
@@ -287,6 +290,16 @@ pub struct LocalRelayBuilder {
 
 impl Default for LocalRelayBuilder {
     fn default() -> Self {
+        // The list of kinds originates from a commit message by Alex Gleason:
+        // <https://gitlab.com/soapbox-pub/ditto-relay/-/commit/ddce82c040e78cc37d3a56b8a7f0448daddf3df2>
+        const BLACKLISTED_KINDS: [Kind; 5] = [
+            Kind::Seal,           // Only valid inside a gift-wrap event; meaningless on its own.
+            Kind::ZapRequest,     // Sent directly to the LNURL callback server, never to relays.
+            Kind::Authentication, // Carried exclusively inside `["AUTH", ...]` frames.
+            Kind::BlossomAuth, // An HTTP Authorization header artifact, not an independent event.
+            Kind::HttpAuth,    // An HTTP Authorization header artifact, not an independent event.
+        ];
+
         Self {
             addr: None,
             port: None,
@@ -300,6 +313,7 @@ impl Default for LocalRelayBuilder {
             default_filter_limit: 500,
             auth_dm: false,
             min_pow: None,
+            kinds_blacklist: HashSet::from(BLACKLISTED_KINDS),
             write_policy: None,
             query_policy: None,
             test: LocalRelayTestOptions::default(),
@@ -398,6 +412,13 @@ impl LocalRelayBuilder {
         if difficulty > 0 {
             self.min_pow = Some(difficulty);
         }
+        self
+    }
+
+    /// Reject events matching the given kinds
+    #[inline]
+    pub fn blacklist_kinds(mut self, kinds: &[Kind]) -> Self {
+        self.kinds_blacklist.extend(kinds);
         self
     }
 

--- a/sdk/src/local_relay/local/inner.rs
+++ b/sdk/src/local_relay/local/inner.rs
@@ -3,7 +3,7 @@
 // Distributed under the MIT software license
 
 use std::borrow::Cow;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::num::NonZeroUsize;
 use std::sync::Arc;
@@ -50,6 +50,7 @@ pub(super) struct InnerLocalRelay {
     default_filter_limit: usize,
     auth_dm: bool,
     min_pow: Option<u8>, // TODO: use AtomicU8 to allow to change it?
+    kinds_blacklist: HashSet<Kind>,
     write_policy: Option<Arc<dyn WritePolicy>>,
     query_policy: Option<Arc<dyn QueryPolicy>>,
     nip42: Option<LocalRelayBuilderNip42>,
@@ -93,6 +94,7 @@ impl InnerLocalRelay {
             default_filter_limit: builder.default_filter_limit,
             auth_dm: builder.auth_dm,
             min_pow: builder.min_pow,
+            kinds_blacklist: builder.kinds_blacklist,
             write_policy: builder.write_policy,
             query_policy: builder.query_policy,
             nip42: builder.nip42,
@@ -380,6 +382,23 @@ impl InnerLocalRelay {
                             message: Cow::Owned(format!(
                                 "{}: slow down",
                                 MachineReadablePrefix::RateLimited
+                            )),
+                        },
+                    )
+                    .await;
+                }
+
+                // Reject the event if it's a blacklisted kind
+                if self.kinds_blacklist.contains(&event.kind) {
+                    return send_msg(
+                        ws_tx,
+                        RelayMessage::Ok {
+                            event_id: event.id,
+                            status: false,
+                            message: Cow::Owned(format!(
+                                "{}: kind `{}` is not accepted by this relay",
+                                MachineReadablePrefix::Blocked,
+                                event.kind.as_u16()
                             )),
                         },
                     )

--- a/sdk/src/local_relay/mod.rs
+++ b/sdk/src/local_relay/mod.rs
@@ -17,7 +17,7 @@ mod tests {
     use std::future::Future;
     use std::pin::Pin;
 
-    use nostr::event::{EventBuilder, FinalizeEvent, Tag};
+    use nostr::event::{EventBuilder, FinalizeEvent, Kind, Tag};
     use nostr::filter::Filter;
     use nostr::key::Keys;
     use nostr_memory::MemoryDatabase;
@@ -85,5 +85,30 @@ mod tests {
                 .all(|e| { e.tags.hashtags().all(|hashtag| hashtag == UPDATE_TAG) }),
             "All tags should have the updated filter tag"
         );
+    }
+
+    #[tokio::test]
+    async fn kind_blacklist() {
+        let relay = LocalRelay::builder()
+            .database(MemoryDatabase::unbounded())
+            .blacklist_kinds(&[Kind::TextNote])
+            .build();
+        relay.run().await.unwrap();
+
+        let keys = Keys::generate();
+        let client = Client::default();
+
+        client
+            .add_relay(relay.url().await)
+            .and_connect()
+            .await
+            .unwrap();
+        let event = EventBuilder::text_note(":)").finalize(&keys).unwrap();
+        let output = client.send_event(&event).await.unwrap();
+
+        assert_eq!(
+            "blocked: kind `1` is not accepted by this relay",
+            output.failed.values().next().unwrap()
+        )
     }
 }


### PR DESCRIPTION
Blacklist the following kinds:
- `Kind::Seal` (only valid inside gift-wrap events)
- `Kind::ZapRequest` (sent directly to the LNURL callback server)
- `Kind::Authentication` (carried exclusively in AUTH frames)
- `Kind::BlossomAuth` (HTTP Authorization header artifact)
- `Kind::HttpAuth` (HTTP Authorization header artifact)

The user can blacklist kinds using `LocalRelayBuilder::blacklist_kinds`

Refs: https://github.com/nostr-protocol/nips/pull/2399

### Notes to the reviewers

is prefixing the change log with `local_relay: ` right?

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/nostrdevkit/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the [CHANGELOG](https://github.com/nostrdevkit/nostr/blob/master/CHANGELOG.md) (if applicable)
- [X] I personally wrote and understood all code in this PR
