### PR TITLE
fix: relay negentropy sync panic on wasm

### DIFF
--- a/sdk/src/relay/api/sync.rs
+++ b/sdk/src/relay/api/sync.rs
@@ -2,12 +2,12 @@ use std::borrow::Cow;
 use std::cmp;
 use std::collections::{HashMap, HashSet};
 use std::future::IntoFuture;
-use std::time::Instant;
 
 use async_utility::time;
 use negentropy::{Id, Negentropy, NegentropyStorageVector};
 use nostr::{ClientMessage, EventId, Filter, RelayMessage, SubscriptionId, Timestamp};
 use tokio::sync::broadcast;
+use universal_time::Instant;
 
 use crate::error::Error;
 use crate::future::BoxedFuture;


### PR DESCRIPTION
### Description

Currently, the negentropy sync is using `Instant` from `std::time` which will cause panic on wasm enviroment. Solution: migrate to `universal_time`

### Notes to the reviewers

### Checklist

- [x] I followed the [contribution guidelines](https://github.com/nostrdevkit/nostr/blob/master/CONTRIBUTING.md)
- [x] I updated the [CHANGELOG](https://github.com/nostrdevkit/nostr/blob/master/CHANGELOG.md) (if applicable)
- [x] I personally wrote and understood all code in this PR
