### PR TITLE
sdk(local_relay): support max event size

### DIFF
--- a/nostr-sdk/CHANGELOG.md
+++ b/nostr-sdk/CHANGELOG.md
@@ -99,6 +99,7 @@
 - Add `Authenticator` and `SignerAuthenticator` for NIP-42 relay authentication (https://github.com/nostrdevkit/nostr/pull/1340)
 - local_relay: support event kind blacklisting via `LocalRelayBuilder::blacklist_kinds` (https://github.com/nostrdevkit/nostr/pull/1401)
 - local_relay: reject gift wraps that p-tag more or less than one key (https://github.com/nostrdevkit/nostr/pull/1411)
+- local_relay: support max event size (https://github.com/nostrdevkit/nostr/pull/1412)
 
 ### Fixed
 

--- a/nostr-sdk/src/local_relay/builder.rs
+++ b/nostr-sdk/src/local_relay/builder.rs
@@ -18,6 +18,7 @@ use super::local::LocalRelay;
 
 pub(super) const DEFAULT_MAX_CONNECTIONS: usize = 128;
 pub(super) const DEFAULT_MAX_FILTERS_PER_REQ: usize = 20;
+pub(super) const DEFAULT_MAX_EVENT_SIZE: usize = 64 * 1024;
 pub(super) const DEFAULT_MAX_QUERY_RESULTS: usize = 500;
 pub(super) const DEFAULT_MAX_NEGENTROPY_ITEMS: usize = 50_000;
 pub(super) const DEFAULT_MAX_SUBSCRIPTION_BYTES: usize = 1024 * 1024;
@@ -287,6 +288,8 @@ pub struct LocalRelayBuilder {
     pub(crate) max_connections: usize,
     /// Max WebSocket message size
     pub(crate) max_websocket_message_size: usize,
+    /// Max event size in bytes
+    pub(crate) max_event_size: usize,
     /// WebSocket handshake timeout
     pub(crate) websocket_handshake_timeout: Duration,
     /// Max subscription ID length in UTF-8 bytes
@@ -344,6 +347,7 @@ impl Default for LocalRelayBuilder {
             nip42: None,
             max_connections: DEFAULT_MAX_CONNECTIONS,
             max_websocket_message_size: DEFAULT_MAX_WEBSOCKET_MESSAGE_SIZE,
+            max_event_size: DEFAULT_MAX_EVENT_SIZE,
             websocket_handshake_timeout: DEFAULT_WEBSOCKET_HANDSHAKE_TIMEOUT,
             max_subid_length: 250,
             max_filters_per_req: DEFAULT_MAX_FILTERS_PER_REQ,
@@ -444,6 +448,13 @@ impl LocalRelayBuilder {
     #[inline]
     pub fn max_websocket_message_size(mut self, max: usize) -> Self {
         self.max_websocket_message_size = max;
+        self
+    }
+
+    /// Sets the maximum accepted event size in bytes. Defaults to 64KB.
+    #[inline]
+    pub fn max_event_size(mut self, max: usize) -> Self {
+        self.max_event_size = max;
         self
     }
 

--- a/nostr-sdk/src/local_relay/local/inner.rs
+++ b/nostr-sdk/src/local_relay/local/inner.rs
@@ -60,6 +60,7 @@ pub(super) struct InnerLocalRelay {
     messages_per_minute: u32,
     connections_limit: Arc<Semaphore>,
     max_websocket_message_size: usize,
+    max_event_size: usize,
     websocket_handshake_timeout: Duration,
     max_subid_length: usize,
     max_filters_per_req: usize,
@@ -112,6 +113,7 @@ impl InnerLocalRelay {
             messages_per_minute: builder.messages_per_minute,
             connections_limit: Arc::new(Semaphore::new(builder.max_connections)),
             max_websocket_message_size: builder.max_websocket_message_size,
+            max_event_size: builder.max_event_size,
             websocket_handshake_timeout: builder.websocket_handshake_timeout,
             max_subid_length: builder.max_subid_length,
             max_filters_per_req: builder.max_filters_per_req,
@@ -470,6 +472,24 @@ impl InnerLocalRelay {
                             message: Cow::Owned(format!(
                                 "{}: slow down",
                                 MachineReadablePrefix::RateLimited
+                            )),
+                        },
+                    )
+                    .await;
+                }
+
+                // Check the event size. The `-10` for `["EVENT",]`
+                if (message_size - 10) > self.max_event_size {
+                    return send_msg(
+                        ws_tx,
+                        RelayMessage::Ok {
+                            event_id: event.id,
+                            status: false,
+                            message: Cow::Owned(format!(
+                                "{}: event size ({} bytes) exceeds maximum allowed size ({} bytes)",
+                                MachineReadablePrefix::Blocked,
+                                message_size - 10,
+                                self.max_event_size
                             )),
                         },
                     )

--- a/nostr-sdk/src/local_relay/local/inner.rs
+++ b/nostr-sdk/src/local_relay/local/inner.rs
@@ -1684,13 +1684,14 @@ mod tests {
         let mut session = session(None);
         let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
 
+        let message_size = event.as_json().len() + 10;
         relay
             .handle_client_msg(
                 &mut session,
                 &mut server_tx,
                 ClientMessage::Event(Cow::Owned(event)),
                 &addr,
-                0,
+                message_size,
             )
             .await
             .unwrap();

--- a/nostr-sdk/src/local_relay/mod.rs
+++ b/nostr-sdk/src/local_relay/mod.rs
@@ -152,4 +152,49 @@ mod tests {
             output.failed.values().next().unwrap()
         );
     }
+
+    #[tokio::test]
+    async fn event_size() {
+        const MAX_SIZE: usize = 500;
+
+        let relay = LocalRelay::builder()
+            .max_event_size(MAX_SIZE)
+            .database(MemoryDatabase::unbounded())
+            .build();
+        relay.run().await.unwrap();
+
+        let keys = Keys::generate();
+        let client = Client::default();
+
+        client
+            .add_relay(relay.url().await)
+            .and_connect()
+            .await
+            .unwrap();
+
+        let base_event_size = EventBuilder::new(Kind::TextNote, "")
+            .finalize(&keys)
+            .unwrap()
+            .as_json()
+            .len();
+
+        let equal_max_size =
+            EventBuilder::new(Kind::TextNote, ".".repeat(MAX_SIZE - base_event_size))
+                .finalize(&keys)
+                .unwrap();
+        let greater_max_size =
+            EventBuilder::new(Kind::TextNote, ".".repeat((MAX_SIZE - base_event_size) + 1))
+                .finalize(&keys)
+                .unwrap();
+
+        let output = client.send_event(&equal_max_size).await.unwrap();
+        dbg!(&output);
+        assert!(!output.success.is_empty());
+
+        let output = client.send_event(&greater_max_size).await.unwrap();
+        assert_eq!(
+            "blocked: event size (501 bytes) exceeds maximum allowed size (500 bytes)",
+            output.failed.values().next().unwrap()
+        );
+    }
 }


### PR DESCRIPTION
### Description

A way to limit the accepted events size.

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/nostrdevkit/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the relevant `CHANGELOG.md` (if applicable)
- [X] I personally wrote and understood all code in this PR
