### PR TITLE
nostr: zeroize NIP49 secret intermediates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2696,6 +2696,7 @@ dependencies = [
  "unicode-normalization",
  "url",
  "url-fork",
+ "zeroize",
 ]
 
 [[package]]

--- a/crates/nostr/CHANGELOG.md
+++ b/crates/nostr/CHANGELOG.md
@@ -23,6 +23,12 @@
 
 -->
 
+## Unreleased
+
+### Security
+
+- Zeroize normalized passwords, scrypt-derived keys, and decrypted plaintext buffers used by NIP-49.
+
 ## v0.44.3 - 2026/05/19
 
 ### Fixed

--- a/crates/nostr/Cargo.toml
+++ b/crates/nostr/Cargo.toml
@@ -56,7 +56,7 @@ nip06 = ["dep:bip39"]
 nip44 = ["dep:base64", "dep:chacha20"]
 nip46 = ["nip04", "nip44"]
 nip47 = ["nip04"]
-nip49 = ["dep:chacha20poly1305", "dep:scrypt", "dep:unicode-normalization"]
+nip49 = ["dep:chacha20poly1305", "dep:scrypt", "dep:unicode-normalization", "dep:zeroize"]
 nip57 = ["dep:aes", "dep:cbc"]
 nip59 = ["nip44"]
 nip60 = ["nip44"]
@@ -81,6 +81,7 @@ serde_json.workspace = true
 unicode-normalization = { version = "0.1", default-features = false, optional = true }
 url = { version = "2.5", default-features = false, features = ["serde"], optional = true } # Used in std
 url-fork = { version = "3.0", default-features = false, features = ["serde"], optional = true } # Used for no_std
+zeroize = { version = "1.8", default-features = false, features = ["alloc"], optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }

--- a/crates/nostr/src/nips/nip49.rs
+++ b/crates/nostr/src/nips/nip49.rs
@@ -20,6 +20,7 @@ use secp256k1::rand::rngs::OsRng;
 use secp256k1::rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use unicode_normalization::UnicodeNormalization;
+use zeroize::Zeroizing;
 
 use super::nip19::{FromBech32, ToBech32};
 use crate::{key, SecretKey};
@@ -217,10 +218,11 @@ impl EncryptedSecretKey {
         let nonce = XChaCha20Poly1305::generate_nonce(rng);
 
         // Derive key
-        let key: [u8; KEY_SIZE] = derive_key(password, &salt, log_n)?;
+        let key = derive_key(password, &salt, log_n)?;
 
         // Compose cipher
-        let cipher = XChaCha20Poly1305::new(&key.into());
+        let cipher = XChaCha20Poly1305::new_from_slice(key.as_ref())
+            .expect("NIP-49 derived keys always have the required length");
 
         // Compose payload
         let payload = Payload {
@@ -323,11 +325,17 @@ impl EncryptedSecretKey {
 
     /// Decrypt secret key
     pub fn decrypt(&self, password: &str) -> Result<SecretKey, Error> {
+        let bytes = self.decrypt_secret_bytes(password)?;
+        Ok(SecretKey::from_slice(&bytes)?)
+    }
+
+    fn decrypt_secret_bytes(&self, password: &str) -> Result<Zeroizing<Vec<u8>>, Error> {
         // Derive key
-        let key: [u8; KEY_SIZE] = derive_key(password, &self.salt, self.log_n)?;
+        let key = derive_key(password, &self.salt, self.log_n)?;
 
         // Compose cipher
-        let cipher = XChaCha20Poly1305::new(&key.into());
+        let cipher = XChaCha20Poly1305::new_from_slice(key.as_ref())
+            .expect("NIP-49 derived keys always have the required length");
 
         // Compose payload
         let payload = Payload {
@@ -336,10 +344,8 @@ impl EncryptedSecretKey {
         };
 
         // Decrypt
-        let bytes: Vec<u8> = cipher.decrypt(&self.nonce.into(), payload)?;
-
-        // Parse secret key from bytes
-        Ok(SecretKey::from_slice(&bytes)?)
+        let bytes = cipher.decrypt(&self.nonce.into(), payload)?;
+        Ok(Zeroizing::new(bytes))
     }
 }
 
@@ -363,25 +369,61 @@ impl<'de> Deserialize<'de> for EncryptedSecretKey {
     }
 }
 
-fn derive_key(password: &str, salt: &[u8; SALT_SIZE], log_n: u8) -> Result<[u8; KEY_SIZE], Error> {
+fn normalize_password(password: &str) -> Zeroizing<String> {
+    Zeroizing::new(password.nfkc().collect())
+}
+
+fn derive_key(
+    password: &str,
+    salt: &[u8; SALT_SIZE],
+    log_n: u8,
+) -> Result<Zeroizing<[u8; KEY_SIZE]>, Error> {
     // Unicode Normalization
-    let password: String = password.nfkc().collect();
+    let password = normalize_password(password);
 
     // Compose params
     let params: ScryptParams = ScryptParams::new(log_n, 8, 1, KEY_SIZE)?;
 
     // Derive key
-    let mut key: [u8; KEY_SIZE] = [0u8; KEY_SIZE];
-    scrypt::scrypt(password.as_bytes(), salt, &params, &mut key)?;
+    let mut key = Zeroizing::new([0u8; KEY_SIZE]);
+    scrypt::scrypt(password.as_bytes(), salt, &params, key.as_mut())?;
     Ok(key)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use zeroize::ZeroizeOnDrop;
 
     const CRYPTSEC: &str = "ncryptsec1qgg9947rlpvqu76pj5ecreduf9jxhselq2nae2kghhvd5g7dgjtcxfqtd67p9m0w57lspw8gsq6yphnm8623nsl8xn9j4jdzz84zm3frztj3z7s35vpzmqf6ksu8r89qk5z2zxfmu5gv8th8wclt0h4p";
     const SECRET_KEY: &str = "3501454135014541350145413501453fefb02227e449e57cf4d3a3ce05378683";
+
+    #[test]
+    fn test_sensitive_intermediates_zeroize_on_drop() {
+        fn assert_zeroize_on_drop<T: ZeroizeOnDrop>(_: &T) {}
+
+        let password = normalize_password("ｎｏｓｔｒ");
+        assert_eq!(password.as_str(), "nostr");
+        assert_zeroize_on_drop(&password);
+
+        let salt = [0u8; SALT_SIZE];
+        let key = derive_key(&password, &salt, 1).unwrap();
+        assert_zeroize_on_drop(&key);
+
+        let cipher = XChaCha20Poly1305::new_from_slice(key.as_ref()).unwrap();
+        assert_zeroize_on_drop(&cipher);
+    }
+
+    #[test]
+    fn test_decrypted_plaintext_zeroizes_on_drop() {
+        fn assert_zeroize_on_drop<T: ZeroizeOnDrop>(_: &T) {}
+
+        let encrypted_secret_key = EncryptedSecretKey::from_bech32(CRYPTSEC).unwrap();
+        let bytes = encrypted_secret_key.decrypt_secret_bytes("nostr").unwrap();
+
+        assert_zeroize_on_drop(&bytes);
+        assert_eq!(hex::encode(&*bytes), SECRET_KEY);
+    }
 
     #[test]
     fn test_encrypted_secret_key_decryption() {


### PR DESCRIPTION
## Summary

- zeroize the NFKC-normalized NIP-49 password on every return path
- zeroize the scrypt-derived key and construct XChaCha20-Poly1305 without an ordinary temporary key copy
- zeroize decrypted plaintext bytes after parsing the returned `SecretKey`
- add compile-time `ZeroizeOnDrop` checks while preserving NFKC and published-vector interoperability

This closes the remaining secret-lifetime gap tracked by marmot-protocol/mdk#474. The caller-owned original password remains outside this helper's ownership and must be handled by the caller.

## Verification

- `cargo test -p nostr --features nip49 nip49::tests`
- `cargo check -p nostr --no-default-features --features 'alloc,nip49'`
- `cargo clippy -p nostr --all-targets --features nip49 -- -D warnings`
