### PR TITLE
sdk(local_relay): reject gift wraps that p-tag more or less than one key

### DIFF
--- a/nostr-sdk/CHANGELOG.md
+++ b/nostr-sdk/CHANGELOG.md
@@ -98,6 +98,7 @@
 - Add `Proxy` with global, onion-only and custom relay proxy policies (https://github.com/nostrdevkit/nostr/pull/1351)
 - Add `Authenticator` and `SignerAuthenticator` for NIP-42 relay authentication (https://github.com/nostrdevkit/nostr/pull/1340)
 - local_relay: support event kind blacklisting via `LocalRelayBuilder::blacklist_kinds` (https://github.com/nostrdevkit/nostr/pull/1401)
+- local_relay: reject gift wraps that p-tag more or less than one key (https://github.com/nostrdevkit/nostr/pull/1411)
 
 ### Fixed
 

--- a/nostr-sdk/src/local_relay/local/inner.rs
+++ b/nostr-sdk/src/local_relay/local/inner.rs
@@ -543,6 +543,27 @@ impl InnerLocalRelay {
                     }
                 }
 
+                if event.kind == Kind::GiftWrap {
+                    let mut pkeys = event.tags.public_keys();
+                    // Ensure exactly one recipient public key: the first
+                    // `next()` must return Some (key exists), and the second
+                    // must return None (no extra keys).
+                    if pkeys.next().is_none() || pkeys.next().is_some() {
+                        return send_msg(
+                            ws_tx,
+                            RelayMessage::Ok {
+                                event_id: event.id,
+                                status: false,
+                                message: Cow::Owned(format!(
+                                    "{}: GiftWrap must contain exactly one recipient public key",
+                                    MachineReadablePrefix::Blocked,
+                                )),
+                            },
+                        )
+                        .await;
+                    }
+                }
+
                 if !event.verify_signature() {
                     return send_msg(
                         ws_tx,

--- a/nostr-sdk/src/local_relay/mod.rs
+++ b/nostr-sdk/src/local_relay/mod.rs
@@ -19,7 +19,8 @@ mod tests {
 
     use nostr::event::{EventBuilder, FinalizeEvent, Kind, Tag};
     use nostr::filter::Filter;
-    use nostr::key::Keys;
+    use nostr::key::{Keys, PublicKey};
+    use nostr::nips::nip17::PrivateDirectMessageBuilder;
     use nostr_memory::MemoryDatabase;
 
     use super::*;
@@ -112,5 +113,43 @@ mod tests {
             "blocked: kind `1` is not accepted by this relay",
             output.failed.values().next().unwrap()
         )
+    }
+
+    #[tokio::test]
+    async fn invalid_gift_wrap() {
+        let relay = LocalRelay::builder()
+            .database(MemoryDatabase::unbounded())
+            .blacklist_kinds(&[Kind::TextNote])
+            .build();
+        relay.run().await.unwrap();
+
+        let keys = Keys::generate();
+        let client = Client::default();
+
+        client
+            .add_relay(relay.url().await)
+            .and_connect()
+            .await
+            .unwrap();
+        let event = PrivateDirectMessageBuilder::new(keys.public_key(), "Hey")
+            .extra_tags([Tag::public_key(PublicKey::from_slice(&[0; 32]).unwrap())])
+            .finalize(&keys)
+            .unwrap();
+        let output = client.send_event(&event).await.unwrap();
+
+        assert_eq!(
+            "blocked: GiftWrap must contain exactly one recipient public key",
+            output.failed.values().next().unwrap()
+        );
+
+        let event = EventBuilder::new(Kind::GiftWrap, "Hey")
+            .finalize(&keys)
+            .unwrap();
+        let output = client.send_event(&event).await.unwrap();
+
+        assert_eq!(
+            "blocked: GiftWrap must contain exactly one recipient public key",
+            output.failed.values().next().unwrap()
+        );
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/nostrdevkit/nostr/issues/1404

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/nostrdevkit/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the relevant `CHANGELOG.md` (if applicable)
- [X] I understand and can explain all code in this PR
