### PR TITLE
test(nostr): ensure `RelayMessage` handles NIP-67 EOSE gracefully

### DIFF
--- a/nostr/src/message/relay.rs
+++ b/nostr/src/message/relay.rs
@@ -676,6 +676,16 @@ mod tests {
             RelayMessage::event(SubscriptionId::new("random_string"), event)
         );
     }
+
+    /// A test to make sure we can parse NIP-67.
+    #[test]
+    fn parse_nip67() {
+        const MSG: &str = r#"["EOSE", "sub", ["finish"]]"#;
+        assert_eq!(
+            RelayMessage::EndOfStoredEvents(Cow::Owned(SubscriptionId::new("sub"))),
+            RelayMessage::from_json(MSG).unwrap()
+        );
+    }
 }
 
 #[cfg(bench)]


### PR DESCRIPTION
Add a test to verify that parsing the NIP-67 EOSE response does not cause client breakage. This provides safety despite the NIP being unnecessary alongside NIP-77 (Negentropy Syncing) 