### PR TITLE
nostr: align image dimensions handling with NIP specs

### DIFF
--- a/nostr/src/nips/image.rs
+++ b/nostr/src/nips/image.rs
@@ -2,8 +2,6 @@
 // Copyright (c) 2023-2025 Rust Nostr Developers
 // Distributed under the MIT software license
 
-//! Image
-
 use core::fmt;
 use core::str::{FromStr, Split};
 

--- a/nostr/src/nips/mod.rs
+++ b/nostr/src/nips/mod.rs
@@ -6,6 +6,7 @@
 //!
 //! See all at <https://github.com/nostr-protocol/nips>
 
+mod image;
 pub mod nip01;
 pub mod nip02;
 pub mod nip04;

--- a/nostr/src/nips/nip23.rs
+++ b/nostr/src/nips/nip23.rs
@@ -8,16 +8,14 @@
 
 use alloc::string::{String, ToString};
 use alloc::vec;
-use alloc::vec::Vec;
 
 use crate::error::Error;
 use crate::event::{Tag, TagCodec, impl_tag_codec_conversions};
 use crate::nips::util::{
-    missing_tag_kind, take_and_parse_from_str, take_and_parse_optional_from_str, take_string,
-    take_timestamp, unknown_tag,
+    missing_tag_kind, take_and_parse_from_str, take_string, take_timestamp, unknown_tag,
 };
+use crate::types::Timestamp;
 use crate::types::url::Url;
-use crate::types::{ImageDimensions, Timestamp};
 
 const TITLE: &str = "title";
 const IMAGE: &str = "image";
@@ -33,7 +31,7 @@ pub enum Nip23Tag {
     /// `title` tag
     Title(String),
     /// `image` tag
-    Image(Url, Option<ImageDimensions>),
+    Image(Url),
     /// `summary` tag
     Summary(String),
     /// `published_at` tag
@@ -57,8 +55,8 @@ impl TagCodec for Nip23Tag {
         match kind.as_ref() {
             TITLE => Ok(Self::Title(take_string(&mut iter, "title")?)),
             IMAGE => {
-                let (url, dimensions) = parse_image_tag(iter)?;
-                Ok(Self::Image(url, dimensions))
+                let url = parse_image_tag(iter)?;
+                Ok(Self::Image(url))
             }
             SUMMARY => Ok(Self::Summary(take_string(&mut iter, "summary")?)),
             PUBLISHED_AT => {
@@ -75,15 +73,7 @@ impl TagCodec for Nip23Tag {
     fn to_tag(&self) -> Tag {
         match self {
             Self::Title(title) => Tag::new(vec![String::from(TITLE), title.clone()]),
-            Self::Image(url, dimensions) => {
-                let mut tag: Vec<String> = Vec::with_capacity(2 + dimensions.is_some() as usize);
-                tag.push(String::from(IMAGE));
-                tag.push(url.to_string());
-                if let Some(dimensions) = dimensions {
-                    tag.push(dimensions.to_string());
-                }
-                Tag::new(tag)
-            }
+            Self::Image(url) => Tag::new(vec![String::from(IMAGE), url.to_string()]),
             Self::Summary(summary) => Tag::new(vec![String::from(SUMMARY), summary.clone()]),
             Self::PublishedAt(timestamp) => {
                 Tag::new(vec![String::from(PUBLISHED_AT), timestamp.to_string()])
@@ -95,15 +85,13 @@ impl TagCodec for Nip23Tag {
 
 impl_tag_codec_conversions!(Nip23Tag);
 
-fn parse_image_tag<T, S>(mut iter: T) -> Result<(Url, Option<ImageDimensions>), Error>
+fn parse_image_tag<T, S>(mut iter: T) -> Result<Url, Error>
 where
     T: Iterator<Item = S>,
     S: AsRef<str>,
 {
     let url: Url = take_and_parse_from_str(&mut iter, "image URL")?;
-    let dimensions: Option<ImageDimensions> = take_and_parse_optional_from_str(&mut iter)?;
-
-    Ok((url, dimensions))
+    Ok(url)
 }
 
 #[cfg(test)]
@@ -120,14 +108,11 @@ mod tests {
 
     #[test]
     fn test_parse_image_tag() {
-        let tag = vec!["image", "https://example.com/image.jpg", "1024x768"];
+        let tag = vec!["image", "https://example.com/image.jpg"];
         let parsed = Nip23Tag::parse(&tag).unwrap();
         assert_eq!(
             parsed,
-            Nip23Tag::Image(
-                Url::parse("https://example.com/image.jpg").unwrap(),
-                Some(ImageDimensions::new(1024, 768))
-            )
+            Nip23Tag::Image(Url::parse("https://example.com/image.jpg").unwrap())
         );
         assert_eq!(parsed.to_tag(), Tag::parse(tag).unwrap());
     }

--- a/nostr/src/nips/nip53.rs
+++ b/nostr/src/nips/nip53.rs
@@ -25,8 +25,8 @@ use crate::event::{
     Event, EventBuilder, EventId, IntoEventBuilder, Kind, Tag, TagCodec, impl_tag_codec_conversions,
 };
 use crate::key::PublicKey;
+use crate::types::Timestamp;
 use crate::types::url::{RelayUrl, Url};
-use crate::types::{ImageDimensions, Timestamp};
 
 const TITLE: &str = "title";
 const SUMMARY: &str = "summary";
@@ -180,7 +180,7 @@ pub enum Nip53Tag {
     /// Summary
     Summary(String),
     /// Image
-    Image(Url, Option<ImageDimensions>),
+    Image(Url),
     /// Hashtag
     Hashtag(String),
     /// Streaming URL
@@ -231,9 +231,7 @@ impl TagCodec for Nip53Tag {
             SUMMARY => Ok(Self::Summary(take_string(&mut iter, "summary")?)),
             IMAGE => {
                 let image: Url = take_and_parse_from_str(&mut iter, "image URL")?;
-                let dimensions: Option<ImageDimensions> =
-                    take_and_parse_optional_from_str(&mut iter)?;
-                Ok(Self::Image(image, dimensions))
+                Ok(Self::Image(image))
             }
             "t" => {
                 let hashtag: String = take_string(&mut iter, "hashtag")?;
@@ -301,13 +299,7 @@ impl TagCodec for Nip53Tag {
         match self {
             Self::Title(title) => Tag::new(vec![String::from(TITLE), title.clone()]),
             Self::Summary(summary) => Tag::new(vec![String::from(SUMMARY), summary.clone()]),
-            Self::Image(image, dimensions) => {
-                let mut tag = vec![String::from(IMAGE), image.to_string()];
-                if let Some(dimensions) = dimensions {
-                    tag.push(dimensions.to_string());
-                }
-                Tag::new(tag)
-            }
+            Self::Image(image) => Tag::new(vec![String::from(IMAGE), image.to_string()]),
             Self::Hashtag(hashtag) => Tag::new(vec![String::from("t"), hashtag.clone()]),
             Self::Streaming(url) => Tag::new(vec![String::from(STREAMING), url.to_string()]),
             Self::Recording(url) => Tag::new(vec![String::from(RECORDING), url.to_string()]),
@@ -448,7 +440,7 @@ pub struct LiveEvent {
     /// Event summary
     pub summary: Option<String>,
     /// Event image
-    pub image: Option<(Url, Option<ImageDimensions>)>,
+    pub image: Option<Url>,
     /// Hashtags
     pub hashtags: Vec<String>,
     /// Streaming URL
@@ -595,7 +587,7 @@ impl LiveEvent {
         match tag {
             Nip53Tag::Title(title) => self.title = Some(title),
             Nip53Tag::Summary(summary) => self.summary = Some(summary),
-            Nip53Tag::Image(image, dim) => self.image = Some((image, dim)),
+            Nip53Tag::Image(image) => self.image = Some(image),
             Nip53Tag::Hashtag(hashtag) => self.hashtags.push(hashtag),
             Nip53Tag::Streaming(url) => self.streaming = Some(url),
             Nip53Tag::Recording(url) => self.recording = Some(url),
@@ -699,8 +691,8 @@ impl From<LiveEvent> for Vec<Tag> {
             tags.push(Nip53Tag::Summary(summary).to_tag());
         }
 
-        if let Some((image, dim)) = image {
-            tags.push(Nip53Tag::Image(image, dim).to_tag());
+        if let Some(image) = image {
+            tags.push(Nip53Tag::Image(image).to_tag());
         }
 
         for hashtag in hashtags.into_iter() {

--- a/nostr/src/nips/nip58.rs
+++ b/nostr/src/nips/nip58.rs
@@ -10,6 +10,7 @@ use alloc::string::{String, ToString};
 use alloc::vec;
 use alloc::vec::Vec;
 
+pub use super::image::ImageDimensions;
 use super::nip01::{Coordinate, Nip01Tag};
 use super::util::{
     missing_tag_kind, take_and_parse_from_str, take_and_parse_optional_from_str, take_string,
@@ -20,8 +21,7 @@ use crate::event::{
     Event, EventBuilder, EventId, IntoEventBuilder, Kind, Tag, TagCodec, impl_tag_codec_conversions,
 };
 use crate::key::PublicKey;
-use crate::types::url::Url;
-use crate::types::{ImageDimensions, RelayUrl};
+use crate::types::{RelayUrl, Url};
 
 const IDENTIFIER: &str = "d";
 const NAME: &str = "name";

--- a/nostr/src/nips/nip94.rs
+++ b/nostr/src/nips/nip94.rs
@@ -14,12 +14,12 @@ use core::str::FromStr;
 use bitcoin_hashes::sha256::Hash as Sha256Hash;
 use url::Url;
 
+pub use super::image::ImageDimensions;
 use super::util::{missing_tag_kind, take_and_parse_from_str, take_string, unknown_tag};
 use crate::error::{Error, ErrorKind};
 use crate::event::{
     EventBuilder, IntoEventBuilder, Kind, Tag, TagCodec, impl_tag_codec_conversions,
 };
-use crate::types::ImageDimensions;
 
 const URL: &str = "url";
 const MIME_TYPE: &str = "m";

--- a/nostr/src/types/mod.rs
+++ b/nostr/src/types/mod.rs
@@ -7,10 +7,8 @@
 #![allow(unknown_lints)]
 #![allow(ambiguous_glob_reexports)]
 
-pub mod image;
 pub mod time;
 pub mod url;
 
-pub use self::image::*;
 pub use self::time::*;
 pub use self::url::*;


### PR DESCRIPTION
### Description

Move `ImageDimensions` under NIP-specific scope and remove image dimensions from tags where they are not defined by the spec.

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/nostrdevkit/nostr/blob/master/CONTRIBUTING.md)
- [ ] I updated the relevant `CHANGELOG.md` (if applicable)
- [X] I understand and can explain all code in this PR
