### PR TITLE
nostr: avoid a `String` per generic tag key in `Filter`

### DIFF
--- a/nostr/CHANGELOG.md
+++ b/nostr/CHANGELOG.md
@@ -118,6 +118,7 @@
 - Hardware-accelerate SHA-256 where available (https://github.com/nostrdevkit/nostr/pull/1419)
 - Reduce allocations and redundant key parsing in the NIP-44 v2 path (https://github.com/nostrdevkit/nostr/pull/1421)
 - Serialize and deserialize `RelayMessage` without a `serde_json::Value` tree (https://github.com/nostrdevkit/nostr/pull/1425)
+- Avoid allocating a `String` per generic tag key when serializing and deserializing `Filter` (https://github.com/nostrdevkit/nostr/pull/1427)
 
 ### Security
 

--- a/nostr/src/filter/mod.rs
+++ b/nostr/src/filter/mod.rs
@@ -695,10 +695,58 @@ where
     S: Serializer,
 {
     let mut map = serializer.serialize_map(Some(generic_tags.len()))?;
+
+    // The key is always `#` followed by a single ASCII letter, so it fits in a
+    // fixed buffer. `format!` would allocate a `String` for every entry.
+    let mut key: [u8; 2] = [b'#', 0];
+
     for (tag, values) in generic_tags.iter() {
-        map.serialize_entry(&format!("#{tag}"), values)?;
+        key[1] = tag.as_byte();
+        let key: &str = core::str::from_utf8(&key).map_err(serde::ser::Error::custom)?;
+        map.serialize_entry(key, values)?;
     }
+
     map.end()
+}
+
+/// A generic tag query key.
+///
+/// `Some` when the key is `#` followed by a single letter, `None` for any other
+/// key, which is ignored. Deserializing through this avoids allocating a
+/// `String` for every key in the map.
+struct TagKey(Option<SingleLetterTag>);
+
+impl<'de> Deserialize<'de> for TagKey {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct TagKeyVisitor;
+
+        impl Visitor<'_> for TagKeyVisitor {
+            type Value = TagKey;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a map key")
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                let mut chars = v.chars();
+                if let (Some('#'), Some(ch), None) = (chars.next(), chars.next(), chars.next()) {
+                    let tag: SingleLetterTag =
+                        SingleLetterTag::from_char(ch).map_err(serde::de::Error::custom)?;
+                    Ok(TagKey(Some(tag)))
+                } else {
+                    Ok(TagKey(None))
+                }
+            }
+        }
+
+        deserializer.deserialize_str(TagKeyVisitor)
+    }
 }
 
 fn deserialize_generic_tags<'de, D>(deserializer: D) -> Result<GenericTags, D::Error>
@@ -719,15 +767,16 @@ where
             M: MapAccess<'de>,
         {
             let mut generic_tags = BTreeMap::new();
-            while let Some(key) = map.next_key::<String>()? {
-                let mut chars = key.chars();
-                if let (Some('#'), Some(ch), None) = (chars.next(), chars.next(), chars.next()) {
-                    let tag: SingleLetterTag =
-                        SingleLetterTag::from_char(ch).map_err(serde::de::Error::custom)?;
-                    let values: BTreeSet<String> = map.next_value()?;
-                    generic_tags.insert(tag, values);
-                } else {
-                    map.next_value::<serde::de::IgnoredAny>()?;
+            while let Some(TagKey(tag)) = map.next_key::<TagKey>()? {
+                match tag {
+                    Some(tag) => {
+                        let values: BTreeSet<String> = map.next_value()?;
+                        generic_tags.insert(tag, values);
+                    }
+                    // Not a `#X` key, so it isn't a generic tag query.
+                    None => {
+                        map.next_value::<serde::de::IgnoredAny>()?;
+                    }
                 }
             }
             Ok(generic_tags)
@@ -915,6 +964,38 @@ mod tests {
         let json = r##"{"aa":["..."],"search":"test"}"##;
         let filter = Filter::from_json(json).unwrap();
         assert_eq!(filter, Filter::new().search("test"));
+    }
+
+    /// A key is a generic tag query only when it is `#` followed by exactly one
+    /// letter. Anything else is ignored, except a single non-letter character,
+    /// which is rejected.
+    #[test]
+    fn test_generic_tag_key_shapes() {
+        // Ignored: not `#` + exactly one character.
+        for json in [
+            r##"{"#ab":["x"],"search":"test"}"##,
+            r##"{"#":["x"],"search":"test"}"##,
+            r##"{"t":["x"],"search":"test"}"##,
+            r##"{"":["x"],"search":"test"}"##,
+        ] {
+            let filter = Filter::from_json(json).unwrap();
+            assert_eq!(filter, Filter::new().search("test"), "{json}");
+        }
+
+        // Rejected: `#` followed by a single non-letter.
+        for json in [
+            r##"{"#1":["x"]}"##,
+            r##"{"#_":["x"]}"##,
+            r##"{"# ":["x"]}"##,
+            r###"{"##":["x"]}"###,
+        ] {
+            assert!(Filter::from_json(json).is_err(), "{json}");
+        }
+
+        // Accepted, both cases.
+        let filter = Filter::from_json(r##"{"#t":["x"],"#T":["y"]}"##).unwrap();
+        assert_eq!(filter.generic_tags.len(), 2);
+        assert_eq!(filter.as_json(), r##"{"#t":["x"],"#T":["y"]}"##);
     }
 
     #[test]


### PR DESCRIPTION
### Description

Third of the follow-ups mentioned in #1425, after #1426.

Serializing a filter built each map key with `format!("#{tag}")`, allocating a `String` per generic tag query. The key is always `#` followed by a single ASCII letter, so it fits in a two-byte buffer on the stack.

Deserializing had the mirror problem: every key in the map was read into an owned `String` just to inspect its first two characters. Reading it through a small key type that looks at the borrowed `&str` and yields the tag directly avoids that.

Measured on an Apple M4, filter with three generic tag queries (178 bytes):

| operation | before | after |
|---|---|---|
| `Filter::as_json` | 302 ns, 5 allocs | 188 ns, 2 allocs |
| `Filter::from_json` | 724 ns, 15 allocs | 584 ns, 12 allocs |

A filter with no generic tags is unchanged (55 -> 52 ns, 119 -> 116 ns, one allocation either way), since neither path allocated for keys in that case. The win is proportional to how many tag queries a filter carries.

### Notes to the reviewers

Output is unchanged. Ten filter shapes, their round-trips, and fifteen well-formed and malformed inputs all produce byte-identical results, including which keys are ignored and which are rejected.

The key-shape rules had only partial coverage, and I got two of them wrong while writing the test, so they are now pinned explicitly:

- `#` followed by exactly one letter is a tag query.
- `#` followed by exactly one non-letter is rejected. This includes `"##"`, which matches the `#X` shape and then fails the letter check.
- Anything else is ignored: `"#ab"`, `"#"`, `"t"`, `""`.

Verified with the full `just precommit` set plus `cargo build --workspace --all-targets` and `cargo clippy --all-targets -- -D warnings`, including the `no_std` and `wasm32` combinations.

That is the last of the near-term follow-ups from #1425. The remaining one is larger and I would rather discuss it before writing anything: `Event::from_json` spends 43 allocations on a twelve-tag event, 37 of them inside `Tags`, because `Tag` holds a `Vec<String>` and `Tags` a `Vec<Tag>`. That is a representation change to a public type, so I will open an issue with the numbers rather than a PR.

### Checklist

- [x] I followed the [contribution guidelines](https://github.com/nostrdevkit/nostr/blob/master/CONTRIBUTING.md)
- [x] I updated the relevant `CHANGELOG.md` (if applicable)
- [x] I understand and can explain all code in this PR
