### PR TITLE
Update `NostrConnectMessage` display and logs

### DIFF
--- a/nostr/CHANGELOG.md
+++ b/nostr/CHANGELOG.md
@@ -27,6 +27,12 @@
 
 -->
 
+## Unreleased
+
+### Fixed
+
+- The `Display` implementations of `NostrConnectMessage` redact the sensitive data (https://github.com/nostrdevkit/nostr/pull/1432)
+
 ## v0.45.0 - 2026/08/05
 
 ### Breaking changes

--- a/nostr/src/nips/nip46.rs
+++ b/nostr/src/nips/nip46.rs
@@ -656,8 +656,9 @@ impl fmt::Debug for NostrConnectMessage {
 }
 
 impl fmt::Display for NostrConnectMessage {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.as_json())
+        fmt::Debug::fmt(self, f)
     }
 }
 

--- a/signer/nostr-connect/CHANGELOG.md
+++ b/signer/nostr-connect/CHANGELOG.md
@@ -27,6 +27,12 @@
 
 -->
 
+## Unreleased
+
+### Fixed
+
+- Log the parsed `NostrConnectMessage` to redact sensitive data, instead of the raw decrypted message (https://github.com/nostrdevkit/nostr/pull/1432)
+
 ## v0.45.0 - 2026/08/05
 
 ### Breaking changes

--- a/signer/nostr-connect/src/client.rs
+++ b/signer/nostr-connect/src/client.rs
@@ -409,13 +409,14 @@ async fn get_remote_signer_public_key(
                         Err(_) => continue,
                     };
 
-                    tracing::debug!("Received Nostr Connect message: '{msg}'");
-
                     // Parse message
                     let msg: NostrConnectMessage = match NostrConnectMessage::from_json(msg) {
                         Ok(m) => m,
                         Err(_) => continue,
                     };
+
+                    // The Debug and Display implementations of NostrConnectMessage redact the sensitive data.
+                    tracing::debug!("Received Nostr Connect message: '{msg}'");
 
                     // Check if it's a `connect` response.
                     //


### PR DESCRIPTION
### Description

Update `NostrConnectMessage` display implementation and reorder NIP-46 message logging in `nostr-connect` client.

### Checklist

- [X] I followed the [contribution guidelines](https://github.com/nostrdevkit/nostr/blob/master/CONTRIBUTING.md)
- [X] I updated the relevant `CHANGELOG.md` (if applicable)
- [X] I understand and can explain all code in this PR
